### PR TITLE
Add Pi delegator skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ node_modules/
 dist/
 build/
 *.log
+__pycache__/
+*.pyc
 .DS_Store
 .env
 .env.local

--- a/README.md
+++ b/README.md
@@ -12,10 +12,11 @@ A curated collection of extensions and themes for [Pi Coding Agent](https://gith
 - **advisor-pi** — Advisor-style strategic guidance tool that lets the executor consult a configured higher-capability model during complex workflows.
 - **grok-pi** — Bridge Grok CLI session models (Composer 2.5, Grok Build) into Pi via `grok-cli` and `~/.grok/auth.json`.
 - **opencode-pi** — Bridge local OpenCode CLI free models into Pi without OpenCode login, with OpenCode tools disabled and Pi tool calls prompt-bridged back into Pi.
+- **pi-delegator** — Agent skill for delegating approved tasks to a monitored Pi subprocess, preferring free `opencode-cli` models and reporting session metrics.
 - **Neon Green themes** — Futuristic dark (`neon-green`) and light (`neon-green-light`) themes with neon green, cyan, and magenta accents.
 - **One-command install** — Interactive or automated (`--auto`) installer via a single curl pipe.
-- **npm convenience scripts** — `install-all`, `install-extensions`, `install-themes` for local development.
-- **Auto-discovery** — Themes are automatically picked up from `~/.pi/agent/themes/`.
+- **npm convenience scripts** — `install-all`, `install-extensions`, `install-themes`, `install-skills` for local development.
+- **Auto-discovery** — Themes and skills are automatically picked up from Pi's agent directories.
 
 ## Quick Start
 
@@ -144,6 +145,20 @@ file changes under the executor's control.
 - Cache preferences are passed through where providers support them.
 - The advisor has no tools; it only returns strategic guidance.
 
+### pi-delegator
+
+`pi-delegator` is an agent skill that lets a main AI agent delegate a clear,
+approved task to a separate Pi process. It starts by checking available Pi models,
+prefers free `opencode-cli` models by default, saves a reusable default model,
+streams progress, and reports duration/token/cost metrics when Pi exposes them.
+
+```bash
+python3 ~/.pi/agent/skills/pi-delegator/scripts/pi_delegate.py models --prefer-free
+```
+
+Use the skill from Pi as `/skill:pi-delegator`, or let Pi auto-load it when you
+ask to delegate work to a separate Pi instance.
+
 ### Themes
 
 Themes are automatically discovered from `~/.pi/agent/themes/`.
@@ -209,6 +224,11 @@ pi-extensions/
 │       ├── package.json
 │       ├── src/index.ts
 │       └── README.md
+├── skills/
+│   └── pi-delegator/
+│       ├── SKILL.md
+│       ├── scripts/pi_delegate.py
+│       └── references/
 └── themes/
     ├── neon-green.json
     └── neon-green-light.json

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Pi Extensions Installation Script
-# Installs all extensions and themes to your Pi setup
+# Installs all extensions, skills, and themes to your Pi setup
 #
 # Usage:
 #   Interactive (default):
@@ -23,6 +23,7 @@ REMOTE_BRANCH="main"
 
 PI_EXTENSIONS="${HOME}/.pi/agent/extensions"
 PI_THEMES="${HOME}/.pi/agent/themes"
+PI_SKILLS="${HOME}/.pi/agent/skills"
 
 MODE="interactive"     # or "auto", "from-clone", "dry-run"
 KEEP_REPO=false         # or "true"
@@ -63,10 +64,11 @@ install() {
 
     info "Extensions target: $PI_EXTENSIONS"
     info "Themes target:     $PI_THEMES"
+    info "Skills target:     $PI_SKILLS"
 
-    mkdir -p "$PI_EXTENSIONS" "$PI_THEMES"
+    mkdir -p "$PI_EXTENSIONS" "$PI_THEMES" "$PI_SKILLS"
 
-    local ext_count=0 theme_count=0
+    local ext_count=0 theme_count=0 skill_count=0
 
     if [ -d "$SRC_DIR/extensions" ]; then
         for d in "$SRC_DIR"/extensions/*/; do
@@ -90,7 +92,18 @@ install() {
         ok "$theme_count theme(s) installed"
     fi
 
-    info "Total: $ext_count extensions + $theme_count themes"
+    if [ -d "$SRC_DIR/skills" ]; then
+        for d in "$SRC_DIR"/skills/*/; do
+            [ -d "$d" ] || continue
+            local name; name="$(basename "$d")"
+            info "  → $name"
+            cp -r "$d" "$PI_SKILLS/${name}"
+            skill_count=$((skill_count + 1))
+        done
+        ok "$skill_count skill(s) installed"
+    fi
+
+    info "Total: $ext_count extensions + $theme_count themes + $skill_count skills"
 }
 
 cleanup() {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pi-extensions",
   "version": "1.0.0",
-  "description": "Collection of extensions and themes for Pi Coding Agent",
+  "description": "Collection of extensions, skills, and themes for Pi Coding Agent",
   "type": "module",
   "repository": {
     "type": "git",
@@ -11,6 +11,7 @@
     "pi",
     "coding-agent",
     "extensions",
+    "skills",
     "themes",
     "context-window",
     "monitoring"
@@ -21,8 +22,9 @@
     "node": ">=18.0.0"
   },
   "scripts": {
-    "install-all": "cp -r extensions/* ~/.pi/agent/extensions/ && cp -r themes/* ~/.pi/agent/themes/ && echo 'Installation complete. Please reload Pi.'",
-    "install-extensions": "cp -r extensions/* ~/.pi/agent/extensions/ && echo 'Extensions installed. Please reload Pi.'",
-    "install-themes": "cp -r themes/* ~/.pi/agent/themes/ && echo 'Themes installed. Please reload Pi.'"
+    "install-all": "mkdir -p ~/.pi/agent/extensions ~/.pi/agent/themes ~/.pi/agent/skills && cp -r extensions/* ~/.pi/agent/extensions/ && cp -r themes/* ~/.pi/agent/themes/ && cp -r skills/* ~/.pi/agent/skills/ && echo 'Installation complete. Please reload Pi.'",
+    "install-extensions": "mkdir -p ~/.pi/agent/extensions && cp -r extensions/* ~/.pi/agent/extensions/ && echo 'Extensions installed. Please reload Pi.'",
+    "install-themes": "mkdir -p ~/.pi/agent/themes && cp -r themes/* ~/.pi/agent/themes/ && echo 'Themes installed. Please reload Pi.'",
+    "install-skills": "mkdir -p ~/.pi/agent/skills && cp -r skills/* ~/.pi/agent/skills/ && echo 'Skills installed. Please reload Pi.'"
   }
 }

--- a/skills/pi-delegator/SKILL.md
+++ b/skills/pi-delegator/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: "pi-delegator"
+description: "Delegate approved coding tasks to Pi subprocesses with free opencode defaults, model setup, live progress, and metrics. Don't use for direct edits, CI, or non-Pi agents."
+license: "MIT"
+effort: "high"
+metadata:
+  version: "1.0.0"
+  author: "Luong NGUYEN <luongnv89@gmail.com>"
+---
+
+# Pi Delegator
+
+Use this skill when another AI agent should delegate a clearly scoped task to a
+separate Pi instance, monitor Pi while it works, and report exact session metrics.
+The main agent stays the orchestrator: it captures intent, gets user approval,
+selects a model, runs Pi, and summarizes the result.
+
+## Repo Sync Before Edits (mandatory)
+
+If the delegated Pi task may modify a git repository, sync the target repo before
+starting Pi so the delegated work begins from current code:
+
+```bash
+branch="$(git rev-parse --abbrev-ref HEAD)"
+git fetch origin
+git pull --rebase origin "$branch"
+```
+
+If the working tree is dirty, stash first, sync, then pop. If `origin` is missing
+or conflicts occur, stop and ask the user before continuing.
+
+## Safety contract
+
+- Never start Pi until the user approves the exact run preview.
+- Prefer free `opencode-cli` models whenever that provider is available.
+- Do not hide that a non-free model will be used; ask for explicit approval.
+- Do not invent token, cost, or duration metrics. Report only collected values.
+- Keep Pi's task prompt clear and bounded; Pi should know what to do, where to
+  work, what tools are allowed, and what output is expected.
+
+## Prerequisites
+
+Before any delegation, verify:
+
+```bash
+which pi
+python3 --version
+```
+
+If either command fails, stop and tell the user what to install. Resolve the
+bundled helper relative to this skill directory, then use it for model discovery,
+config persistence, execution, event monitoring, and metrics collection:
+
+```bash
+helper="<absolute-path-to-this-skill>/scripts/pi_delegate.py"
+```
+
+## Step 1 — Check models and configure default
+
+Run model discovery first on every skill invocation:
+
+```bash
+python3 "$helper" models --prefer-free
+```
+
+The helper reads Pi's available models and highlights free `opencode-cli` models.
+Configuration is stored in:
+
+```text
+~/.pi/agent/skills/pi-delegator/config.json
+```
+
+If no config exists, or the configured model is no longer available:
+
+1. Show the model list or the helper's recommended free default.
+2. Ask the user to select a default model and thinking level.
+3. Save it with:
+
+```bash
+python3 "$helper" configure \
+  --model "provider/model" \
+  --thinking "low"
+```
+
+Default policy: if `opencode-cli` is available, recommend and use an
+`opencode-cli` model unless the user explicitly chooses another provider.
+
+## Step 2 — Capture clear input
+
+Build a delegation brief before asking for approval:
+
+- Task: the exact work Pi should perform.
+- Target cwd: absolute path where Pi will run.
+- Permissions: read-only, edit files, run tests, install deps, or other limits.
+- Tools: allowed Pi tools, such as `read,bash,edit,write` or read-only tools.
+- Constraints: files to avoid, coding standards, time limits, expected tests.
+- Expected output: summary only, changed files, patch, report path, etc.
+- Complexity: `simple`, `medium`, or `complex`.
+
+If any field is unclear, ask a concise clarifying question before continuing.
+
+## Step 3 — Select model and thinking
+
+Read `references/model-selection.md` when choosing a model. In short:
+
+- Simple tasks: free `opencode-cli` if available, thinking `off` or `minimal`.
+- Medium tasks: free capable model if available, thinking `low` or `medium`.
+- Complex/risky tasks: strongest available free model first; if a paid model is
+  recommended, ask the user to approve the paid model explicitly.
+
+Respect user overrides. If the run will use a non-free provider while
+`opencode-cli` is available, include that warning in the approval preview.
+
+## Step 4 — Approval gate
+
+Show this preview and wait for explicit approval:
+
+```text
+◆ Pi Delegation Preview
+┄┄┄┄┄┄┄┄┄┄┄┄┄
+  Task:       <one sentence>
+  Cwd:        <absolute path>
+  Model:      <provider/model>
+  Thinking:   <off|minimal|low|medium|high|xhigh>
+  Tools:      <tool allowlist>
+  Permissions:<read-only|can edit|can run tests|...>
+  Complexity: <simple|medium|complex>
+
+Run Pi with this task? [y/N]
+```
+
+Default to **No**. If the user declines, stop without launching Pi.
+
+## Step 5 — Run and monitor Pi
+
+After approval, write the delegation prompt to a temporary file and run:
+
+```bash
+python3 "$helper" run \
+  --approved \
+  --task-file /tmp/pi-task.md \
+  --cwd "<target-cwd>" \
+  --model "<provider/model>" \
+  --thinking "<level>" \
+  --tools "read,bash,edit,write" \
+  --approve-project \
+  --session-name "pi-delegated-task"
+```
+
+The helper uses Pi RPC mode, streams progress events, and requests final session
+stats. Read `references/event-monitoring.md` for the event-to-progress mapping.
+Use `--verbose` only when the user asks for raw streaming detail.
+
+## Step 6 — Report result and metrics
+
+Return a compact report:
+
+```text
+◆ Pi Delegation Complete
+┄┄┄┄┄┄┄┄┄┄┄┄┄
+  Result:       DONE | FAILED | ABORTED
+  Duration:     <seconds>
+  Model:        <provider/model>
+  Thinking:     <level>
+  Tokens:       input <n>, output <n>, cache read <n>, cache write <n>
+  Cost:         <amount or not reported>
+  Tool calls:   <n>
+  Session:      <session file or not persisted>
+
+  Summary:
+  <Pi's final answer or concise synthesis>
+```
+
+If Pi changed files, list them from `git status --short` after the run. Do not
+claim tests passed unless Pi or the main agent actually ran them.
+
+## Error handling
+
+- Missing `pi`: ask the user to install Pi and stop.
+- No models available: ask the user to authenticate Pi or configure providers.
+- Configured model unavailable: rerun model selection and update config.
+- User declines approval: stop cleanly.
+- Pi process fails: show stderr, partial progress, and any collected metrics.
+- Metrics unavailable: write `not reported` instead of guessing.
+
+## Step Completion Reports
+
+After each major phase, print a compact status block:
+
+```text
+◆ <Phase> ([step N of 6])
+┄┄┄┄┄┄┄┄┄┄┄
+  Models checked:    ✓ pass
+  Free default:      ✓ pass (opencode-cli available)
+  User approval:     ✓ approved
+  Result:            PASS
+```

--- a/skills/pi-delegator/docs/README.md
+++ b/skills/pi-delegator/docs/README.md
@@ -1,0 +1,58 @@
+<!-- AI_SKIP: Human-facing catalog README. Agents should read ../SKILL.md instead. -->
+
+# Pi Delegator
+
+Pi Delegator is an agent skill for safely handing a clearly scoped task from one
+AI agent to a separate Pi subprocess.
+
+## Highlights
+
+- Checks available Pi models before running.
+- Prefers free `opencode-cli` models by default.
+- Saves a default model in `~/.pi/agent/skills/pi-delegator/config.json`.
+- Requires a clear task preview and explicit approval before execution.
+- Streams Pi progress events in compact human-readable form.
+- Reports duration, tokens, cost, tool calls, retries, compactions, and session
+  path when Pi exposes them.
+
+## When to use
+
+| Use it for | Avoid it for |
+| --- | --- |
+| Delegating implementation tasks to Pi | Direct edits by the current agent |
+| Running a separate monitored Pi session | CI/CD pipeline setup |
+| Capturing metrics from a Pi run | Non-Pi coding agents |
+| Free-model-first task execution | Unapproved background automation |
+
+## How it works
+
+```mermaid
+flowchart TD
+  A[Main AI agent] --> B[Check Pi models]
+  B --> C[Prefer free opencode-cli model]
+  C --> D[Build delegation brief]
+  D --> E{User approves?}
+  E -- No --> F[Stop]
+  E -- Yes --> G[Spawn Pi RPC subprocess]
+  G --> H[Stream progress events]
+  H --> I[Collect session stats]
+  I --> J[Report result and metrics]
+```
+
+## Helper script
+
+```bash
+python3 skills/pi-delegator/scripts/pi_delegate.py models --prefer-free
+python3 skills/pi-delegator/scripts/pi_delegate.py configure \
+  --model "opencode-cli/opencode/deepseek-v4-flash-free" \
+  --thinking low
+python3 skills/pi-delegator/scripts/pi_delegate.py run \
+  --approved \
+  --task-file /tmp/pi-task.md \
+  --cwd "$PWD" \
+  --complexity medium \
+  --tools read,bash,edit,write
+```
+
+The `run` command refuses to start unless `--approved` is present, so the skill
+can enforce an explicit approval gate.

--- a/skills/pi-delegator/evals/evals.json
+++ b/skills/pi-delegator/evals/evals.json
@@ -1,0 +1,23 @@
+{
+  "skill_name": "pi-delegator",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Use Pi to inspect this repo and summarize the package scripts. Prefer free models.",
+      "expected_output": "Checks available Pi models, recommends opencode-cli if available, builds an approval preview, and does not run until approved.",
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "Delegate a medium complexity test-fix task to Pi and show progress and metrics at the end.",
+      "expected_output": "Captures cwd, tools, permissions, model, thinking, asks for approval, runs Pi via the helper after approval, and reports duration/tokens/tool metrics.",
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "Change the default Pi delegation model to a paid OpenAI model even though opencode-cli is available.",
+      "expected_output": "Warns that free opencode-cli models are available, asks for explicit confirmation, then saves the selected default only after confirmation.",
+      "files": []
+    }
+  ]
+}

