### PR TITLE
feat(statusline): show average model speed (#10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A curated collection of extensions and themes for [Pi Coding Agent](https://gith
 
 ## Key Features
 
-- **statusline-pi** — Compact custom footer showing current directory, git branch, changed files, GitHub PR number, remaining context window (tokens + percentage), context zone, and active provider/model.
+- **statusline-pi** — Compact custom footer showing current directory, git branch, changed files, GitHub PR number, remaining context window (tokens + percentage), context zone, average model response speed, and active provider/model.
 - **advisor-pi** — Advisor-style strategic guidance tool that lets the executor consult a configured higher-capability model during complex workflows.
 - **grok-pi** — Bridge Grok CLI session models (Composer 2.5, Grok Build) into Pi via `grok-cli` and `~/.grok/auth.json`.
 - **opencode-pi** — Bridge local OpenCode CLI free models into Pi without OpenCode login, with OpenCode tools disabled and Pi tool calls prompt-bridged back into Pi.
@@ -46,16 +46,16 @@ Reload Pi after installation — open Pi and type `/reload`.
 
 `statusline-pi` replaces Pi's default footer with a compact project statusline.
 
-![statusline-pi — custom footer with git, PR, context, and model](assets/statusline-pi.png)
+![statusline-pi — custom footer with git, PR, context, average speed, and model](assets/statusline-pi.png)
 
 ```
-current-dir │ branch [changed files] PR #x │ remaining context tokens (percentage) context zone │ provider/model
+current-dir │ branch [changed files] PR #x │ remaining context tokens (percentage) context zone │ average response speed │ provider/model
 ```
 
 Example:
 
 ```
-pi-extensions │ main [2] PR #12 │ 840,037 (84.0%) Plan │ openai-codex/gpt-5.5
+pi-extensions │ main [2] PR #12 │ 840,037 (84.0%) Plan │ 42.5 tok/s │ openai-codex/gpt-5.5
 ```
 
 **Git section** — groups all git-related status:
@@ -73,6 +73,14 @@ Zone coloring:
 - **Plan** / **Code** — success color
 - **Dump** — warning color
 - **ExDump** / **Dead** — error color
+
+**Average response speed** — approximate model output speed for the current model/thinking context:
+
+```
+42.5 tok/s
+```
+
+The value averages completed assistant responses, includes the active response while streaming, and remains visible while idle.
 
 **Commands:**
 

--- a/extensions/statusline-pi/README.md
+++ b/extensions/statusline-pi/README.md
@@ -7,7 +7,7 @@ Compact project statusline footer for Pi.
 Format:
 
 ```text
-current-dir │ branch [changed files] PR #x │ remaining context tokens (percentage) context zone │ response speed │ provider/model
+current-dir │ branch [changed files] PR #x │ remaining context tokens (percentage) context zone │ average response speed │ provider/model
 ```
 
 Example:
@@ -21,8 +21,8 @@ pi-extensions │ main [2] PR #12 │ 840,037 (84.0%) Plan │ 42.5 tok/s │ op
 - Installs as a Pi extension and enables automatically on session start.
 - Replaces Pi's default footer with a single compact statusline.
 - Refreshes git change count every 5 seconds.
-- Shows live response speed while the assistant is streaming and the final output token rate after each response.
-- Calculates final speed from assistant output tokens divided by response duration (`tok/s`).
+- Shows average model response speed as output tokens per second (`tok/s`) across completed assistant responses.
+- Includes the active assistant response in the average while it is streaming, then keeps the completed average visible while idle.
 - Checks for a GitHub PR associated with the current branch every 60 seconds using `gh pr view`.
 - Omits the PR segment when `gh` is unavailable or the branch has no PR.
 

--- a/extensions/statusline-pi/src/index.ts
+++ b/extensions/statusline-pi/src/index.ts
@@ -13,6 +13,19 @@ interface ResponseSpeedInfo {
 	tokensPerSecond?: number;
 	outputTokens: number;
 	durationMs: number;
+	responseCount: number;
+	inProgress: boolean;
+}
+
+interface ResponseSpeedAggregate {
+	totalOutputTokens: number;
+	totalDurationMs: number;
+	responseCount: number;
+}
+
+interface CurrentResponseSpeed {
+	outputTokens: number;
+	durationMs: number;
 	inProgress: boolean;
 }
 
@@ -29,6 +42,7 @@ export default function statuslinePiExtension(pi: ExtensionAPI) {
 	let lastPrBranch: string | undefined;
 	let renderRequested: (() => void) | undefined;
 	let responseSpeed: ResponseSpeedInfo | undefined;
+	let completedResponseSpeed = createEmptyResponseSpeedAggregate();
 	let responseStartMs: number | undefined;
 	let liveOutputTokenEstimate = 0;
 	let lastSpeedRender = 0;
@@ -58,11 +72,11 @@ export default function statuslinePiExtension(pi: ExtensionAPI) {
 
 		responseStartMs = Date.now();
 		liveOutputTokenEstimate = 0;
-		responseSpeed = {
+		responseSpeed = getAverageResponseSpeed(completedResponseSpeed, {
 			outputTokens: 0,
 			durationMs: 0,
 			inProgress: true,
-		};
+		});
 		requestRender();
 	});
 	pi.on("message_update", async (event, _ctx) => {
@@ -78,12 +92,11 @@ export default function statuslinePiExtension(pi: ExtensionAPI) {
 		}
 
 		const durationMs = Date.now() - responseStartMs;
-		responseSpeed = {
-			tokensPerSecond: calculateTokensPerSecond(liveOutputTokenEstimate, durationMs),
+		responseSpeed = getAverageResponseSpeed(completedResponseSpeed, {
 			outputTokens: Math.round(liveOutputTokenEstimate),
 			durationMs,
 			inProgress: true,
-		};
+		});
 		requestSpeedRender();
 	});
 	pi.on("message_end", async (event, _ctx) => {
@@ -94,12 +107,10 @@ export default function statuslinePiExtension(pi: ExtensionAPI) {
 
 		const durationMs = responseStartMs === undefined ? 0 : Date.now() - responseStartMs;
 		const outputTokens = event.message.usage?.output || estimateAssistantOutputTokens(event.message) || Math.round(liveOutputTokenEstimate);
-		responseSpeed = {
-			tokensPerSecond: calculateTokensPerSecond(outputTokens, durationMs),
-			outputTokens,
-			durationMs,
-			inProgress: false,
-		};
+		if (responseStartMs !== undefined) {
+			completedResponseSpeed = addCompletedResponseSpeed(completedResponseSpeed, outputTokens, durationMs);
+		}
+		responseSpeed = getAverageResponseSpeed(completedResponseSpeed);
 		responseStartMs = undefined;
 		liveOutputTokenEstimate = 0;
 		requestRender();
@@ -208,6 +219,7 @@ export default function statuslinePiExtension(pi: ExtensionAPI) {
 
 	function resetResponseSpeed(): void {
 		responseSpeed = undefined;
+		completedResponseSpeed = createEmptyResponseSpeedAggregate();
 		responseStartMs = undefined;
 		liveOutputTokenEstimate = 0;
 		lastSpeedRender = 0;
@@ -378,6 +390,50 @@ function formatTokensPerSecond(tokensPerSecond: number): string {
 function calculateTokensPerSecond(tokens: number, durationMs: number): number | undefined {
 	if (tokens <= 0 || durationMs <= 0) return undefined;
 	return tokens / (durationMs / 1000);
+}
+
+function createEmptyResponseSpeedAggregate(): ResponseSpeedAggregate {
+	return {
+		totalOutputTokens: 0,
+		totalDurationMs: 0,
+		responseCount: 0,
+	};
+}
+
+function addCompletedResponseSpeed(
+	aggregate: ResponseSpeedAggregate,
+	outputTokens: number,
+	durationMs: number,
+): ResponseSpeedAggregate {
+	if (outputTokens <= 0 || durationMs <= 0) return aggregate;
+
+	return {
+		totalOutputTokens: aggregate.totalOutputTokens + outputTokens,
+		totalDurationMs: aggregate.totalDurationMs + durationMs,
+		responseCount: aggregate.responseCount + 1,
+	};
+}
+
+function getAverageResponseSpeed(
+	completed: ResponseSpeedAggregate,
+	current?: CurrentResponseSpeed,
+): ResponseSpeedInfo | undefined {
+	const hasCurrentData = current !== undefined && current.outputTokens > 0 && current.durationMs > 0;
+	const outputTokens = completed.totalOutputTokens + (hasCurrentData ? current.outputTokens : 0);
+	const durationMs = completed.totalDurationMs + (hasCurrentData ? current.durationMs : 0);
+	const responseCount = completed.responseCount + (hasCurrentData ? 1 : 0);
+	const inProgress = current?.inProgress ?? false;
+	const tokensPerSecond = calculateTokensPerSecond(outputTokens, durationMs);
+
+	if (tokensPerSecond === undefined && !inProgress) return undefined;
+
+	return {
+		tokensPerSecond,
+		outputTokens,
+		durationMs,
+		responseCount,
+		inProgress,
+	};
 }
 
 function estimateTokens(text: string): number {


### PR DESCRIPTION
Closes #10

## Summary

Updates `statusline-pi` so the `tok/s` segment reports an average model response speed for the current model/thinking context instead of only the live or last-response streaming speed. The average includes completed assistant responses, includes the active response while streaming, and remains visible while idle.

## Approach

Selected option 2 — session/model average including current response. The implementation keeps cumulative completed-response totals, derives the displayed average from completed totals plus the active response when present, folds each response into the aggregate on `message_end`, and resets the aggregate when model/thinking context changes.

## Decision Record

- **Root cause:** `extensions/statusline-pi/src/index.ts` stored a single current/last response speed value, replacing it on each response and documenting it as live/final response speed. That made the metric jump during streaming and lose useful average-speed meaning while idle.
- **Options considered:** Option 1 — completed-responses-only average; Option 2 — session/model average including current response; Option 3 — rolling or smoothed average.
- **Options rejected:** Option 1 — leaves the first in-progress response without useful speed feedback; Option 3 — adds unclear rolling-average semantics beyond the issue scope.
- **Selected option:** Option 2 — session/model average including current response.
- **Residual risk:** No automated test framework exists for `statusline-pi`, so behavior is verified by TypeScript build and code review rather than unit tests.

Analyzed at: `feat/10-show-average-model-speed @ cc20885` (2026-06-03)

## Changes

| File | Change |
|------|--------|
| `extensions/statusline-pi/src/index.ts` | Adds completed-response aggregate state and computes displayed average `tok/s` from aggregate totals. |
| `extensions/statusline-pi/README.md` | Documents `tok/s` as average model response speed that remains visible while idle. |
| `README.md` | Updates the statusline format, example, and feature description to include average response speed. |

## Test Results

- Unit tests: skipped (no existing test framework)
- Integration tests: skipped (no integration test framework)
- E2e tests: skipped (no e2e framework)
- Build: passed (`cd extensions/statusline-pi && npm run build`)
- QA cycles: 1

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| The statusline communicates average model response speed rather than only instantaneous streaming activity. | pass | `extensions/statusline-pi/src/index.ts` computes `getAverageResponseSpeed(...)` from aggregate totals. |
| The displayed speed remains meaningful when no data is actively streaming. | pass | `message_end` folds the response into `completedResponseSpeed` and keeps `responseSpeed` populated with the aggregate. |
| The metric is stable enough for a user to understand an approximate session/model speed, such as "about 50 tok/s". | pass | Completed totals accumulate across responses and reset on model/thinking context changes. |
| User-facing documentation describes the metric as an average model response speed. | pass | `extensions/statusline-pi/README.md` and `README.md` describe average model response speed. |
