### PR TITLE
fix(statusline): wrap narrow terminal layout (#15)

### DIFF
--- a/extensions/statusline-pi/README.md
+++ b/extensions/statusline-pi/README.md
@@ -19,7 +19,9 @@ pi-extensions │ main [2] PR #12 │ 840,037 (84.0%) Plan │ 42.5 tok/s │ op
 ## Behavior
 
 - Installs as a Pi extension and enables automatically on session start.
-- Replaces Pi's default footer with a single compact statusline.
+- Replaces Pi's default footer with a compact responsive statusline.
+- Uses one line when the terminal is wide enough, then wraps into multiple width-safe
+  lines on narrow terminals so long branch names do not hide context, speed, or model details.
 - Refreshes git change count every 5 seconds.
 - Shows average model response speed as output tokens per second (`tok/s`) across completed assistant responses.
 - Includes the active assistant response in the average while it is streaming, then keeps the completed average visible while idle.

--- a/extensions/statusline-pi/package.json
+++ b/extensions/statusline-pi/package.json
@@ -17,6 +17,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "test": "npm run build && node --test test/*.test.mjs",
     "prepublishOnly": "npm run build"
   },
   "pi": {

--- a/extensions/statusline-pi/src/index.ts
+++ b/extensions/statusline-pi/src/index.ts
@@ -340,7 +340,7 @@ function getZone(contextUsageRatio: number, contextWindow: number): string {
 	}
 }
 