--- a/skills/pi-delegator/references/event-monitoring.md
+++ b/skills/pi-delegator/references/event-monitoring.md
@@ -1,0 +1,43 @@
+# Event Monitoring
+
+The helper streams Pi RPC events as concise progress lines. Keep default output
+compact; use verbose mode only when the user asks for raw event detail.
+
+## Progress mapping
+
+| RPC event | Progress line |
+| --- | --- |
+| `session` | `● Pi session started — <id>` |
+| `agent_start` | `● Pi agent started` |
+| `turn_start` | `● Turn <n> started` |
+| `tool_execution_start` | `● Tool started: <toolName>` |
+| `tool_execution_update` | Verbose only; show accumulated tool output preview |
+| `tool_execution_end` | `✓ Tool complete: <toolName>` or `✗ Tool failed: <toolName>` |
+| `compaction_start` | `● Compaction started — <reason>` |
+| `compaction_end` | `✓ Compaction complete` or `⚠ Compaction failed` |
+| `auto_retry_start` | `⚠ Retry <attempt>/<max> after transient error` |
+| `auto_retry_end` | `✓ Retry recovered` or `✗ Retry failed` |
+| `agent_end` | `✓ Pi agent finished` |
+| failed command response | `✗ Pi command failed: <error>` |
+
+## Metrics to collect
+
+At the end of the run, call RPC `get_session_stats` and report:
+
+- duration wall time
+- model and thinking level used for the run
+- session file and session id when available
+- message counts
+- tool call count
+- input, output, cache read, cache write, and total tokens
+- estimated cost when Pi reports it
+- context usage when Pi reports it
+- retry and compaction counts observed from events
+
+If a field is missing, write `not reported`.
+
+## What not to stream by default
+
+Do not print every assistant text delta by default. It makes the main agent's
+conversation noisy and can bury important progress. At the end, fetch the final
+assistant text and summarize it for the user.

--- a/skills/pi-delegator/references/model-selection.md
+++ b/skills/pi-delegator/references/model-selection.md
@@ -1,0 +1,70 @@
+# Model Selection
+
+Use this rubric after running `scripts/pi_delegate.py models --prefer-free`.
+
+## Default policy
+
+Prefer free models from the `opencode-cli` provider whenever available. This is
+the default even when a paid default model is saved in config. Use paid providers
+only when the user explicitly selects or approves them for the current run.
+
+## Complexity levels
+
+### Simple
+
+Use for small edits, file lookups, formatting, simple scripts, or straightforward
+bug fixes with a known location.
+
+- Provider/model: fastest free `opencode-cli` model available.
+- Thinking: `off` for non-reasoning models, `minimal` for reasoning models.
+- Tools: keep narrow; use read-only tools for inspection tasks.
+
+Preferred names when present: `deepseek-v4-flash-free`, `mimo-v2.5-free`,
+`flash`, `mini`, `nano`.
+
+### Medium
+
+Use for multi-file changes, test fixes, small feature implementation, dependency
+configuration, or tasks that require reading several files.
+
+- Provider/model: capable free `opencode-cli` model, or saved default if no free
+  model exists.
+- Thinking: `low` or `medium`.
+- Tools: allow write/edit only if the approval preview says so.
+
+Preferred names when present: `big-pickle`, `nemotron-3-ultra-free`, `deepseek`.
+
+### Complex or risky
+
+Use for architecture changes, migrations, security-sensitive work, broad
+refactors, unclear bugs, or tasks where a bad patch is expensive.
+
+- First choice: strongest free `opencode-cli` model available.
+- If no suitable free model is available, recommend a stronger paid model but
+  require explicit user approval before using it.
+- Thinking: `medium` or `high`; `xhigh` only for models known to support it.
+
+Strong-model name signals: `opus`, `gpt-5`, `pro`, `ultra`, `nemotron`, large
+context window, high max output.
+
+## Fallback order
+
+1. User-specified model for this run.
+2. Free `opencode-cli` model if available.
+3. Saved default from `~/.pi/agent/skills/pi-delegator/config.json`.
+4. Best available model from Pi's model list, after user approval.
+
+## Approval wording for paid fallback
+
+When selecting a non-`opencode-cli` model while free models exist, include this
+in the preview:
+
+```text
+⚠ Non-free model selected while free opencode-cli models are available.
+  Continue with <provider/model>? [y/N]
+```
+
+## Thinking compatibility
+
+If a model does not support reasoning, use `off` even if the complexity rubric
+suggests a higher thinking level. Do not force unsupported levels.