-interface StatuslineSegments {
+export interface StatuslineSegments {
 	dir: string;
 	git: string;
 	compactGit: string;
@@ -349,7 +349,7 @@ interface StatuslineSegments {
 	model: string;
 }
 
-function formatResponsiveStatusline(segments: StatuslineSegments, separator: string, width: number): string[] {
+export function formatResponsiveStatusline(segments: StatuslineSegments, separator: string, width: number): string[] {
 	const safeWidth = Math.max(1, width);
 	const wideLine = [segments.dir, segments.git, segments.context, segments.speed, segments.model].join(separator);
 	if (visibleWidth(wideLine) <= safeWidth) return [wideLine];
@@ -366,11 +366,11 @@ function formatStatuslineGroup(segments: string[], separator: string, width: num
 	return segments.filter(Boolean).map((segment) => truncateToWidth(segment, width));
 }
 
-function getNarrowBranchWidth(width: number): number {
+export function getNarrowBranchWidth(width: number): number {
 	return Math.max(MIN_NARROW_BRANCH_WIDTH, Math.floor(width * NARROW_BRANCH_WIDTH_RATIO));
 }
 
-function truncatePlainTextToWidth(text: string, maxWidth: number, ellipsis = "…"): string {
+export function truncatePlainTextToWidth(text: string, maxWidth: number, ellipsis = "…"): string {
 	if (visibleWidth(text) <= maxWidth) return text;
 
 	const targetWidth = Math.max(0, maxWidth - visibleWidth(ellipsis));
@@ -382,7 +382,7 @@ function truncatePlainTextToWidth(text: string, maxWidth: number, ellipsis = "�
 	return `${output}${ellipsis}`;
 }
 
-function formatGitSection(
+export function formatGitSection(
 	theme: ExtensionContext["ui"]["theme"],
 	branch: string,
 	changedFiles: number,

--- a/extensions/statusline-pi/src/index.ts
+++ b/extensions/statusline-pi/src/index.ts
@@ -1,5 +1,5 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
-import { truncateToWidth } from "@earendil-works/pi-tui";
+import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import { execFileSync } from "node:child_process";
 import * as path from "node:path";
 
@@ -32,6 +32,8 @@ interface CurrentResponseSpeed {
 const GIT_REFRESH_MS = 5_000;
 const PR_REFRESH_MS = 60_000;
 const SPEED_RENDER_THROTTLE_MS = 250;
+const NARROW_BRANCH_WIDTH_RATIO = 0.55;
+const MIN_NARROW_BRANCH_WIDTH = 8;
 
 export default function statuslinePiExtension(pi: ExtensionAPI) {
 	let enabled = true;
@@ -172,22 +174,31 @@ export default function statuslinePiExtension(pi: ExtensionAPI) {
 					const dir = path.basename(ctx.cwd) || ctx.cwd;
 					const branch = gitInfo.branch ?? footerData.getGitBranch?.() ?? "no-git";
 					const changed = gitInfo.changedFiles;
-
-					const segments = [
-						theme.fg("mdLink", dir),
-						formatGitSection(theme, branch, changed, gitInfo.prNumber),
-						formatContextSection(theme, usage, zone),
-						formatSpeedSection(theme, responseSpeed),
-						theme.fg("mdLink", model),
-					].filter((segment): segment is string => Boolean(segment));
-
 					const separator = theme.fg("borderMuted", " │ ");
-					const statusline = truncateToWidth(segments.join(separator), width);
+
+					const statuslines = formatResponsiveStatusline(
+						{
+							dir: theme.fg("mdLink", dir),
+							git: formatGitSection(theme, branch, changed, gitInfo.prNumber),
+							compactGit: formatGitSection(
+								theme,
+								branch,
+								changed,
+								gitInfo.prNumber,
+								getNarrowBranchWidth(width),
+							),
+							context: formatContextSection(theme, usage, zone),
+							speed: formatSpeedSection(theme, responseSpeed),
+							model: theme.fg("mdLink", model),
+						},
+						separator,
+						width,
+					);
 					const extensionStatuses = Array.from(footerData.getExtensionStatuses?.().values() ?? []).map((status) =>
 						truncateToWidth(status, width),
 					);
 
-					return [statusline, ...extensionStatuses];
+					return [...statuslines, ...extensionStatuses];
 				},
 			};
 		});
@@ -329,13 +340,57 @@ function getZone(contextUsageRatio: number, contextWindow: number): string {
 	}
 }
 
+interface StatuslineSegments {
+	dir: string;
+	git: string;
+	compactGit: string;
+	context: string;
+	speed: string;
+	model: string;
+}
+
+function formatResponsiveStatusline(segments: StatuslineSegments, separator: string, width: number): string[] {
+	const safeWidth = Math.max(1, width);
+	const wideLine = [segments.dir, segments.git, segments.context, segments.speed, segments.model].join(separator);
+	if (visibleWidth(wideLine) <= safeWidth) return [wideLine];
+
+	return [
+		...formatStatuslineGroup([segments.dir, segments.compactGit], separator, safeWidth),
+		...formatStatuslineGroup([segments.context, segments.speed, segments.model], separator, safeWidth),
+	];
+}
+
+function formatStatuslineGroup(segments: string[], separator: string, width: number): string[] {
+	const line = segments.filter(Boolean).join(separator);
+	if (visibleWidth(line) <= width) return [line];
+	return segments.filter(Boolean).map((segment) => truncateToWidth(segment, width));
+}
+
+function getNarrowBranchWidth(width: number): number {
+	return Math.max(MIN_NARROW_BRANCH_WIDTH, Math.floor(width * NARROW_BRANCH_WIDTH_RATIO));
+}
+
+function truncatePlainTextToWidth(text: string, maxWidth: number, ellipsis = "…"): string {
+	if (visibleWidth(text) <= maxWidth) return text;
+
+	const targetWidth = Math.max(0, maxWidth - visibleWidth(ellipsis));
+	let output = "";
+	for (const character of text) {
+		if (visibleWidth(output + character) > targetWidth) break;
+		output += character;
+	}
+	return `${output}${ellipsis}`;
+}
+
 function formatGitSection(
 	theme: ExtensionContext["ui"]["theme"],
 	branch: string,
 	changedFiles: number,
 	prNumber?: number,
+	maxBranchWidth?: number,
 ): string {
-	const branchText = theme.fg("mdLink", branch);
+	const branchDisplay = maxBranchWidth === undefined ? branch : truncatePlainTextToWidth(branch, maxBranchWidth);
+	const branchText = theme.fg("mdLink", branchDisplay);
 	const changesColor = changedFiles > 0 ? "warning" : "dim";
 	const changesText = theme.fg(changesColor, `[${changedFiles}]`);
 	const prText = prNumber ? ` ${theme.fg("mdHeading", `PR #${prNumber}`)}` : "";

--- a/extensions/statusline-pi/test/layout.test.mjs
+++ b/extensions/statusline-pi/test/layout.test.mjs
@@ -1,0 +1,91 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import {
+	formatGitSection,
+	formatResponsiveStatusline,
+	getNarrowBranchWidth,
+	truncatePlainTextToWidth,
+} from "../dist/index.js";
+
+const theme = {
+	fg: (_color, text) => text,
+};
+
+function assertWidthSafe(lines, width) {
+	for (const line of lines) {
+		assert.ok(visibleWidth(line) <= width, `${line} exceeds ${width} columns`);
+	}
+}
+
+describe("responsive statusline layout", () => {
+	it("keeps the compact single-line layout when it fits", () => {
+		const separator = " │ ";
+		const segments = {
+			dir: "pi-extensions",
+			git: "main [2] PR #12",
+			compactGit: "main [2] PR #12",
+			context: "840,037 (84.0%) Plan",
+			speed: "42.5 tok/s",
+			model: "openai/gpt-5.5 [T]",
+		};
+
+		const wideLine = [segments.dir, segments.git, segments.context, segments.speed, segments.model].join(separator);
+		const lines = formatResponsiveStatusline(segments, separator, visibleWidth(wideLine));
+
+		assert.deepEqual(lines, [wideLine]);
+	});
+
+	it("wraps into width-safe lines when a long branch would hide other segments", () => {
+		const width = 70;
+		const separator = " │ ";
+		const branch = "issue/77-pr-number-statusline-with-a-very-very-long-branch-name";
+		const compactGit = formatGitSection(theme, branch, 3, 79, getNarrowBranchWidth(width));
+		const lines = formatResponsiveStatusline(
+			{
+				dir: "context-stats",
+				git: formatGitSection(theme, branch, 3, 79),
+				compactGit,
+				context: "58,261 (45.5%) Code",
+				speed: "87.5 tok/s",
+				model: "advisor:3",
+			},
+			separator,
+			width,
+		);
+
+		assert.ok(lines.length >= 2);
+		assertWidthSafe(lines, width);
+		assert.ok(lines.some((line) => line.includes("58,261")), "context segment should remain visible");
+		assert.ok(lines.some((line) => line.includes("87.5 tok/s")), "speed segment should remain visible");
+		assert.ok(lines.some((line) => line.includes("advisor:3")), "model segment should remain visible");
+		assert.ok(lines.some((line) => line.includes("[3]") && line.includes("PR #79")), "git metadata should remain visible");
+	});
+
+	it("truncates plain long branch names without ANSI reset artifacts", () => {
+		const truncated = truncatePlainTextToWidth("feature/super-long-responsive-statusline-branch", 16);
+
+		assert.equal(visibleWidth(truncated), 16);
+		assert.equal(truncated, "feature/super-l…");
+		assert.equal(/\u001b\[[0-9;]*m/.test(truncated), false);
+	});
+
+	it("keeps every segment width-safe at very narrow widths", () => {
+		const width = 12;
+		const lines = formatResponsiveStatusline(
+			{
+				dir: "pi-extensions",
+				git: "issue/very-long-branch [3] PR #79",
+				compactGit: "issue/ve… [3] PR #79",
+				context: "58,261 (45.5%) Code",
+				speed: "87.5 tok/s",
+				model: "openai/gpt-5.5 [T]",
+			},
+			" │ ",
+			width,
+		);
+
+		assert.ok(lines.length > 2);
+		assertWidthSafe(lines, width);
+	});
+});


### PR DESCRIPTION
Closes #15

## Summary

Improves `statusline-pi` so long branch names no longer force the whole footer into a single truncated line. The footer now keeps the existing one-line layout when it fits, and switches to width-safe grouped lines on narrow terminals while preserving context, speed, model, git change count, and PR metadata.

## Approach

Selected option 2 — Balanced responsive layout. The render path now measures the full statusline with ANSI-aware width helpers, returns the original compact line when it fits, and otherwise renders grouped narrow lines with a bounded branch segment.

## Decision Record

- **Root cause:** `statusline-pi` previously joined every footer segment into one string and truncated that final line to the terminal width. A long branch name could consume the available columns and hide later context, speed, model, and PR information.
- **Options considered:** Option 1 — always render two lines; Option 2 — balanced responsive layout; Option 3 — full adaptive priority layout engine.
- **Options rejected:** Option 1 — would unnecessarily change the wide-terminal layout; Option 3 — higher complexity than needed for this focused issue.
- **Selected option:** Option 2 — Balanced responsive layout.
- **Residual risk:** Extremely narrow terminals may still require per-segment truncation, but every emitted line is width-safe and key status groups are preserved on separate lines.

Analyzed at: `improvement/15-statusline-narrow-layout @ e8d275e` (2026-06-11)

## Changes

| File | Change |
|------|--------|
| `extensions/statusline-pi/src/index.ts` | Adds ANSI-aware responsive footer grouping, compact branch rendering, and width-safe fallback lines. |
| `extensions/statusline-pi/test/layout.test.mjs` | Adds Node test coverage for wide layout, narrow wrapping, branch truncation, and very narrow widths. |
| `extensions/statusline-pi/package.json` | Adds a test script that builds the extension and runs Node tests. |
| `extensions/statusline-pi/README.md` | Documents responsive multi-line behavior on narrow terminals. |

## Test Results

- Unit tests: 4 passed
- Integration tests: skipped — no integration test framework
- E2e tests: skipped — no e2e framework
- Build: passed (`npm run build`)
- QA cycles: 2

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| The status line remains readable when the terminal width is narrow. | pass | `formatResponsiveStatusline` splits overflowing content into width-safe groups; covered by `keeps every segment width-safe at very narrow widths`. |
| Long branch names no longer hide other important status information. | pass | Narrow layout uses `compactGit` and separate context/speed/model grouping; covered by `wraps into width-safe lines when a long branch would hide other segments`. |
| Wide terminal layouts can still display the status line compactly on one line when possible. | pass | `formatResponsiveStatusline` returns the original wide line when it fits; covered by `keeps the compact single-line layout when it fits`. |
| A narrow-terminal fallback uses wrapped or multi-line presentation instead of losing information. | pass | `render(width)` returns all responsive status lines plus extension statuses; covered by narrow and very-narrow layout tests. |