--- a/skills/pi-delegator/scripts/pi_delegate.py
+++ b/skills/pi-delegator/scripts/pi_delegate.py
@@ -1,0 +1,549 @@
+#!/usr/bin/env python3
+"""Delegate approved tasks to Pi with model discovery, monitoring, and metrics."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import select
+import shutil
+import subprocess
+import sys
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+CONFIG_DIR = Path.home() / ".pi" / "agent" / "skills" / "pi-delegator"
+CONFIG_PATH = CONFIG_DIR / "config.json"
+THINKING_LEVELS = {"off", "minimal", "low", "medium", "high", "xhigh"}
+
+
+@dataclass
+class ModelInfo:
+    provider: str
+    model: str
+    context: str = ""
+    max_out: str = ""
+    thinking: str = ""
+    images: str = ""
+
+    @property
+    def ref(self) -> str:
+        return f"{self.provider}/{self.model}"
+
+    @property
+    def is_free(self) -> bool:
+        return self.provider == "opencode-cli"
+
+    @property
+    def supports_thinking(self) -> bool:
+        return self.thinking.lower() == "yes"
+
+
+def fail(message: str, code: int = 1) -> None:
+    print(f"✗ {message}", file=sys.stderr)
+    raise SystemExit(code)
+
+
+def ensure_pi() -> None:
+    if not shutil.which("pi"):
+        fail("Pi CLI not found. Install Pi first: npm install -g @earendil-works/pi-coding-agent")
+
+
+def run_pi_list_models() -> str:
+    ensure_pi()
+    proc = subprocess.run(
+        ["pi", "--list-models"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if proc.returncode != 0:
+        fail(f"Failed to list Pi models. stderr: {proc.stderr.strip() or 'not reported'}")
+    # Pi currently prints --list-models to stderr because it is a CLI display
+    # command. Accept either stream so this helper survives future changes.
+    return proc.stdout or proc.stderr
+
+
+def parse_models(table: str) -> list[ModelInfo]:
+    models: list[ModelInfo] = []
+    for line in table.splitlines():
+        line = line.rstrip()
+        if not line or line.startswith("provider"):
+            continue
+        parts = line.split()
+        if len(parts) < 2:
+            continue
+        # Current Pi output columns: provider model context max-out thinking images.
+        provider, model = parts[0], parts[1]
+        rest = parts[2:]
+        models.append(
+            ModelInfo(
+                provider=provider,
+                model=model,
+                context=rest[0] if len(rest) > 0 else "",
+                max_out=rest[1] if len(rest) > 1 else "",
+                thinking=rest[2] if len(rest) > 2 else "",
+                images=rest[3] if len(rest) > 3 else "",
+            )
+        )
+    return models
+
+
+def load_models() -> list[ModelInfo]:
+    models = parse_models(run_pi_list_models())
+    if not models:
+        fail("No Pi models are available. Run `pi /login` or configure a provider first.")
+    return models
+
+
+def load_config() -> dict[str, Any]:
+    if not CONFIG_PATH.exists():
+        return {}
+    try:
+        return json.loads(CONFIG_PATH.read_text())
+    except json.JSONDecodeError as exc:
+        fail(f"Invalid config at {CONFIG_PATH}: {exc}")
+
+
+def save_config(config: dict[str, Any]) -> None:
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    CONFIG_PATH.write_text(json.dumps(config, indent=2, sort_keys=True) + "\n")
+
+
+def find_model(models: list[ModelInfo], ref_or_model: str) -> ModelInfo | None:
+    matches = [m for m in models if m.ref == ref_or_model]
+    if matches:
+        return matches[0]
+    matches = [m for m in models if m.model == ref_or_model]
+    if len(matches) == 1:
+        return matches[0]
+    return None
+
+
+def score_model(model: ModelInfo, complexity: str) -> tuple[int, int, int, str]:
+    name = model.model.lower()
+    provider_bonus = 1000 if model.is_free else 0
+    thinking_bonus = 50 if model.supports_thinking else 0
+
+    if complexity == "simple":
+        name_score = 0
+        for marker, score in [
+            ("flash", 120),
+            ("mini", 100),
+            ("mimo", 90),
+            ("nano", 80),
+            ("deepseek", 70),
+            ("free", 20),
+        ]:
+            if marker in name:
+                name_score += score
+        return (provider_bonus, name_score, thinking_bonus, model.ref)
+
+    if complexity == "complex":
+        name_score = 0
+        for marker, score in [
+            ("ultra", 160),
+            ("big-pickle", 150),
+            ("opus", 140),
+            ("gpt-5", 130),
+            ("pro", 100),
+            ("nemotron", 90),
+            ("deepseek", 60),
+        ]:
+            if marker in name:
+                name_score += score
+        return (provider_bonus, name_score, thinking_bonus, model.ref)
+
+    # medium
+    name_score = 0
+    for marker, score in [
+        ("big-pickle", 130),
+        ("nemotron", 120),
+        ("deepseek", 100),
+        ("flash", 60),
+        ("free", 20),
+    ]:
+        if marker in name:
+            name_score += score
+    return (provider_bonus, name_score, thinking_bonus, model.ref)
+
+
+def recommended_model(models: list[ModelInfo], complexity: str = "medium") -> ModelInfo:
+    complexity = complexity if complexity in {"simple", "medium", "complex"} else "medium"
+    return sorted(models, key=lambda m: score_model(m, complexity), reverse=True)[0]
+
+
+def default_thinking(model: ModelInfo, complexity: str, requested: str | None = None) -> str:
+    if requested:
+        if requested not in THINKING_LEVELS:
+            fail(f"Invalid thinking level: {requested}. Expected one of: {', '.join(sorted(THINKING_LEVELS))}")
+        if requested != "off" and not model.supports_thinking:
+            return "off"
+        return requested
+    if not model.supports_thinking:
+        return "off"
+    if complexity == "simple":
+        return "minimal"
+    if complexity == "complex":
+        return "high"
+    return "low"
+
+
+def command_models(args: argparse.Namespace) -> None:
+    models = load_models()
+    config = load_config()
+    configured_ref = config.get("defaultModel")
+    configured = find_model(models, configured_ref) if configured_ref else None
+    rec = recommended_model(models, args.complexity)
+
+    if args.json:
+        print(json.dumps({
+            "configPath": str(CONFIG_PATH),
+            "configuredDefault": configured.ref if configured else None,
+            "configuredAvailable": bool(configured),
+            "recommended": rec.ref,
+            "recommendedThinking": default_thinking(rec, args.complexity),
+            "freeProviderAvailable": any(m.is_free for m in models),
+            "models": [m.__dict__ | {"ref": m.ref, "free": m.is_free} for m in models],
+        }, indent=2))
+        return
+
+    print("◆ Pi Models")
+    print("┄" * 40)
+    print(f"  Config:      {CONFIG_PATH}")
+    if configured:
+        print(f"  Saved:       {configured.ref} ({config.get('defaultThinking', 'not set')})")
+    elif configured_ref:
+        print(f"  Saved:       {configured_ref} (unavailable)")
+    else:
+        print("  Saved:       not configured")
+    print(f"  Recommended: {rec.ref} ({default_thinking(rec, args.complexity)})")
+    if any(m.is_free for m in models):
+        print("  Free:        opencode-cli available ✓")
+    else:
+        print("  Free:        opencode-cli not available")
+    print()
+    print("  Available models:")
+    for m in models:
+        marker = "★" if m.ref == rec.ref else " "
+        free = "free" if m.is_free else "paid/unknown"
+        print(
+            f"  {marker} {m.ref}  context={m.context or '?'} "
+            f"thinking={m.thinking or '?'} {free}"
+        )
+
+
+def command_configure(args: argparse.Namespace) -> None:
+    models = load_models()
+    model = find_model(models, args.model)
+    if not model:
+        fail(f"Model not available in Pi: {args.model}. Run `pi --list-models` to inspect choices.")
+    thinking = default_thinking(model, "medium", args.thinking)
+    config = load_config()
+    config.update({
+        "defaultModel": model.ref,
+        "defaultThinking": thinking,
+        "preferFreeProvider": True,
+        "updatedAt": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    })
+    save_config(config)
+    print("✓ Pi delegator default saved")
+    print(f"  Config:    {CONFIG_PATH}")
+    print(f"  Model:     {model.ref}")
+    print(f"  Thinking:  {thinking}")
+
+
+def read_task(args: argparse.Namespace) -> str:
+    if args.task_file:
+        path = Path(args.task_file)
+        if not path.exists():
+            fail(f"Task file not found: {path}")
+        return path.read_text()
+    if args.task:
+        return args.task
+    if not sys.stdin.isatty():
+        return sys.stdin.read()
+    fail("No task provided. Use --task-file, --task, or pipe a prompt on stdin.")
+
+
+def stderr_pump(proc: subprocess.Popen[str]) -> None:
+    assert proc.stderr is not None
+    for line in proc.stderr:
+        text = line.rstrip()
+        if text:
+            print(f"  stderr: {text}", file=sys.stderr)
+
+
+def send_rpc(proc: subprocess.Popen[str], payload: dict[str, Any]) -> None:
+    assert proc.stdin is not None
+    proc.stdin.write(json.dumps(payload) + "\n")
+    proc.stdin.flush()
+
+
+def compact_stats(data: dict[str, Any] | None) -> dict[str, Any]:
+    if not data:
+        return {}
+    tokens = data.get("tokens") or {}
+    return {
+        "sessionFile": data.get("sessionFile"),
+        "sessionId": data.get("sessionId"),
+        "userMessages": data.get("userMessages"),
+        "assistantMessages": data.get("assistantMessages"),
+        "toolCalls": data.get("toolCalls"),
+        "tokens": {
+            "input": tokens.get("input"),
+            "output": tokens.get("output"),
+            "cacheRead": tokens.get("cacheRead"),
+            "cacheWrite": tokens.get("cacheWrite"),
+            "total": tokens.get("total"),
+        },
+        "cost": data.get("cost"),
+        "contextUsage": data.get("contextUsage"),
+    }
+
+
+def value_or_unknown(value: Any) -> str:
+    if value is None:
+        return "not reported"
+    return str(value)
+
+
+def command_run(args: argparse.Namespace) -> None:
+    if not args.approved:
+        fail("Refusing to run without --approved. Get explicit user approval first.")
+
+    ensure_pi()
+    cwd = Path(args.cwd).expanduser().resolve()
+    if not cwd.exists() or not cwd.is_dir():
+        fail(f"Target cwd does not exist or is not a directory: {cwd}")
+
+    models = load_models()
+    config = load_config()
+    selected = find_model(models, args.model) if args.model else None
+    if not selected:
+        configured = find_model(models, config.get("defaultModel", ""))
+        free = recommended_model(models, args.complexity) if any(m.is_free for m in models) else None
+        selected = free or configured or recommended_model(models, args.complexity)
+    thinking = default_thinking(selected, args.complexity, args.thinking or config.get("defaultThinking"))
+    task = read_task(args).strip()
+    if not task:
+        fail("Task is empty. Provide a clear delegated task.")
+
+    cmd = [
+        "pi",
+        "--mode", "rpc",
+        "--model", selected.ref,
+        "--thinking", thinking,
+        "--name", args.session_name,
+    ]
+    if args.tools:
+        cmd.extend(["--tools", args.tools])
+    if args.approve_project:
+        cmd.append("--approve")
+    if args.no_session:
+        cmd.append("--no-session")
+
+    start = time.time()
+    print("◆ Pi Delegation Run")
+    print("┄" * 40)
+    print(f"  Cwd:       {cwd}")
+    print(f"  Model:     {selected.ref}")
+    print(f"  Thinking:  {thinking}")
+    print(f"  Tools:     {args.tools or 'Pi default'}")
+    print()
+
+    proc = subprocess.Popen(
+        cmd,
+        cwd=str(cwd),
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        bufsize=1,
+    )
+    threading.Thread(target=stderr_pump, args=(proc,), daemon=True).start()
+
+    send_rpc(proc, {"id": "prompt-1", "type": "prompt", "message": task})
+
+    turn_count = 0
+    retry_count = 0
+    compaction_count = 0
+    stats: dict[str, Any] | None = None
+    final_text: str | None = None
+    requested_stats = False
+    stats_requested_at: float | None = None
+    result = "FAILED"
+
+    assert proc.stdout is not None
+    try:
+        while True:
+            if proc.poll() is not None:
+                break
+            if requested_stats and stats_requested_at and time.time() - stats_requested_at > args.stats_timeout:
+                print("⚠ Timed out waiting for Pi session stats; finishing with partial metrics")
+                result = "DONE"
+                break
+
+            ready, _, _ = select.select([proc.stdout], [], [], 1)
+            if not ready:
+                continue
+            raw_line = proc.stdout.readline()
+            if raw_line == "":
+                break
+            line = raw_line.strip()
+            if not line:
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                print(f"⚠ Non-JSON output from Pi: {line[:200]}")
+                continue
+
+            etype = event.get("type")
+            if args.verbose:
+                print(json.dumps(event, ensure_ascii=False)[:2000])
+
+            if etype == "session":
+                print(f"● Pi session started — {event.get('id', 'unknown')}")
+            elif etype == "response":
+                if not event.get("success", False):
+                    print(f"✗ Pi command failed: {event.get('error', 'unknown error')}")
+                    break
+                if event.get("id") == "stats-1":
+                    stats = event.get("data") or {}
+                    result = "DONE"
+                    break
+            elif etype == "agent_start":
+                print("● Pi agent started")
+            elif etype == "turn_start":
+                turn_count += 1
+                print(f"● Turn {turn_count} started")
+            elif etype == "tool_execution_start":
+                print(f"● Tool started: {event.get('toolName', 'unknown')}")
+            elif etype == "tool_execution_end":
+                name = event.get("toolName", "unknown")
+                if event.get("isError"):
+                    print(f"✗ Tool failed: {name}")
+                else:
+                    print(f"✓ Tool complete: {name}")
+            elif etype == "compaction_start":
+                compaction_count += 1
+                print(f"● Compaction started — {event.get('reason', 'unknown')}")
+            elif etype == "compaction_end":
+                if event.get("errorMessage"):
+                    print(f"⚠ Compaction failed: {event.get('errorMessage')}")
+                else:
+                    print("✓ Compaction complete")
+            elif etype == "auto_retry_start":
+                retry_count += 1
+                print(f"⚠ Retry {event.get('attempt')}/{event.get('maxAttempts')} after transient error")
+            elif etype == "auto_retry_end":
+                print("✓ Retry recovered" if event.get("success") else "✗ Retry failed")
+            elif etype == "agent_end":
+                print("✓ Pi agent finished")
+                for message in reversed(event.get("messages") or []):
+                    if message.get("role") == "assistant":
+                        parts = message.get("content") or []
+                        texts = [part.get("text", "") for part in parts if part.get("type") == "text"]
+                        final_text = "\n".join(text for text in texts if text)
+                        break
+                send_rpc(proc, {"id": "stats-1", "type": "get_session_stats"})
+                requested_stats = True
+                stats_requested_at = time.time()
+    except KeyboardInterrupt:
+        result = "ABORTED"
+        try:
+            send_rpc(proc, {"type": "abort"})
+        except Exception:
+            pass
+    finally:
+        duration = time.time() - start
+        if proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+
+    summary = compact_stats(stats)
+    tokens = summary.get("tokens", {})
+    print()
+    print("◆ Pi Delegation Complete")
+    print("┄" * 40)
+    print(f"  Result:       {result}")
+    print(f"  Duration:     {duration:.1f}s")
+    print(f"  Model:        {selected.ref}")
+    print(f"  Thinking:     {thinking}")
+    print(
+        "  Tokens:       "
+        f"input {value_or_unknown(tokens.get('input'))}, "
+        f"output {value_or_unknown(tokens.get('output'))}, "
+        f"cache read {value_or_unknown(tokens.get('cacheRead'))}, "
+        f"cache write {value_or_unknown(tokens.get('cacheWrite'))}"
+    )
+    print(f"  Total tokens: {value_or_unknown(tokens.get('total'))}")
+    print(f"  Cost:         {value_or_unknown(summary.get('cost'))}")
+    print(f"  Tool calls:   {value_or_unknown(summary.get('toolCalls'))}")
+    print(f"  Retries:      {retry_count}")
+    print(f"  Compactions:  {compaction_count}")
+    print(f"  Session:      {value_or_unknown(summary.get('sessionFile'))}")
+    print("\n  Final response:")
+    if final_text:
+        for line in final_text.strip().splitlines()[:80]:
+            print(f"  {line}")
+    else:
+        print("  not reported")
+
+    if result != "DONE":
+        raise SystemExit(1)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Delegate approved tasks to Pi.")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_models = sub.add_parser("models", help="List available Pi models and recommendation")
+    p_models.add_argument("--json", action="store_true", help="Print machine-readable JSON")
+    p_models.add_argument("--prefer-free", action="store_true", help="Prefer opencode-cli in recommendation")
+    p_models.add_argument("--complexity", choices=["simple", "medium", "complex"], default="medium")
+    p_models.set_defaults(func=command_models)
+
+    p_config = sub.add_parser("configure", help="Save default model selection")
+    p_config.add_argument("--model", required=True, help="Model ref, e.g. opencode-cli/opencode/deepseek-v4-flash-free")
+    p_config.add_argument("--thinking", default="low", choices=sorted(THINKING_LEVELS))
+    p_config.set_defaults(func=command_configure)
+
+    p_run = sub.add_parser("run", help="Run an approved delegated Pi task")
+    p_run.add_argument("--approved", action="store_true", help="Required after explicit user approval")
+    p_run.add_argument("--task-file", help="File containing delegated prompt")
+    p_run.add_argument("--task", help="Delegated prompt text")
+    p_run.add_argument("--cwd", default=os.getcwd(), help="Target working directory")
+    p_run.add_argument("--model", help="Model ref. Defaults to free/recommended/configured model")
+    p_run.add_argument("--thinking", choices=sorted(THINKING_LEVELS))
+    p_run.add_argument("--complexity", choices=["simple", "medium", "complex"], default="medium")
+    p_run.add_argument("--tools", help="Pi tool allowlist, e.g. read,bash,edit,write")
+    p_run.add_argument("--session-name", default="pi-delegated-task")
+    p_run.add_argument("--approve-project", action="store_true", help="Pass --approve to Pi for project-local resources")
+    p_run.add_argument("--no-session", action="store_true", help="Do not persist the Pi session")
+    p_run.add_argument("--stats-timeout", type=float, default=10.0, help="Seconds to wait for post-run stats")
+    p_run.add_argument("--verbose", action="store_true", help="Print raw JSON events")
+    p_run.set_defaults(func=command_run)
+
+    return parser
+
+
+def main() -> None:
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(line_buffering=True)
+    parser = build_parser()
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/pi-delegator/scripts/pi_delegate.py
+++ b/skills/pi-delegator/scripts/pi_delegate.py
@@ -325,6 +325,8 @@ def command_run(args: argparse.Namespace) -> None:
     models = load_models()
     config = load_config()
     selected = find_model(models, args.model) if args.model else None
+    if args.model and not selected:
+        fail(f"Model not available in Pi: {args.model}. Run `pi --list-models` to inspect choices.")
     if not selected:
         configured = find_model(models, config.get("defaultModel", ""))
         free = recommended_model(models, args.complexity) if any(m.is_free for m in models) else None


### PR DESCRIPTION
Type: chore

## Summary
- add a pi-delegator agent skill for approved Pi subprocess delegation
- prefer free opencode-cli models by default and persist the selected default
- stream Pi RPC progress events and report duration/token/cost metrics
- install skills via install.sh and npm scripts

## Testing
- python3 -m py_compile skills/pi-delegator/scripts/pi_delegate.py
- bash -n install.sh
- python3 skills/pi-delegator/scripts/pi_delegate.py models --prefer-free --complexity simple --json
- python3 skills/pi-delegator/scripts/pi_delegate.py run --approved --task 'Reply with exactly: OK' --cwd "/Users/montimage/buildspace/luongnv89/pi-extensions" --no-session --session-name test-pi-delegator-final --stats-timeout 20
- npm run install-skills
- python3 ~/.pi/agent/skills/pi-delegator/scripts/pi_delegate.py run --approved --task 'Reply with exactly: OK' --cwd "/Users/montimage/buildspace/luongnv89/pi-extensions" --no-session --session-name test-installed-pi-delegator-final --stats-timeout 20
