### PR TITLE
feat(statusline-pi): add CPU and memory usage (#22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A curated collection of extensions and themes for [Pi Coding Agent](https://gith
 - **statusline-pi** — Compact custom footer showing current directory, git branch, changed files, GitHub PR number, remaining context window (tokens + percentage), context zone, average model response speed, and active provider/model.
 - **advisor-pi** — Advisor-style strategic guidance tool that lets the executor consult a configured higher-capability model during complex workflows.
 - **claude-code-pi** — Bridge Claude Code CLI model aliases into Pi strictly through local `claude -p` calls, with no SDK/API fallback path.
+- **apple-fm-pi** — Bridge Apple Foundation Models (`fm` CLI: on-device `system`, `pcc`) into Pi with auto-start `fm serve` and `/apple-fm-pi` commands.
 - **grok-pi** — Bridge Grok CLI session models (Composer 2.5, Grok Build) into Pi via `grok-cli` and `~/.grok/auth.json`.
 - **opencode-pi** — Bridge local OpenCode CLI free models into Pi without OpenCode login, with OpenCode tools disabled and Pi tool calls prompt-bridged back into Pi.
 - **pi-delegator** — Agent skill for delegating approved tasks to a monitored Pi subprocess, preferring free `opencode-cli` models and reporting session metrics.
@@ -102,6 +103,18 @@ pi --provider claude-code-cli --model sonnet
 ```
 
 **Commands:** `/claude-code-pi status`, `/claude-code-pi models`, `/claude-code-pi test`, `/claude-code-pi help`
+
+### apple-fm-pi
+
+`apple-fm-pi` registers **`apple-fm`** so Pi can use Apple's **`fm`** CLI models (**`system`** on-device, **`pcc`** when available). It auto-starts `fm serve` and replaces a manual `models.json` entry.
+
+Full setup: [extensions/apple-fm-pi/README.md](extensions/apple-fm-pi/README.md)
+
+```bash
+pi --provider apple-fm --model system
+```
+
+**Commands:** `/apple-fm-pi status`, `/apple-fm-pi start`, `/apple-fm-pi models`, `/apple-fm-pi context`, `/apple-fm-pi test`, `/apple-fm-pi help`
 
 ### grok-pi
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **apple-fm-pi extension**: Apple FM bridge with in-process fm-proxy tool-schema fix (default direct `fm serve` :1976); optional `APPLE_FM_PI_USE_PROXY` for full HTTP proxy; `/apple-fm-pi launch-terminal` for PCC.
 - **advisor-pi extension**: Advisor-style strategic guidance tool that lets the executor consult a configured higher-capability model for planning, review, and course correction.
 - **advisor-pi configuration**: `/advisor-pi` command plus CLI flags for advisor model, max uses, and cache preference.
 - **claude-code-pi extension**: Claude Code CLI provider bridge that exposes Claude Code model aliases in Pi while strictly routing every request and response through local `claude -p` with no SDK/API fallback.

--- a/extensions/apple-fm-pi/README.md
+++ b/extensions/apple-fm-pi/README.md
@@ -1,0 +1,61 @@
+# apple-fm-pi
+
+Use **Apple Foundation Models** (`fm` CLI) in **Pi** — **`system`** and **`pcc`**.
+
+## Default: absorbed fm-proxy (no extra Node server)
+
+Pi tool schemas are **flattened inside the extension** (logic from [fm-proxy](https://github.com/gregbarbosa/fm-proxy), MIT) via `streamSimple` + `onPayload`. That fixes **400 Invalid tool definition** without running `fm-proxy.cjs`.
+
+- Pi → **`http://127.0.0.1:1976/v1`** (`fm serve`) with in-process tool fix  
+- Only **`fm serve`** is auto-started (background)
+
+Optional **`APPLE_FM_PI_USE_PROXY=true`** restores the full HTTP proxy (`:1977` → `:1976`) for streaming retries, token repair, and CORS — not required for normal Pi agent use.
+
+## PCC (503)
+
+Background `fm serve` often breaks **PCC attribution**. For **`pcc`**:
+
+```bash
+/apple-fm-pi launch-terminal
+```
+
+Keep that Terminal open (foreground `fm serve` + optional proxy per `fm-launch.sh`).
+
+## Install
+
+```bash
+cp -r extensions/apple-fm-pi ~/.pi/agent/extensions/
+chmod +x ~/.pi/agent/extensions/apple-fm-pi/bin/fm-launch.sh
+/reload
+```
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `/apple-fm-pi start` | Start `fm serve` (and proxy only if `USE_PROXY=true`) |
+| `/apple-fm-pi launch-terminal` | Foreground stack for PCC |
+| `/apple-fm-pi test system` | Smoke test |
+| `/apple-fm-pi status` | Ports and mode |
+
+## Environment
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `APPLE_FM_PI_FM_PORT` | `1976` | `fm serve` |
+| `APPLE_FM_PI_PROXY_PORT` | `1977` | Only when `USE_PROXY=true` |
+| `APPLE_FM_PI_USE_PROXY` | `false` | Full HTTP fm-proxy instead of in-process fix |
+| `APPLE_FM_PI_CONTEXT_WINDOW` | `131072` | Pi context budget |
+
+## Verify
+
+```bash
+/apple-fm-pi start
+pi -p --provider apple-fm --model system "Reply OK"
+```
+
+## Vendored proxy
+
+`vendor/fm-proxy/fm-proxy.cjs` remains for `USE_PROXY=true` and `bin/fm-launch.sh`; default path does not run it.
+
+MIT (extension). fm-proxy © Greg Barbosa — see `vendor/fm-proxy/LICENSE`.

--- a/extensions/apple-fm-pi/bin/fm-launch.sh
+++ b/extensions/apple-fm-pi/bin/fm-launch.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# apple-fm-pi — foreground fm serve + background fm-proxy (PCC attribution).
+# Based on https://github.com/gregbarbosa/fm-proxy (MIT)
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+VERBOSE=false
+FM_PORT="${FM_PORT:-1976}"
+PROXY_PORT="${PROXY_PORT:-1977}"
+FM_BIN="${FM_BIN:-/usr/bin/fm}"
+HEALTH_TIMEOUT_MS="${HEALTH_TIMEOUT_MS:-20000}"
+
+usage() {
+  cat <<EOF
+apple-fm-pi fm-launch — fm serve (foreground) + fm-proxy
+
+  OpenAI base URL: http://127.0.0.1:\$PROXY_PORT/v1
+
+  -v, --verbose
+  --fm-port <n>       (default 1976)
+  --proxy-port <n>    (default 1977)
+  --fm-bin <path>
+  -h, --help
+
+Keep this Terminal open for PCC. Ctrl-C to stop.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -v|--verbose) VERBOSE=true; shift ;;
+    --fm-port) FM_PORT="${2:-}"; shift 2 ;;
+    --proxy-port) PROXY_PORT="${2:-}"; shift 2 ;;
+    --fm-bin) FM_BIN="${2:-}"; shift 2 ;;
+    --health-timeout) HEALTH_TIMEOUT_MS="${2:-}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown: $1" >&2; exit 2 ;;
+  esac
+done
+
+ts() { date '+%H:%M:%S'; }
+say() { printf '%s [apple-fm-pi] %s\n' "$(ts)" "$*"; }
+
+probe_health() {
+  curl -s -m 1 "http://127.0.0.1:$1/health" 2>/dev/null | grep -qE 'running|available|status'
+}
+
+wait_health() {
+  local deadline=$(( $(date +%s) * 1000 + $2 ))
+  while :; do
+    probe_health "$1" && return 0
+    [[ $(( $(date +%s) * 1000 )) -ge $deadline ]] && return 1
+    sleep 0.3
+  done
+}
+
+probe_listening() {
+  curl -s -m 1 -o /dev/null "http://127.0.0.1:$1/health" 2>/dev/null
+}
+
+wait_listening() {
+  local deadline=$(( $(date +%s) * 1000 + $2 ))
+  while :; do
+    probe_listening "$1" && return 0
+    [[ $(( $(date +%s) * 1000 )) -ge $deadline ]] && return 1
+    sleep 0.3
+  done
+}
+
+PROXY_PID=""
+cleaning=false
+cleanup() {
+  $cleaning && return
+  cleaning=true
+  [ -n "$PROXY_PID" ] && kill "$PROXY_PID" 2>/dev/null
+  pkill -f "fm serve --port $FM_PORT" 2>/dev/null || true
+  wait 2>/dev/null || true
+}
+trap cleanup INT TERM HUP EXIT
+
+export FM_PORT PROXY_PORT
+say "starting fm-proxy on :$PROXY_PORT → fm :$FM_PORT"
+node "$SCRIPT_DIR/vendor/fm-proxy/fm-proxy.cjs" >>"$HOME/.pi/agent/logs/apple-fm-pi-fm-launch-proxy.log" 2>&1 &
+PROXY_PID=$!
+if ! wait_listening "$PROXY_PORT" 10000; then
+  say "proxy did not listen on :$PROXY_PORT"
+  exit 1
+fi
+
+say "starting fm serve on :$FM_PORT (foreground — required for PCC)"
+(
+  if wait_health "$FM_PORT" "$HEALTH_TIMEOUT_MS"; then
+    say "stack up — OpenAI base URL: http://127.0.0.1:$PROXY_PORT/v1"
+  else
+    say "fm serve not healthy; check Apple Intelligence / Terminal sign-in"
+  fi
+) &
+
+exec "$FM_BIN" serve --port "$FM_PORT"

--- a/extensions/apple-fm-pi/package-lock.json
+++ b/extensions/apple-fm-pi/package-lock.json
@@ -1,0 +1,3352 @@
+{
+  "name": "apple-fm-pi",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "apple-fm-pi",
+      "version": "1.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "typescript": "^5.6.0"
+      },
+      "peerDependencies": {
+        "@earendil-works/pi-ai": "^0.75.5",
+        "@earendil-works/pi-coding-agent": "^0.75.4"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.91.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-runtime": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
+      "integrity": "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/credential-provider-node": "^3.972.42",
+        "@aws-sdk/eventstream-handler-node": "^3.972.16",
+        "@aws-sdk/middleware-eventstream": "^3.972.12",
+        "@aws-sdk/middleware-websocket": "^3.972.19",
+        "@aws-sdk/token-providers": "3.1048.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.974.21",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.21.tgz",
+      "integrity": "sha512-P5JAHvn4dTi96UsAGS67LVOqqpUNNRhnfFXqzCYtdBIGZtqBue4CXvRr9YenOO7PALj/Pn8uuyw53FBCiCYw8w==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.13",
+        "@aws-sdk/xml-builder": "^3.972.30",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.47",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.47.tgz",
+      "integrity": "sha512-3YoPwJczcc+MtX2xxXaYaOOWO6xKUJr1ZIIDIFuninr51BYONVVcF/CP8K2xfVRC/PztJjqKWxNGFH7BWQAw1Q==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.21",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.49",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.49.tgz",
+      "integrity": "sha512-2UtGUPy+x3lqyceHrtC1uEuVxBZbDalPF6KAFqBwYgm4edWdBrZKNnCqzDs7KynWUvEC6mrR+ojRk+ZgQz9C2w==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.21",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-http-handler": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.8.0.tgz",
+      "integrity": "sha512-Mq7TNt/VhlEWiYRLQGpzUWeUxh899UGpjKh7Ru0WVIDIjnE+cTRAn0NYlFQ6bWfsQnKnpCbWJj86HzmcG0qEdg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/core": "^3.25.0",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.54",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.54.tgz",
+      "integrity": "sha512-Hx4gO4YRjFwitf3MVl3cDwYe1aryJthC4txVl9b+JAURovA50M2ywf9r8j1E/Q6SCTPT4qQpjOAbKYIC9CG+Vw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.21",
+        "@aws-sdk/credential-provider-env": "^3.972.47",
+        "@aws-sdk/credential-provider-http": "^3.972.49",
+        "@aws-sdk/credential-provider-login": "^3.972.53",
+        "@aws-sdk/credential-provider-process": "^3.972.47",
+        "@aws-sdk/credential-provider-sso": "^3.972.53",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.53",
+        "@aws-sdk/nested-clients": "^3.997.21",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.53",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.53.tgz",
+      "integrity": "sha512-+71sluhkgPqdhbbD3UDwUpj24GCkng9HQx6z7qoBFb8dwkF4ktpOcVKDeHpgg8PvBgLYwAnUYLTEGRC/PniCiQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.21",
+        "@aws-sdk/nested-clients": "^3.997.21",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.56",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.56.tgz",
+      "integrity": "sha512-iI+4o0dvQQ4NHel4FMDiFy5q2gaU/ryLK3niOsoPccAt9WLFRkV4XTYPWRr9XvmBUqEzXG73S4p/8gm0Lu/W3A==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.47",
+        "@aws-sdk/credential-provider-http": "^3.972.49",
+        "@aws-sdk/credential-provider-ini": "^3.972.54",
+        "@aws-sdk/credential-provider-process": "^3.972.47",
+        "@aws-sdk/credential-provider-sso": "^3.972.53",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.53",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.47",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.47.tgz",
+      "integrity": "sha512-tAizPm9IFo/PHn06c+LQJlzfY2AGOlyF0CUljFejrU6LcZBjnk8pmbZK3/xoIDdnIzjEdbClfvY3mXfr818ZEg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.21",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.53",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.53.tgz",
+      "integrity": "sha512-pUXE3fu4tfEDV8BksIgf4dXvuIH10FhwHMl/wu8rBD5T1sMpryQWFVitH3kdPS90wlgrGYJQ/meQTSPacyZfeg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.21",
+        "@aws-sdk/nested-clients": "^3.997.21",
+        "@aws-sdk/token-providers": "3.1069.0",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1069.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1069.0.tgz",
+      "integrity": "sha512-ks4X+kngC3PA5howV7Qu1TgG4bfC4jPykKdvw3nmBSXR9yZxRJouBholFSNQ5kY3L+Fgwyw+LCjzQmNi+KR91g==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.21",
+        "@aws-sdk/nested-clients": "^3.997.21",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.53",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.53.tgz",
+      "integrity": "sha512-JmMGlhVvSj8uSG9CpeDkJAXT35H89tc6v84iMgEIE75q4yp1MKVVKvopv6Gg28HJIR7hMNkojRF8H2m5W44wyg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.21",
+        "@aws-sdk/nested-clients": "^3.997.21",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-handler-node": {
+      "version": "3.972.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.22.tgz",
+      "integrity": "sha512-tqPJv0dz4+O0hWGm1a6YekcMZyPhDFs/zH73Von7icaVT5n0Jqvm86typ3jRrG+qoUdPhALOnboRLTmnWQTlYQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-eventstream": {
+      "version": "3.972.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.18.tgz",
+      "integrity": "sha512-OHpk8YoZi3yexPq8aFt1vN1IxA2zLKvsIR5GpWYylX/ve6kQmY7wxHNSFy/D3t2apMZ16rs76Co4dJWcDyIk3A==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-websocket": {
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.29.tgz",
+      "integrity": "sha512-Agv95NCgYyvuYUXt2PcFcOMrKCkhBFPhoH+nVMQh85RcXSCQrhAa4475plBOeomCihP26vKHT5KinVQT3iD14w==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.21",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.21",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.21.tgz",
+      "integrity": "sha512-eC7Vl7Qom/BGhZjG9GEqPwdQ/fk45hg1t5LP4EUxG5d1fdshLbaxCiwh/tszUzDX/4mW40mu2QsbeJJRPBbqUw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.21",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.35",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-http-handler": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.8.0.tgz",
+      "integrity": "sha512-Mq7TNt/VhlEWiYRLQGpzUWeUxh899UGpjKh7Ru0WVIDIjnE+cTRAn0NYlFQ6bWfsQnKnpCbWJj86HzmcG0qEdg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/core": "^3.25.0",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.35.tgz",
+      "integrity": "sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
+      "integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.13.tgz",
+      "integrity": "sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.8.tgz",
+      "integrity": "sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.30",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.30.tgz",
+      "integrity": "sha512-StElZPEoBquWwNqw1AcfpzEyZqJvFxouG+mpDNYlcH6ZOrqd2CuIryv+8LV8gNHZUOyKyJF3Dq9vxaXEmDR9TQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/types": "^4.14.3",
+        "fast-xml-parser": "5.7.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-ai": {
+      "version": "0.75.5",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.75.5.tgz",
+      "integrity": "sha512-zf1F5kXk1pqZeFShXOqq9ibUk8QdtRoLCDPAjO+hj44e3EUs9/GFO2qnhTC5+JA2uwVCx+WCNe1PiCjlBYWm5w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@anthropic-ai/sdk": "0.91.1",
+        "@aws-sdk/client-bedrock-runtime": "3.1048.0",
+        "@google/genai": "1.52.0",
+        "@mistralai/mistralai": "2.2.1",
+        "@smithy/node-http-handler": "4.7.3",
+        "http-proxy-agent": "7.0.2",
+        "https-proxy-agent": "7.0.6",
+        "openai": "6.26.0",
+        "partial-json": "0.1.7",
+        "typebox": "1.1.38"
+      },
+      "bin": {
+        "pi-ai": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent": {
+      "version": "0.75.5",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.75.5.tgz",
+      "integrity": "sha512-O3CCQDYy28D4uwtP6zZkdEwzHN6X22v49Sb0+SZTC7x37V/YfmogrWPiaFoWeoc2hmdKhSATI7ZAK5bQbJG5NA==",
+      "hasShrinkwrap": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@earendil-works/pi-agent-core": "^0.75.5",
+        "@earendil-works/pi-ai": "^0.75.5",
+        "@earendil-works/pi-tui": "^0.75.5",
+        "@silvia-odwyer/photon-node": "0.3.4",
+        "chalk": "5.6.2",
+        "cross-spawn": "7.0.6",
+        "diff": "8.0.4",
+        "glob": "13.0.6",
+        "highlight.js": "10.7.3",
+        "hosted-git-info": "9.0.3",
+        "ignore": "7.0.5",
+        "jiti": "2.7.0",
+        "minimatch": "10.2.5",
+        "proper-lockfile": "4.1.2",
+        "typebox": "1.1.38",
+        "undici": "8.3.0",
+        "yaml": "2.9.0"
+      },
+      "bin": {
+        "pi": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      },
+      "optionalDependencies": {
+        "@mariozechner/clipboard": "0.3.6"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@anthropic-ai/sdk": {
+      "version": "0.91.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/client-bedrock-runtime": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
+      "integrity": "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/credential-provider-node": "^3.972.42",
+        "@aws-sdk/eventstream-handler-node": "^3.972.16",
+        "@aws-sdk/middleware-eventstream": "^3.972.12",
+        "@aws-sdk/middleware-websocket": "^3.972.19",
+        "@aws-sdk/token-providers": "3.1048.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/core": {
+      "version": "3.974.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.11.tgz",
+      "integrity": "sha512-QpnINq5FZH6EOaDEkmHdT7eUunbvD27pDNQypaWjFyYz7Zl1q3UCMQErBZxpmfGfI7MvI2TlK8KTkgNpv8b1ug==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/xml-builder": "^3.972.24",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.37.tgz",
+      "integrity": "sha512-/jpPvEh6f7ntmIzf7dNxoNX6Q8vt8UpesCjbW6mFfk4V1NW6bIy9qxcQ6WbA8As5yQhsZOe+xeNd4xHX8kdY2Q==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.39.tgz",
+      "integrity": "sha512-pIgTpisWyWg7X1bUbzSjuUYosYTD0Ghz2M0hkSTmb3a6i3qV3uU+NYJPI/E2XSC0HcsZh5rsLPzeXrkb2DS0Cg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.41.tgz",
+      "integrity": "sha512-u2tyjaxJJzW8UtW4SM1ZcPMDwO6y+kV+llvou+Adts0FAKyzes5jG4izQN+KX3yE8ZROpS5y1LJ//xL2iSf76w==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/credential-provider-env": "^3.972.37",
+        "@aws-sdk/credential-provider-http": "^3.972.39",
+        "@aws-sdk/credential-provider-login": "^3.972.41",
+        "@aws-sdk/credential-provider-process": "^3.972.37",
+        "@aws-sdk/credential-provider-sso": "^3.972.41",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.41",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/credential-provider-imds": "^4.3.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.41.tgz",
+      "integrity": "sha512-0LBitxXiAiaE5nlFPfpNIww/8FRY/I7WIndWsc9GmNFOM7cE1wNpVNQEGEk9Outg5l8xl+3vybxFyUy4l9q/LQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.42.tgz",
+      "integrity": "sha512-D4oon2zbqqsWOJUM99Gm3/ZyJ0IJvTXVN3PyloGb3kQEyI36fjCZheZj422lAgTWWd6TSHgiImLt3RIaLdv3dQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.37",
+        "@aws-sdk/credential-provider-http": "^3.972.39",
+        "@aws-sdk/credential-provider-ini": "^3.972.41",
+        "@aws-sdk/credential-provider-process": "^3.972.37",
+        "@aws-sdk/credential-provider-sso": "^3.972.41",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.41",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/credential-provider-imds": "^4.3.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.37.tgz",
+      "integrity": "sha512-7nVaHBUaWIddASYfVaA9O4D5ZVjewU3sCol9WqZPGfW0nR+0WqE0xHZnD/U2L33PlOB8KNXGKZ6wOES/QijKzg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.41.tgz",
+      "integrity": "sha512-IOWAWEHe5LkjSKkkUUX9ciV6Y1scHTsnfEkdt5yyC4Slrc7AGbkLPrpntjqh18ksJAMOaVhoBsO8p2WyTcY2wQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/token-providers": "3.1048.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.41.tgz",
+      "integrity": "sha512-mbACk9Yypa8nm4iGZLs0PofOXEcTDOUw6wDnsPXNDNSd2WNXs1tSo+6nc/fh0jLYdfVZThhBL98PHW4aXFsG5A==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/eventstream-handler-node": {
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.16.tgz",
+      "integrity": "sha512-yedpPgKftqjU5SlPFHfqWpOw6xSCRieWRG1euWOlXn4WJxt2VX92VprCa2PpSOXjVCAeK6dTjW9eJRXVig9yGA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/middleware-eventstream": {
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.12.tgz",
+      "integrity": "sha512-tHTHHCHNrq6XklQvlzHBDJG4Iuhh7NVPRdtmvP+nHFA+5sxPlIDzlAHHgfoYHGvT3NXP1yVP/L5c3opUn6T3Qg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/middleware-websocket": {
+      "version": "3.972.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.19.tgz",
+      "integrity": "sha512-mkEhOGYozqKQkbFaVrjwr0faiwwZza1v5/jSY6Tucm3bD+uKTazIUH/4Yo6aMnQD2ua2W9cMP6s8mvwTcjtqHw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.9.tgz",
+      "integrity": "sha512-jPR3rnmRI4hWYyzfmTGBr7NblMp8QYYeflHXba1H6+7CGrWVqWKQzaXFQ4qbExqPRsXN3T3L3JxFhr6aouXUGQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.27",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.27.tgz",
+      "integrity": "sha512-0Phbz4t6HI3D3skxvG2uI+VWU034/nSIw1T8d+FPzzQG9EQTrw94o9mOKO2Gv3n3Oc8P7JD7RAUxkoneLWv5Eg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
+      "integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/types": {
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.24.tgz",
+      "integrity": "sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@nodable/entities": "2.1.0",
+        "@smithy/types": "^4.14.1",
+        "fast-xml-parser": "5.7.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
+      "version": "0.75.5",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.75.5.tgz",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@earendil-works/pi-ai": "^0.75.5",
+        "ignore": "7.0.5",
+        "typebox": "1.1.38",
+        "yaml": "2.9.0"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
+      "version": "0.75.5",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.75.5.tgz",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@anthropic-ai/sdk": "0.91.1",
+        "@aws-sdk/client-bedrock-runtime": "3.1048.0",
+        "@google/genai": "1.52.0",
+        "@mistralai/mistralai": "2.2.1",
+        "@smithy/node-http-handler": "4.7.3",
+        "http-proxy-agent": "7.0.2",
+        "https-proxy-agent": "7.0.6",
+        "openai": "6.26.0",
+        "partial-json": "0.1.7",
+        "typebox": "1.1.38"
+      },
+      "bin": {
+        "pi-ai": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
+      "version": "0.75.5",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.75.5.tgz",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "get-east-asian-width": "1.6.0",
+        "marked": "15.0.12"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@google/genai": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
+      "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.6.tgz",
+      "integrity": "sha512-MXdtr+6+ntlIVHdrZYuZNQydu6o8yZswFJ2Ln81j2O/Y9B/LDHvEaIm95xWNPkjGTWriSOeLnQJRFs6dYb60bg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@mariozechner/clipboard-darwin-arm64": "0.3.6",
+        "@mariozechner/clipboard-darwin-universal": "0.3.6",
+        "@mariozechner/clipboard-darwin-x64": "0.3.6",
+        "@mariozechner/clipboard-linux-arm64-gnu": "0.3.6",
+        "@mariozechner/clipboard-linux-arm64-musl": "0.3.6",
+        "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.6",
+        "@mariozechner/clipboard-linux-x64-gnu": "0.3.6",
+        "@mariozechner/clipboard-linux-x64-musl": "0.3.6",
+        "@mariozechner/clipboard-win32-arm64-msvc": "0.3.6",
+        "@mariozechner/clipboard-win32-x64-msvc": "0.3.6"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-arm64": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.6.tgz",
+      "integrity": "sha512-HjaisYCAbHi/1+N1yDAQHc8ZXGffufIUT5NSOSVR3f3AuMDusxTtnbK8tZ7JFDkShua1oNGZoNwQHsc8MPtE0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-universal": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.6.tgz",
+      "integrity": "sha512-8BWtPjOtJOJoykml3w0fx0zRrfWP31mXrJwfoA7xzNprkZw1uolCNfgmjDiVBseoKjp16EGITz7bN+61qn8dWA==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-x64": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.6.tgz",
+      "integrity": "sha512-p9syiZD1kU4I+1ya7f7g+zD1GiUvR8fdlRlNmgsZNWlyjtc8rlV2EjTLd/35x1LsdBq020GVvtzp0ZmPgBI09Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-arm64-gnu": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.6.tgz",
+      "integrity": "sha512-5JFf5rGofrm+V29HNF+wLthXphHdQpMbKDUYJ5tML6/Z5DLlLOV/9Ak4kDPtYyZ+Dzf+kAusE0VsFg4+tfP1IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-arm64-musl": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.6.tgz",
+      "integrity": "sha512-JlVjxxw0GbGC0djXYWRIqyteO3J1KZ/QG3udlEFaOD5TLOM1FnmXXAPDQBqr+aBVr720ef9K00dirYnJ0LDCtw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-riscv64-gnu": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.6.tgz",
+      "integrity": "sha512-4t8BUi5zZ+L77otFQVnVSlaTyAX4TVk9EqQm4syMrEQp96trFEHEwwNHcNEBGzYv5+K7mxay50TthYkz47OWzQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-x64-gnu": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.6.tgz",
+      "integrity": "sha512-trtPwcNLW37irwQCJLtCxLw757jjJZk3TSnY/MU9bhtWtA3K9b/eLW0e4RGhUXDoFRds9opNWWaUDuFLa8dm0w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-x64-musl": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.6.tgz",
+      "integrity": "sha512-WfnzIvOCCWQiN0MmltCEo6cLceUDbYe+I7xyFZjaps5A+2Op/M2CY7Rey+C4ucQhrvmpoHmTSFgY9ODWk7snoA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-win32-arm64-msvc": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.6.tgz",
+      "integrity": "sha512-+8+1aHYsBPUjmW3otmWlg+Hijt0iJvoBBs5e0mxFeUd4gDaKMB8Bn6x7c6KVtscg7E5j5NFXnwQqNSIAO4p8zQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-win32-x64-msvc": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.6.tgz",
+      "integrity": "sha512-S4xfPmERC8ZkiLHe3vekZCjdDwNEETCuvCgQK2kP6/TnvmUkq1y2Pk+DjM4t8uh9KMX9bH4zs5ePcKa8GTXmfg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mistralai/mistralai": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.1.tgz",
+      "integrity": "sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-to-json-schema": "^3.25.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/inquire": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@silvia-odwyer/photon-node": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
+      "integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
+      "license": "Apache-2.0",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/core": {
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.3.tgz",
+      "integrity": "sha512-Ep/7tPamGY8mgESE3LyLKtxJyy6U52WWAqr/3wial47Sj4u3PiIF73AOGI27UyLy9duTkhZbgzodOfLV4TduZg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/credential-provider-imds": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.3.tgz",
+      "integrity": "sha512-I2Bti0DKFo2IJyN28ijCsx51BAumEYR4/1yZ1FXyBygy9MqbnMqCev4JPth/MbpRfBSRAX35hITSnAdJRo1u5w==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/fetch-http-handler": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.3.tgz",
+      "integrity": "sha512-F+DRf8IJazRJgYog2A/yJK7eYVc0rqTlRzO+5ZxjJd4WkZoKz0IJRncf7G6t1pdVT3kryJcwuTFhN1c5m6N47A==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/node-http-handler": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
+      "integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/signature-v4": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.3.tgz",
+      "integrity": "sha512-53+75QuPl6DL+ct6vVEB51FDO5oulXr20TPV46VvJZg76lIlXNWfxi8j+G2V/t0I2qxCBOa3vX/8bmjrpFVo9g==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/types": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
+      "integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-parser": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "peer": true,
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/google-auth-library": {
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/hosted-git-info": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+      "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "lru-cache": "^11.1.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/lru-cache": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.4.0.tgz",
+      "integrity": "sha512-W+R+kFL4HgVxONq2bhXPi3bGpzGe/yEhVOp233qw9wCRtgncJ15P3bC+e4zZMu4Cq7d+WAJjXGW0uUkifhcatA==",
+      "license": "BlueOak-1.0.0",
+      "peer": true,
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/marked": {
+      "version": "15.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "peer": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/openai": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
+      "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/p-retry/node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/partial-json": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
+      "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "peer": true,
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/proper-lockfile/node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/protobufjs": {
+      "version": "7.5.9",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.9.tgz",
+      "integrity": "sha512-Od4muIm3HW1AouyHF5lONOf1FWo3hY1NbFDoy191X9GzhpgW1clCoaFjfVs2rKJNFYpTNJbje4cbAIDBZJ63ZA==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/strnum": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/typebox": {
+      "version": "1.1.38",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
+      "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/undici": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.3.0.tgz",
+      "integrity": "sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peer": true,
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    },
+    "node_modules/@google/genai": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
+      "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mistralai/mistralai": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.1.tgz",
+      "integrity": "sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-to-json-schema": "^3.25.0"
+      }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.25.0.tgz",
+      "integrity": "sha512-TTD6el7tvKyafkXBf7XO3jLOE+qVxOTrLjp/fEGiV3BMfUHK/LfdYlQO9YgZvzxC7kqA3H/IhJXNqQgnbgjb7A==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.0.tgz",
+      "integrity": "sha512-pPQmNdEvMJttv9z2kdYxoui83p/nr32zjMf0aMfmzmGmFEgKXUfy0vXiNg0fx4R5XLQzmJBLM9Wg0guEq2/q8A==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/core": "^3.25.0",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.5.0.tgz",
+      "integrity": "sha512-OG8kBYAgX7lf32+xLzgirvuLffn1KNoszaSiButt45i2cRa5irk8LQXLYQ5Smij1SBTN4KMNcBsRwRrLPfIGyA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/core": "^3.25.0",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
+      "integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.5.0.tgz",
+      "integrity": "sha512-vW6UdK7e7gV2wU/tXRsPq4pMQMusb8VymdVOyIFNA1FtyRmEClRFkYDtYI8UcO/HM0wK3qqjvvQs3HOlbgMbdg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/core": "^3.25.0",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.21.tgz",
+      "integrity": "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/anynum": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.0.tgz",
+      "integrity": "sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.5.tgz",
+      "integrity": "sha512-5FZy72Rh8LhtjmvDrKkI+lVhrsQrVKVsItxMoDm5mNQE+xR0WVIIs+jzPSJgBvKVsLi24fZhXJIsNI0bihDzFg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.7.0.tgz",
+      "integrity": "sha512-QpTAbNJ36TliZLx3TTtahR8HG0hN9RllL1e3FymOvQSIKK8JmgV58H924ub2wa2DsS3ANjjP1Aw1N+Ramc8hqQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0",
+      "peer": true
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
+      "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/partial-json": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
+      "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/strnum": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.0.tgz",
+      "integrity": "sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "anynum": "^1.0.0"
+      }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "peer": true
+    },
+    "node_modules/typebox": {
+      "version": "1.1.38",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
+      "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peer": true,
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/extensions/apple-fm-pi/package.json
+++ b/extensions/apple-fm-pi/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "apple-fm-pi",
+  "version": "1.0.0",
+  "description": "Bridge Apple Foundation Models (fm CLI: system, pcc) into Pi with auto-start fm serve",
+  "type": "module",
+  "main": "./src/index.ts",
+  "files": [
+    "src",
+    "bin",
+    "vendor",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "test": "node --test test/*.test.mjs"
+  },
+  "pi": {
+    "extensions": [
+      "./src/index.ts"
+    ]
+  },
+  "keywords": [
+    "pi",
+    "apple",
+    "foundation-models",
+    "fm",
+    "on-device",
+    "pcc",
+    "custom-provider"
+  ],
+  "author": "pi-extensions contributors",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/luongnv89/pi-extensions.git"
+  },
+  "bugs": {
+    "url": "https://github.com/luongnv89/pi-extensions/issues"
+  },
+  "homepage": "https://github.com/luongnv89/pi-extensions/tree/main/extensions/apple-fm-pi",
+  "peerDependencies": {
+    "@earendil-works/pi-ai": "^0.75.5",
+    "@earendil-works/pi-coding-agent": "^0.75.4"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.6.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/extensions/apple-fm-pi/src/config.ts
+++ b/extensions/apple-fm-pi/src/config.ts
@@ -1,0 +1,100 @@
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const PROVIDER_ID = "apple-fm";
+
+/** Pi budgeting default — matches ~4k on-device `system` limit (not 128k). Override with APPLE_FM_PI_CONTEXT_WINDOW. */
+const DEFAULT_CONTEXT = 4096;
+const MAX_ALLOWED_CONTEXT = 131_072;
+
+/** Extension root (parent of src/). */
+export function extensionRoot(): string {
+	return join(dirname(fileURLToPath(import.meta.url)), "..");
+}
+
+export type AppleFmConfig = {
+	host: string;
+	fmPort: number;
+	proxyPort: number;
+	baseUrl: string;
+	fmBin: string;
+	autoStart: boolean;
+	useProxy: boolean;
+	contextWindow: number;
+	maxTokens: number;
+	agentDir: string;
+	proxyScript: string;
+	pidFileProxy: string;
+	pidFileFm: string;
+	logFileProxy: string;
+	logFileFm: string;
+};
+
+function agentDir(): string {
+	return process.env.PI_CODING_AGENT_DIR ?? join(homedir(), ".pi", "agent");
+}
+
+function parsePort(raw: string | undefined, fallback: number): number {
+	if (!raw) return fallback;
+	const n = Number.parseInt(raw, 10);
+	if (!Number.isFinite(n) || n < 1 || n > 65_535) return fallback;
+	return n;
+}
+
+function parsePositiveInt(raw: string | undefined, fallback: number, max: number): number {
+	if (!raw) return fallback;
+	const n = Number.parseInt(raw, 10);
+	if (!Number.isFinite(n) || n < 1) return fallback;
+	return Math.min(n, max);
+}
+
+function parseBool(raw: string | undefined, fallback: boolean): boolean {
+	if (raw === undefined || raw === "") return fallback;
+	const v = raw.toLowerCase();
+	if (v === "1" || v === "true" || v === "yes" || v === "on") return true;
+	if (v === "0" || v === "false" || v === "no" || v === "off") return false;
+	return fallback;
+}
+
+/** Read config from environment (used by extension and tests). */
+export function loadAppleFmConfig(env: NodeJS.ProcessEnv = process.env): AppleFmConfig {
+	const host = env.APPLE_FM_PI_HOST ?? env.FM_HOST ?? "127.0.0.1";
+	const fmPort = parsePort(env.APPLE_FM_PI_FM_PORT ?? env.FM_PORT, 1976);
+	const proxyPort = parsePort(env.APPLE_FM_PI_PROXY_PORT ?? env.PROXY_PORT, 1977);
+	const useProxy = parseBool(env.APPLE_FM_PI_USE_PROXY, false);
+	const dir = agentDir();
+	const contextWindow = parsePositiveInt(
+		env.APPLE_FM_PI_CONTEXT_WINDOW,
+		DEFAULT_CONTEXT,
+		MAX_ALLOWED_CONTEXT,
+	);
+	const maxTokensDefault = contextWindow <= 8192 ? Math.min(2048, contextWindow) : contextWindow;
+	const maxTokens = parsePositiveInt(env.APPLE_FM_PI_MAX_TOKENS, maxTokensDefault, MAX_ALLOWED_CONTEXT);
+
+	const clientPort = useProxy ? proxyPort : fmPort;
+
+	return {
+		host,
+		fmPort,
+		proxyPort,
+		baseUrl: `http://${host}:${clientPort}/v1`,
+		fmBin: env.APPLE_FM_PI_FM_BIN ?? "fm",
+		autoStart: parseBool(env.APPLE_FM_PI_AUTO_START, true),
+		useProxy,
+		contextWindow,
+		maxTokens,
+		agentDir: dir,
+		proxyScript: join(extensionRoot(), "vendor", "fm-proxy", "fm-proxy.cjs"),
+		pidFileProxy: join(dir, "apple-fm-pi-proxy.pid"),
+		pidFileFm: join(dir, "apple-fm-pi-fm-serve.pid"),
+		logFileProxy: join(dir, "logs", "apple-fm-pi-proxy.log"),
+		logFileFm: join(dir, "logs", "apple-fm-pi-fm-serve.log"),
+	};
+}
+
+export const CONTEXT_WINDOW_NOTE =
+	"Tool schemas are flattened in-extension (fm-proxy logic). Apple's on-device limit is still ~4k effective tokens for system — use `fm token-count`. Set APPLE_FM_PI_USE_PROXY=true to use the full HTTP proxy instead.";
+
+export const PCC_FOREGROUND_NOTE =
+	"PCC requires fm serve in a foreground Terminal (macOS attribution). Use /apple-fm-pi launch-terminal for full stack, or run bin/fm-launch.sh. Background fm serve: system works, pcc returns 503.";

--- a/extensions/apple-fm-pi/src/fm-server.ts
+++ b/extensions/apple-fm-pi/src/fm-server.ts
@@ -1,0 +1,312 @@
+import { spawn } from "node:child_process";
+import { mkdir, open, readFile, unlink, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import type { AppleFmConfig } from "./config.js";
+import { extensionRoot } from "./config.js";
+
+export type FmHealth = {
+	running: boolean;
+	url: string;
+	viaProxy: boolean;
+	health?: {
+		status?: string;
+		models?: Array<{ name: string; available?: boolean; reason?: string }>;
+	};
+	error?: string;
+};
+
+export type EnsureResult = {
+	ok: boolean;
+	started: boolean;
+	message: string;
+	health?: FmHealth;
+};
+
+function healthUrl(cfg: AppleFmConfig): string {
+	const port = cfg.useProxy ? cfg.proxyPort : cfg.fmPort;
+	return `http://${cfg.host}:${port}/health`;
+}
+
+export async function fetchHealth(cfg: AppleFmConfig, timeoutMs = 3000): Promise<FmHealth> {
+	const url = healthUrl(cfg);
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), timeoutMs);
+	try {
+		const res = await fetch(url, { signal: controller.signal });
+		if (!res.ok) {
+			return { running: false, url, viaProxy: cfg.useProxy, error: `HTTP ${res.status}` };
+		}
+		const health = (await res.json()) as FmHealth["health"];
+		return { running: true, url, viaProxy: cfg.useProxy, health };
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		return { running: false, url, viaProxy: cfg.useProxy, error: message };
+	} finally {
+		clearTimeout(timer);
+	}
+}
+
+async function readPid(pidFile: string): Promise<number | null> {
+	try {
+		const raw = (await readFile(pidFile, "utf8")).trim();
+		const pid = Number.parseInt(raw, 10);
+		return Number.isFinite(pid) && pid > 0 ? pid : null;
+	} catch {
+		return null;
+	}
+}
+
+function processAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function waitForHealthy(cfg: AppleFmConfig, attempts = 40): Promise<FmHealth> {
+	for (let i = 0; i < attempts; i++) {
+		const h = await fetchHealth(cfg, 2000);
+		if (h.running) return h;
+		await new Promise((r) => setTimeout(r, 250));
+	}
+	return fetchHealth(cfg);
+}
+
+async function spawnLogged(
+	command: string,
+	args: string[],
+	env: NodeJS.ProcessEnv,
+	logFile: string,
+	pidFile: string,
+): Promise<{ pid: number } | { error: string }> {
+	await mkdir(dirname(logFile), { recursive: true });
+	const logHandle = await open(logFile, "a").catch(() => null);
+	const child = spawn(command, args, {
+		detached: true,
+		stdio: logHandle ? ["ignore", logHandle.fd, logHandle.fd] : "ignore",
+		env: { ...process.env, ...env },
+	});
+	child.unref();
+	if (!child.pid) {
+		if (logHandle) await logHandle.close();
+		return { error: `Failed to spawn ${command}` };
+	}
+	await writeFile(pidFile, `${child.pid}\n`, "utf8");
+	return { pid: child.pid };
+}
+
+async function stopPidFile(pidFile: string): Promise<string | null> {
+	const pid = await readPid(pidFile);
+	if (pid && processAlive(pid)) {
+		try {
+			process.kill(pid, "SIGTERM");
+		} catch {
+			/* ignore */
+		}
+		try {
+			await unlink(pidFile);
+		} catch {
+			/* ignore */
+		}
+		return `stopped pid ${pid}`;
+	}
+	try {
+		await unlink(pidFile);
+	} catch {
+		/* ignore */
+	}
+	return null;
+}
+
+async function fmServeHealthy(cfg: AppleFmConfig): Promise<boolean> {
+	const url = `http://${cfg.host}:${cfg.fmPort}/health`;
+	try {
+		const res = await fetch(url, { signal: AbortSignal.timeout(2000) });
+		if (!res.ok) return false;
+		const body = await res.text();
+		return /running|available|status/i.test(body);
+	} catch {
+		return false;
+	}
+}
+
+export async function startFmServe(cfg: AppleFmConfig): Promise<EnsureResult> {
+	if (await fmServeHealthy(cfg)) {
+		const health = await fetchHealth(cfg);
+		return {
+			ok: health.running,
+			started: false,
+			message: `fm serve already on :${cfg.fmPort}`,
+			health,
+		};
+	}
+
+	const spawned = await spawnLogged(
+		cfg.fmBin,
+		["serve", "--host", cfg.host, "--port", String(cfg.fmPort)],
+		{},
+		cfg.logFileFm,
+		cfg.pidFileFm,
+	);
+	if ("error" in spawned) {
+		return { ok: false, started: false, message: spawned.error };
+	}
+
+	for (let i = 0; i < 40; i++) {
+		if (await fmServeHealthy(cfg)) break;
+		await new Promise((r) => setTimeout(r, 250));
+	}
+	if (!(await fmServeHealthy(cfg))) {
+		return {
+			ok: false,
+			started: true,
+			message: `fm serve pid ${spawned.pid} but not healthy on :${cfg.fmPort}`,
+		};
+	}
+
+	const health = await fetchHealth(cfg);
+	return {
+		ok: health.running,
+		started: true,
+		message: `Started fm serve on :${cfg.fmPort} (pid ${spawned.pid})`,
+		health,
+	};
+}
+
+export async function startProxy(cfg: AppleFmConfig): Promise<EnsureResult> {
+	const listenUrl = `http://${cfg.host}:${cfg.proxyPort}/health`;
+	try {
+		const res = await fetch(listenUrl, { signal: AbortSignal.timeout(1500) });
+		if (res.ok || res.status === 502) {
+			const health = await fetchHealth(cfg);
+			return {
+				ok: health.running,
+				started: false,
+				message: `fm-proxy already listening on :${cfg.proxyPort}`,
+				health,
+			};
+		}
+	} catch {
+		/* not up */
+	}
+
+	const spawned = await spawnLogged(
+		process.execPath,
+		[cfg.proxyScript],
+		{
+			FM_PORT: String(cfg.fmPort),
+			PROXY_PORT: String(cfg.proxyPort),
+		},
+		cfg.logFileProxy,
+		cfg.pidFileProxy,
+	);
+	if ("error" in spawned) {
+		return { ok: false, started: false, message: spawned.error };
+	}
+
+	const health = await waitForHealthy(cfg);
+	return {
+		ok: health.running,
+		started: true,
+		message: `Started fm-proxy on :${cfg.proxyPort} → fm :${cfg.fmPort} (pid ${spawned.pid})`,
+		health,
+	};
+}
+
+/** Start fm serve + optional fm-proxy (OpenAI tool schema fix). */
+export async function startStack(cfg: AppleFmConfig): Promise<EnsureResult> {
+	const fm = await startFmServe(cfg);
+	if (!fm.ok) return fm;
+
+	if (!cfg.useProxy) {
+		const health = await fetchHealth(cfg);
+		return {
+			ok: health.running,
+			started: fm.started,
+			message: `${fm.message}. Pi uses in-process tool fix at ${cfg.baseUrl}`,
+			health,
+		};
+	}
+
+	const proxy = await startProxy(cfg);
+	if (!proxy.ok) {
+		return {
+			ok: false,
+			started: true,
+			message: `${fm.message}; proxy failed: ${proxy.message}`,
+			health: proxy.health,
+		};
+	}
+
+	return {
+		ok: true,
+		started: fm.started || proxy.started,
+		message: `${fm.message}; ${proxy.message}. Pi base: ${cfg.baseUrl}`,
+		health: proxy.health,
+	};
+}
+
+export async function stopFmServe(cfg: AppleFmConfig): Promise<{ ok: boolean; message: string }> {
+	const parts: string[] = [];
+	if (cfg.useProxy) {
+		const p = await stopPidFile(cfg.pidFileProxy);
+		if (p) parts.push(`proxy ${p}`);
+	}
+	const f = await stopPidFile(cfg.pidFileFm);
+	if (f) parts.push(`fm ${f}`);
+
+	if (parts.length > 0) {
+		return { ok: true, message: `Stopped ${parts.join("; ")}` };
+	}
+
+	const health = await fetchHealth(cfg);
+	if (health.running) {
+		return {
+			ok: false,
+			message:
+				"Stack still running but not started by apple-fm-pi (no pid files). Stop manually or use the process that started it.",
+		};
+	}
+	return { ok: true, message: "apple-fm stack is not running" };
+}
+
+export async function ensureFmServe(cfg: AppleFmConfig): Promise<EnsureResult> {
+	if (!cfg.autoStart) {
+		const health = await fetchHealth(cfg);
+		if (health.running) {
+			return { ok: true, started: false, message: "stack is running", health };
+		}
+		return {
+			ok: false,
+			started: false,
+			message: `stack not running (${health.url}). Run /apple-fm-pi start`,
+			health,
+		};
+	}
+	return startStack(cfg);
+}
+
+/** Open macOS Terminal with foreground fm-launch (PCC attribution). */
+export async function launchStackInTerminal(cfg: AppleFmConfig): Promise<{ ok: boolean; message: string }> {
+	if (process.platform !== "darwin") {
+		return { ok: false, message: "launch-terminal is only supported on macOS" };
+	}
+	const extRoot = extensionRoot();
+	const launchSh = join(extRoot, "bin", "fm-launch.sh");
+	const { access } = await import("node:fs/promises");
+	try {
+		await access(launchSh);
+	} catch {
+		return { ok: false, message: `fm-launch.sh not found at ${launchSh}` };
+	}
+	const cmd = `cd '${extRoot}' && FM_PORT=${cfg.fmPort} PROXY_PORT=${cfg.proxyPort} FM_BIN='${cfg.fmBin}' ./bin/fm-launch.sh`;
+	const script = `tell application "Terminal" to do script "${cmd.replace(/"/g, '\\"')}"`;
+	const child = spawn("osascript", ["-e", script], { stdio: "ignore", detached: true });
+	child.unref();
+	return {
+		ok: true,
+		message: `Opened Terminal with fm-launch (proxy :${cfg.proxyPort}, fm :${cfg.fmPort}). Keep that window open for PCC.`,
+	};
+}

--- a/extensions/apple-fm-pi/src/fm-tools.ts
+++ b/extensions/apple-fm-pi/src/fm-tools.ts
@@ -1,0 +1,158 @@
+/**
+ * Tool schema flattening for Apple fm serve (from gregbarbosa/fm-proxy, MIT).
+ * fm serve rejects nested JSON Schema — Pi tools must be simplified in-flight.
+ */
+
+const DECORATIVE = [
+	"title",
+	"examples",
+	"default",
+	"$schema",
+	"$id",
+	"$comment",
+	"readOnly",
+	"writeOnly",
+];
+
+const STRIP_KEYS = new Set([
+	"anyOf",
+	"allOf",
+	"oneOf",
+	"if",
+	"then",
+	"else",
+	"not",
+	"$defs",
+	"definitions",
+	"$ref",
+	"patternProperties",
+	"description",
+	...DECORATIVE,
+]);
+
+const EMBED_STRIP_KEYS = new Set(["description", "additionalProperties", ...DECORATIVE]);
+
+type JsonSchema = Record<string, unknown>;
+
+function flattenComposite(prop: JsonSchema, key: "anyOf" | "oneOf" | "allOf", mergeAll: boolean): JsonSchema {
+	const subs = (prop[key] as JsonSchema[] | undefined) ?? [];
+	let merged: JsonSchema;
+	if (mergeAll) {
+		merged = {};
+		for (const sub of subs) {
+			if (sub && typeof sub === "object") Object.assign(merged, sub);
+		}
+		for (const [k, v] of Object.entries(prop)) {
+			if (k !== key) merged[k] = v;
+		}
+	} else {
+		const base =
+			subs.find((s) => s && typeof s === "object" && s.type) ||
+			subs[0] ||
+			({ type: "string" } as JsonSchema);
+		merged = { ...base };
+		for (const [k, v] of Object.entries(prop)) {
+			if (k !== key && !(k in merged)) merged[k] = v;
+		}
+	}
+	return simplifyProperty(merged) as JsonSchema;
+}
+
+export function simplifyProperty(prop: unknown): unknown {
+	if (!prop || typeof prop !== "object") return prop;
+	const p = prop as JsonSchema;
+
+	if (p.anyOf) return flattenComposite(p, "anyOf", false);
+	if (p.oneOf) return flattenComposite(p, "oneOf", false);
+	if (p.allOf) return flattenComposite(p, "allOf", true);
+
+	if (p.type === "object" || p.properties) {
+		return { type: "string" };
+	}
+
+	if (p.type === "array") {
+		const result: JsonSchema = { type: "array" };
+		if (p.items) result.items = simplifyProperty(p.items);
+		if (typeof p.description === "string") result.description = p.description;
+		return result;
+	}
+
+	const result: JsonSchema = {};
+	for (const [k, v] of Object.entries(p)) {
+		if (!STRIP_KEYS.has(k)) result[k] = v;
+	}
+	return result;
+}
+
+function needsJsonRoundTrip(prop: unknown): boolean {
+	if (!prop || typeof prop !== "object") return false;
+	const p = prop as JsonSchema;
+	if (p.type === "object" || p.properties) return true;
+	if (p.type === "array") return needsJsonRoundTrip(p.items);
+	return false;
+}
+
+export function fixToolSchema(schema: unknown): { schema: JsonSchema; jsonFields: string[] } {
+	const result: JsonSchema = { type: "object", required: [], properties: {} };
+	const jsonFields: string[] = [];
+
+	if (!schema || typeof schema !== "object") {
+		return { schema: { ...result, properties: {} }, jsonFields };
+	}
+
+	const s = schema as JsonSchema;
+	const properties = (s.properties as Record<string, unknown>) || {};
+
+	for (const [name, prop] of Object.entries(properties)) {
+		if (needsJsonRoundTrip(prop)) {
+			jsonFields.push(name);
+			const p = prop as JsonSchema;
+			const shape = JSON.stringify(prop, (k, v) => (EMBED_STRIP_KEYS.has(k) ? undefined : v));
+			const desc = typeof p.description === "string" ? `${p.description} ` : "";
+			(result.properties as Record<string, unknown>)[name] = {
+				type: "string",
+				description: `${desc}JSON string matching: ${shape}`,
+			};
+		} else {
+			(result.properties as Record<string, unknown>)[name] = simplifyProperty(prop);
+		}
+	}
+
+	if (Array.isArray(s.required)) {
+		result.required = (s.required as string[]).filter((n) => n in (result.properties as object));
+	}
+
+	return { schema: result, jsonFields };
+}
+
+export type CoercionMap = Record<string, string[]>;
+
+export function fixOpenAIChatPayload(payload: unknown): { payload: unknown; coercion: CoercionMap } {
+	if (!payload || typeof payload !== "object") {
+		return { payload, coercion: {} };
+	}
+	const body = { ...(payload as Record<string, unknown>) };
+	const coercion: CoercionMap = {};
+
+	if (!Array.isArray(body.tools)) {
+		return { payload: body, coercion };
+	}
+
+	body.tools = (body.tools as unknown[]).map((tool) => {
+		if (!tool || typeof tool !== "object") return tool;
+		const t = tool as Record<string, unknown>;
+		const fn = t.function as Record<string, unknown> | undefined;
+		if (!fn) return tool;
+		const { schema, jsonFields } = fixToolSchema(fn.parameters);
+		const name = typeof fn.name === "string" ? fn.name : undefined;
+		if (jsonFields.length && name) {
+			coercion[name] = jsonFields;
+		}
+		return {
+			...t,
+			function: { ...fn, parameters: schema },
+		};
+	});
+
+	return { payload: body, coercion };
+}

--- a/extensions/apple-fm-pi/src/index.ts
+++ b/extensions/apple-fm-pi/src/index.ts
@@ -1,0 +1,255 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import {
+	CONTEXT_WINDOW_NOTE,
+	loadAppleFmConfig,
+	PCC_FOREGROUND_NOTE,
+	PROVIDER_ID,
+} from "./config.js";
+import {
+	ensureFmServe,
+	fetchHealth,
+	launchStackInTerminal,
+	startStack,
+	stopFmServe,
+} from "./fm-server.js";
+import { buildProviderModels, STATIC_MODELS } from "./models.js";
+import { streamAppleFm } from "./stream-fm.js";
+
+const execFileAsync = promisify(execFile);
+
+function registerAppleFmProvider(pi: ExtensionAPI) {
+	const cfg = loadAppleFmConfig();
+	pi.registerProvider(PROVIDER_ID, {
+		name: "Apple Foundation Models",
+		baseUrl: cfg.baseUrl,
+		api: "openai-completions",
+		apiKey: "sk-apple-fm-pi",
+		models: buildProviderModels(cfg),
+		...(cfg.useProxy ? {} : { streamSimple: streamAppleFm }),
+	});
+}
+
+async function fmInstalled(bin: string): Promise<boolean> {
+	try {
+		await execFileAsync(bin, ["--help"], { timeout: 5000 });
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function statusLines(): string[] {
+	const cfg = loadAppleFmConfig();
+	const lines: string[] = [];
+	lines.push(`Provider: ${PROVIDER_ID}`);
+	lines.push(`Pi base URL: ${cfg.baseUrl}`);
+	lines.push(
+		`Mode: ${cfg.useProxy ? `external fm-proxy :${cfg.proxyPort} → fm :${cfg.fmPort}` : `in-process tool fix → fm :${cfg.fmPort}`}`,
+	);
+	lines.push(`fm binary: ${cfg.fmBin}`);
+	lines.push(`Auto-start: ${cfg.autoStart ? "yes" : "no"}`);
+	lines.push(`Context window (Pi): ${cfg.contextWindow}`);
+	lines.push("");
+	lines.push("Models:");
+	for (const m of STATIC_MODELS) {
+		lines.push(`  - ${m.id}: ${m.name}`);
+	}
+	lines.push("");
+	lines.push(CONTEXT_WINDOW_NOTE);
+	lines.push(PCC_FOREGROUND_NOTE);
+	lines.push("");
+	lines.push("Commands:");
+	lines.push("  /apple-fm-pi status");
+	lines.push("  /apple-fm-pi start          — background fm + fm-proxy (system; pcc often 503)");
+	lines.push("  /apple-fm-pi launch-terminal — macOS Terminal + foreground fm (best for pcc)");
+	lines.push("  /apple-fm-pi stop");
+	lines.push("  /apple-fm-pi models | context | test [system|pcc] | reload | help");
+	return lines;
+}
+
+export default function appleFmPiExtension(pi: ExtensionAPI) {
+	registerAppleFmProvider(pi);
+
+	pi.on("session_start", async (_event, ctx) => {
+		const cfg = loadAppleFmConfig();
+		if (!(await fmInstalled(cfg.fmBin))) {
+			ctx.ui.notify(
+				`apple-fm-pi: \`${cfg.fmBin}\` not found. Install Apple's Foundation Models CLI.`,
+				"warning",
+			);
+			return;
+		}
+
+		const result = await ensureFmServe(cfg);
+		if (!result.ok) {
+			ctx.ui.notify(`apple-fm-pi: ${result.message}`, "warning");
+			if (cfg.useProxy) {
+				ctx.ui.notify(
+					"Tip: /apple-fm-pi launch-terminal for PCC, or /apple-fm-pi start for background stack.",
+					"info",
+				);
+			}
+			return;
+		}
+
+			ctx.ui.notify(
+			`apple-fm-pi: ready at ${cfg.baseUrl} (${cfg.useProxy ? "HTTP fm-proxy" : "in-process tool schema fix"}). system ctx=${cfg.contextWindow}.`,
+			"info",
+		);
+		ctx.ui.notify(
+			"Use apple-fm/system for agent work. pcc only after /apple-fm-pi launch-terminal (foreground fm).",
+			"info",
+		);
+	});
+
+	pi.on("model_select", async (event, ctx) => {
+		if (event.model.provider !== PROVIDER_ID) return;
+		if (event.model.id === "pcc") {
+			const health = await fetchHealth(loadAppleFmConfig());
+			const pcc = health.health?.models?.find((x) => x.name === "pcc");
+			if (pcc?.available === false) {
+				ctx.ui.notify(
+					`apple-fm/pcc: ${pcc.reason ?? "unavailable"}. Run /apple-fm-pi launch-terminal, keep Terminal open, then retry.`,
+					"warning",
+				);
+			} else {
+				ctx.ui.notify(
+					"apple-fm/pcc: use /apple-fm-pi launch-terminal if you get 503 (background fm lacks PCC attribution).",
+					"info",
+				);
+			}
+		}
+		if (event.model.id === "system") {
+			ctx.ui.notify(
+				"apple-fm/system: small context (~4k). Start a fresh session if you see 'exceeded context size'.",
+				"info",
+			);
+		}
+	});
+
+	pi.registerCommand("apple-fm-pi", {
+		description: "Apple FM + fm-proxy stack",
+		handler: async (args, ctx) => {
+			const parts = args.trim().split(/\s+/).filter(Boolean);
+			const sub = parts[0] ?? "status";
+			const cfg = loadAppleFmConfig();
+
+			if (sub === "help") {
+				for (const line of statusLines()) ctx.ui.notify(line, "info");
+				return;
+			}
+
+			if (sub === "status") {
+				const health = await fetchHealth(cfg);
+				for (const line of statusLines()) ctx.ui.notify(line, "info");
+				ctx.ui.notify(
+					health.running
+						? `Server: up (${health.url}${health.viaProxy ? ", via fm-proxy" : ""})`
+						: `Server: down (${health.error ?? "unreachable"})`,
+					health.running ? "info" : "warning",
+				);
+				return;
+			}
+
+			if (sub === "start") {
+				const result = await startStack(cfg);
+				ctx.ui.notify(result.message, result.ok ? "info" : "error");
+				if (result.ok) {
+					ctx.ui.notify(PCC_FOREGROUND_NOTE, "info");
+				}
+				return;
+			}
+
+			if (sub === "launch-terminal" || sub === "lauch-terminal" || sub === "terminal") {
+				const result = await launchStackInTerminal(cfg);
+				ctx.ui.notify(result.message, result.ok ? "info" : "error");
+				return;
+			}
+
+			if (sub === "stop") {
+				const result = await stopFmServe(cfg);
+				ctx.ui.notify(result.message, result.ok ? "info" : "warning");
+				return;
+			}
+
+			if (sub === "models") {
+				const health = await fetchHealth(cfg);
+				for (const m of STATIC_MODELS) {
+					const live = health.health?.models?.find((x) => x.name === m.id);
+					const avail =
+						live?.available === true
+							? "available"
+							: live?.available === false
+								? `unavailable${live.reason ? `: ${live.reason}` : ""}`
+								: health.running
+									? "unknown"
+									: "server down";
+					ctx.ui.notify(`${m.id} — ${m.name} [${avail}]`, "info");
+				}
+				return;
+			}
+
+			if (sub === "context") {
+				ctx.ui.notify(`contextWindow=${cfg.contextWindow}, maxTokens=${cfg.maxTokens}`, "info");
+				ctx.ui.notify(CONTEXT_WINDOW_NOTE, "info");
+				return;
+			}
+
+			if (sub === "reload") {
+				try {
+					registerAppleFmProvider(pi);
+					ctx.ui.notify("apple-fm-pi: provider re-registered.", "info");
+				} catch (err) {
+					const message = err instanceof Error ? err.message : String(err);
+					ctx.ui.notify(`reload failed: ${message}. Use /reload`, "warning");
+				}
+				return;
+			}
+
+			if (sub === "test") {
+				const model = parts[1] ?? "system";
+				if (!STATIC_MODELS.some((m) => m.id === model)) {
+					ctx.ui.notify(`Unknown model '${model}'.`, "error");
+					return;
+				}
+				const stack = await ensureFmServe(cfg);
+				if (!stack.ok) {
+					ctx.ui.notify(stack.message, "error");
+					return;
+				}
+				try {
+					const res = await fetch(`${cfg.baseUrl}/chat/completions`, {
+						method: "POST",
+						headers: {
+							"Content-Type": "application/json",
+							Authorization: "Bearer sk-apple-fm-pi",
+						},
+						body: JSON.stringify({
+							model,
+							messages: [{ role: "user", content: "Reply with exactly: OK" }],
+							max_tokens: 16,
+						}),
+					});
+					const text = await res.text();
+					if (!res.ok) {
+						ctx.ui.notify(`Test HTTP ${res.status}: ${text.slice(0, 240)}`, "error");
+						return;
+					}
+					ctx.ui.notify(`Test OK (${model}): ${text.slice(0, 160)}`, "info");
+				} catch (err) {
+					const message = err instanceof Error ? err.message : String(err);
+					ctx.ui.notify(`Test error: ${message}`, "error");
+				}
+				return;
+			}
+
+			const hint =
+				sub === "lauch-terminal" || sub.includes("lauch")
+					? " Did you mean launch-terminal?"
+					: "";
+			ctx.ui.notify(`Unknown '${sub}'.${hint} Try /apple-fm-pi help`, "warning");
+		},
+	});
+}

--- a/extensions/apple-fm-pi/src/models.ts
+++ b/extensions/apple-fm-pi/src/models.ts
@@ -1,0 +1,55 @@
+import type { AppleFmConfig } from "./config.js";
+
+export type AppleFmModelDef = {
+	id: string;
+	name: string;
+	description: string;
+};
+
+export const STATIC_MODELS: AppleFmModelDef[] = [
+	{
+		id: "system",
+		name: "Apple Foundation Model (on-device)",
+		description: "On-device inference via Neural Engine. Best for privacy and zero token cost.",
+	},
+	{
+		id: "pcc",
+		name: "Apple Foundation Model (Private Cloud Compute)",
+		description: "Apple-hosted PCC when available in your account/context.",
+	},
+];
+
+function limitsForModel(id: string, cfg: AppleFmConfig): { contextWindow: number; maxTokens: number } {
+	if (id === "system") {
+		return {
+			contextWindow: cfg.contextWindow,
+			maxTokens: Math.min(cfg.maxTokens, cfg.contextWindow),
+		};
+	}
+	// PCC (when launch-terminal works) — larger budget than on-device; still below Pi's 128k fiction.
+	const pccCtx = Math.max(cfg.contextWindow, 32_768);
+	return { contextWindow: pccCtx, maxTokens: Math.min(cfg.maxTokens, 8192) };
+}
+
+export function buildProviderModels(cfg: AppleFmConfig) {
+	return STATIC_MODELS.map((m) => {
+		const limits = limitsForModel(m.id, cfg);
+		return {
+		id: m.id,
+		name: m.name,
+		reasoning: false,
+		input: ["text"] as ("text" | "image")[],
+		contextWindow: limits.contextWindow,
+		maxTokens: limits.maxTokens,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		compat: {
+			supportsDeveloperRole: false,
+			supportsReasoningEffort: false,
+			supportsStore: false,
+			supportsUsageInStreaming: false,
+			supportsStrictMode: false,
+			maxTokensField: "max_tokens" as const,
+		},
+	};
+	});
+}

--- a/extensions/apple-fm-pi/src/stream-fm.ts
+++ b/extensions/apple-fm-pi/src/stream-fm.ts
@@ -1,0 +1,29 @@
+import {
+	streamSimpleOpenAICompletions,
+	type Api,
+	type AssistantMessageEventStream,
+	type Context,
+	type Model,
+	type SimpleStreamOptions,
+} from "@earendil-works/pi-ai";
+import { fixOpenAIChatPayload } from "./fm-tools.js";
+
+/** Pi stream handler: flatten tools in-flight, then delegate to openai-completions. */
+export function streamAppleFm(
+	model: Model<Api>,
+	context: Context,
+	options?: SimpleStreamOptions,
+): AssistantMessageEventStream {
+	return streamSimpleOpenAICompletions(model as Model<"openai-completions">, context, {
+		...options,
+		onPayload: async (payload, m) => {
+			const { payload: fixed } = fixOpenAIChatPayload(payload);
+			let body = fixed as Record<string, unknown>;
+			if (m.id === "system" && typeof body.max_tokens === "number") {
+				body = { ...body, max_tokens: Math.min(body.max_tokens, 1024) };
+			}
+			const next = await options?.onPayload?.(body, m);
+			return next !== undefined ? fixOpenAIChatPayload(next).payload : body;
+		},
+	});
+}

--- a/extensions/apple-fm-pi/test/config.test.mjs
+++ b/extensions/apple-fm-pi/test/config.test.mjs
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const extRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+const { loadAppleFmConfig } = await import(
+	`file://${join(extRoot, "src/config.ts")}`
+);
+
+test("loadAppleFmConfig defaults", () => {
+	const cfg = loadAppleFmConfig({});
+	assert.equal(cfg.fmPort, 1976);
+	assert.equal(cfg.proxyPort, 1977);
+	assert.equal(cfg.host, "127.0.0.1");
+	assert.equal(cfg.baseUrl, "http://127.0.0.1:1976/v1");
+	assert.equal(cfg.useProxy, false);
+	assert.equal(cfg.fmBin, "fm");
+	assert.equal(cfg.autoStart, true);
+	assert.equal(cfg.contextWindow, 4096);
+	assert.equal(cfg.maxTokens, 2048);
+});
+
+test("loadAppleFmConfig 128k context", () => {
+	const cfg = loadAppleFmConfig({
+		APPLE_FM_PI_CONTEXT_WINDOW: "131072",
+		APPLE_FM_PI_MAX_TOKENS: "8192",
+	});
+	assert.equal(cfg.contextWindow, 131_072);
+	assert.equal(cfg.maxTokens, 8192);
+});
+
+test("loadAppleFmConfig caps context at 131072", () => {
+	const cfg = loadAppleFmConfig({ APPLE_FM_PI_CONTEXT_WINDOW: "999999" });
+	assert.equal(cfg.contextWindow, 131_072);
+});
+
+test("loadAppleFmConfig auto start off", () => {
+	const cfg = loadAppleFmConfig({ APPLE_FM_PI_AUTO_START: "false" });
+	assert.equal(cfg.autoStart, false);
+});

--- a/extensions/apple-fm-pi/test/fm-tools.test.mjs
+++ b/extensions/apple-fm-pi/test/fm-tools.test.mjs
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const extRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const { fixOpenAIChatPayload, fixToolSchema } = await import(
+	`file://${join(extRoot, "src/fm-tools.ts")}`
+);
+
+test("fixToolSchema flattens nested object to string", () => {
+	const { schema } = fixToolSchema({
+		type: "object",
+		properties: {
+			path: { type: "string" },
+			edits: {
+				type: "array",
+				items: { type: "object", properties: { oldText: { type: "string" } } },
+			},
+		},
+		required: ["path"],
+	});
+	assert.equal(schema.properties.edits.type, "string");
+	assert.deepEqual(schema.required, ["path"]);
+});
+
+test("fixOpenAIChatPayload rewrites tools array", () => {
+	const { payload } = fixOpenAIChatPayload({
+		model: "system",
+		messages: [],
+		tools: [
+			{
+				type: "function",
+				function: {
+					name: "edit",
+					parameters: {
+						type: "object",
+						properties: {
+							edits: { type: "array", items: { type: "object", properties: { x: { type: "string" } } } },
+						},
+						required: ["edits"],
+					},
+				},
+			},
+		],
+	});
+	const params = payload.tools[0].function.parameters;
+	assert.equal(params.properties.edits.type, "string");
+});

--- a/extensions/apple-fm-pi/test/models.test.mjs
+++ b/extensions/apple-fm-pi/test/models.test.mjs
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const extRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const { buildProviderModels, STATIC_MODELS } = await import(
+	`file://${join(extRoot, "src/models.ts")}`
+);
+const { loadAppleFmConfig } = await import(`file://${join(extRoot, "src/config.ts")}`);
+
+test("STATIC_MODELS includes system and pcc", () => {
+	assert.equal(STATIC_MODELS.length, 2);
+	assert.deepEqual(
+		STATIC_MODELS.map((m) => m.id),
+		["system", "pcc"],
+	);
+});
+
+test("buildProviderModels applies context window", () => {
+	const cfg = loadAppleFmConfig({ APPLE_FM_PI_CONTEXT_WINDOW: "131072" });
+	const models = buildProviderModels(cfg);
+	assert.equal(models[0].contextWindow, 131_072);
+	assert.equal(models[1].contextWindow, 131_072);
+	const small = buildProviderModels(loadAppleFmConfig({}));
+	assert.equal(small[0].contextWindow, 4096);
+	assert.equal(small[1].contextWindow, 32_768);
+	assert.equal(models[0].compat.maxTokensField, "max_tokens");
+});

--- a/extensions/apple-fm-pi/tsconfig.json
+++ b/extensions/apple-fm-pi/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/extensions/apple-fm-pi/vendor/fm-proxy/LICENSE
+++ b/extensions/apple-fm-pi/vendor/fm-proxy/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Greg
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/extensions/apple-fm-pi/vendor/fm-proxy/README.md
+++ b/extensions/apple-fm-pi/vendor/fm-proxy/README.md
@@ -1,0 +1,11 @@
+# fm-proxy (vendored)
+
+Upstream: [gregbarbosa/fm-proxy](https://github.com/gregbarbosa/fm-proxy) (MIT).
+
+Shipped as `fm-proxy.cjs` (extension package is ESM). Bundled in **apple-fm-pi** to:
+
+- Flatten Pi/OpenAI tool schemas so `fm serve` accepts them (fixes **400 Invalid tool definition**).
+- Repair `prompt_tokens` in usage for Pi's context gauge.
+- Add CORS and OpenAI-shaped errors.
+
+PCC still requires **foreground** `fm serve` — use `/apple-fm-pi launch-terminal` or `bin/fm-launch.sh`.

--- a/extensions/apple-fm-pi/vendor/fm-proxy/fm-proxy.cjs
+++ b/extensions/apple-fm-pi/vendor/fm-proxy/fm-proxy.cjs
@@ -37,6 +37,7 @@ const PROXY_PORT = Number(process.env.PROXY_PORT) || 1977;
 const MAX_RETRIES = Number(process.env.FM_MAX_RETRIES ?? 4);
 const RETRY_BASE_MS = Number(process.env.FM_RETRY_BASE_MS ?? 1000);
 const RETRY_CAP_MS = Number(process.env.FM_RETRY_CAP_MS ?? 15000);
+const MAX_BODY_BYTES = Number(process.env.FM_PROXY_MAX_BODY_BYTES ?? 10 * 1024 * 1024);
 
 // ── Token counting ───────────────────────────────────────────────────────────
 // Apple's `fm serve` reports usage incorrectly: prompt_tokens is always 0
@@ -431,9 +432,31 @@ const server = http.createServer((req, res) => {
   // reassembled by Node's StringDecoder instead of corrupting into U+FFFD.
   req.setEncoding("utf8");
   let body = "";
-  req.on("data", (chunk) => (body += chunk));
+  let bodyTooLarge = false;
+  req.on("data", (chunk) => {
+    if (bodyTooLarge) return;
+    body += chunk;
+    if (Buffer.byteLength(body, "utf8") > MAX_BODY_BYTES) {
+      bodyTooLarge = true;
+      if (!res.headersSent) {
+        setCors(res);
+        res.writeHead(413, { "content-type": "application/json" });
+        res.end(
+          JSON.stringify({
+            error: {
+              message: `request body exceeds ${MAX_BODY_BYTES} bytes`,
+              type: "invalid_request_error",
+              code: "payload_too_large",
+            },
+          }),
+        );
+      }
+      req.destroy();
+    }
+  });
   req.on("error", () => { /* client aborted upload; nothing to forward */ });
   req.on("end", () => {
+    if (bodyTooLarge) return;
     const { body: fixed, coercion, parsed: parsedReq } = fixTools(body);
 
     const isChat = req.url && req.url.includes("/chat/completions");
@@ -786,7 +809,7 @@ const server = http.createServer((req, res) => {
 
 // Only start listening when run directly; importing for tests must not bind.
 if (require.main === module) {
-  server.listen(PROXY_PORT, () => {
+  server.listen(PROXY_PORT, "127.0.0.1", () => {
     console.log(`fm-proxy listening on http://127.0.0.1:${PROXY_PORT}`);
     console.log(`  proxying to http://127.0.0.1:${FM_PORT}`);
     console.log(`  simplifies tool schemas to flat format for fm serve compatibility`);

--- a/extensions/apple-fm-pi/vendor/fm-proxy/fm-proxy.cjs
+++ b/extensions/apple-fm-pi/vendor/fm-proxy/fm-proxy.cjs
@@ -1,0 +1,794 @@
+#!/usr/bin/env node
+// fm-proxy.js - Fixes Apple fm serve compatibility with OpenAI-compatible clients
+//
+// fm serve has very limited JSON Schema support for tool parameters:
+//   - Only FLAT schemas supported (no nested type:"object" in properties)
+//   - "required" must be present on the root object
+//   - No anyOf, allOf, oneOf, if/then/else, not, patternProperties
+//   - enum, minimum, maximum, additionalProperties are OK
+//   - arrays of primitives are OK
+//
+// This proxy aggressively simplifies tool schemas to work within these limits.
+//
+// Usage: node fm-proxy.js
+// Proxies http://127.0.0.1:1977 -> http://127.0.0.1:1976
+
+const http = require("http");
+const { execFileSync } = require("child_process");
+const FM_PORT = Number(process.env.FM_PORT) || 1976;
+const PROXY_PORT = Number(process.env.PROXY_PORT) || 1977;
+
+// fm serve (PCC) has two DISTINCT mid-stream failure modes that this proxy must NOT
+// conflate — clients need to tell them apart because the remedy differs:
+//   1. Rate-limit / capacity: HTTP 200 then an error frame ("LanguageModelError -1"),
+//      rejecting at admission before any text. Transient; retry with backoff (below).
+//   2. Safety-guardrail abort: the model emits valid output, THEN fm serve interrupts
+//      ("The model's safety guardrails were triggered."). Deterministic + terminal +
+//      PCC-only — retrying the identical request re-fails at the identical point, so we
+//      do NOT retry; we surface it at once. Benign code triggers it, so it is NOT a
+//      judgment that the user's content is unsafe.
+// classifyError() maps each to an OpenAI-shaped outcome so clients can branch without
+// string-matching Apple's prose:
+//   - guardrail      → finish_reason:"content_filter" (keep partial; NOT an error — the
+//                      OpenAI-idiomatic representation of a safety-stopped generation)
+//   - rate-limit     → type:"rate_limit_exceeded" (retried, then surfaced)
+//   - unavailability → type:"service_unavailable" (terminal; e.g. missing PCC attribution)
+// Set FM_MAX_RETRIES=0 to disable rate-limit retries.
+const MAX_RETRIES = Number(process.env.FM_MAX_RETRIES ?? 4);
+const RETRY_BASE_MS = Number(process.env.FM_RETRY_BASE_MS ?? 1000);
+const RETRY_CAP_MS = Number(process.env.FM_RETRY_CAP_MS ?? 15000);
+
+// ── Token counting ───────────────────────────────────────────────────────────
+// Apple's `fm serve` reports usage incorrectly: prompt_tokens is always 0
+// (non-streaming) and streaming responses carry no usage at all. Pi reads these
+// to drive its context gauge, so it always shows ~0%. We repair usage here.
+//
+// Strategy (hybrid): exact count for the prompt (the big, stable number) via
+// Apple's own `fm token-count`; cheap heuristic for the streamed completion.
+//
+// Calibration (measured against `fm token-count`):
+//   per-turn chat-template overhead ≈ 9 tokens; content ≈ chars / 4.4.
+const PER_TURN_OVERHEAD = 9;
+const CHARS_PER_TOKEN = 4.4;
+
+function estimateTokens(text) {
+  if (!text) return 0;
+  return PER_TURN_OVERHEAD + Math.ceil(text.length / CHARS_PER_TOKEN);
+}
+
+// Flatten an OpenAI messages array into the text Apple's model actually sees.
+// System messages map to instructions (-i); user/assistant/tool become the prompt.
+function splitMessages(messages) {
+  const instr = [];
+  const prompt = [];
+  for (const m of messages || []) {
+    const content = typeof m.content === "string"
+      ? m.content
+      : Array.isArray(m.content)
+        ? m.content.map((p) => p.text || "").join("")
+        : "";
+    if (m.role === "system") instr.push(content);
+    else prompt.push(content);
+  }
+  return { instructions: instr.join("\n"), prompt: prompt.join("\n") };
+}
+
+// Exact token count via `fm token-count -q`. Text is piped on stdin to avoid
+// argv length limits; optional instructions go through -i so the count includes
+// their (heavier) template wrapping, matching how the server frames a turn.
+// Returns null if the binary is missing or errors (callers fall back to the
+// heuristic).
+// Memoize counts: each call forks `fm` (a synchronous spawn that blocks the event
+// loop), and the heavy inputs — system prompt and flattened tool schemas — repeat
+// verbatim on every turn. Counts are a pure function of (text, instructions), so a
+// keyed cache turns those repeats into free lookups. Bounded to keep memory flat.
+const _tokenCache = new Map();
+const _TOKEN_CACHE_MAX = 512;
+function fmTokenCount(text, instructions) {
+  // fm token-count requires at least one input; skip the call entirely when both
+  // are empty (e.g. tool-only turns) — the count is just the per-turn overhead.
+  if (!text && !instructions) return PER_TURN_OVERHEAD;
+  const key = (instructions || "") + "\0" + (text || "");
+  if (_tokenCache.has(key)) return _tokenCache.get(key);
+  let result = null;
+  try {
+    const args = ["token-count", "-q"];
+    if (instructions) args.push("-i", instructions);
+    const out = execFileSync("/usr/bin/fm", args, {
+      input: text || "",
+      encoding: "utf8",
+      timeout: 5000,
+    });
+    const n = parseInt(out.trim(), 10);
+    result = Number.isFinite(n) ? n : null;
+  } catch {
+    result = null;
+  }
+  // Cache only successful counts; a null is a transient failure worth retrying.
+  if (result != null) {
+    if (_tokenCache.size >= _TOKEN_CACHE_MAX) _tokenCache.clear();
+    _tokenCache.set(key, result);
+  }
+  return result;
+}
+
+// Exact prompt token count for the full messages array. The fallback mirrors the
+// exact path's single per-turn framing (one overhead, not one per concatenated
+// string) by estimating the joined text in a single call.
+function countPromptTokens(messages) {
+  const { instructions, prompt } = splitMessages(messages);
+  const n = fmTokenCount(prompt, instructions);
+  return n != null ? n : estimateTokens(instructions + "\n" + prompt);
+}
+
+// ── Assembled-request instrumentation ────────────────────────────────────────
+// The usage gauge (countPromptTokens) deliberately counts ONLY messages[].content
+// — that is what Pi displays. But fm serve frames a much larger prompt: the
+// flattened tool schemas, the assistant's prior tool_calls (which live in
+// m.tool_calls, not m.content), and a per-turn template wrapper on EVERY turn.
+// This breakdown measures the real assembled size so we can find PCC's true
+// context ceiling empirically: log it for every request, then read off the value
+// at the request where fm serve reports "transcript exceeded the model's context
+// size". `fixedBody` is the post-fixTools payload actually forwarded upstream, so
+// its `tools` are the flattened schemas the model really receives.
+function assembledTokenBreakdown(parsedReq, fixedBody) {
+  const messages = (parsedReq && parsedReq.messages) || [];
+  // 1. messages content — the current gauge number.
+  const msgTokens = countPromptTokens(messages);
+  // 2. flattened tool schemas as forwarded to fm serve.
+  let tools = (parsedReq && parsedReq.tools) || null;
+  try { const f = JSON.parse(fixedBody); if (f && f.tools) tools = f.tools; } catch {}
+  const toolsJson = tools && tools.length ? JSON.stringify(tools) : "";
+  const toolTokens = toolsJson
+    ? (fmTokenCount(toolsJson) ?? estimateTokens(toolsJson))
+    : 0;
+  // 3. assistant tool_calls — invisible to splitMessages (content is null).
+  let toolCallText = "";
+  for (const m of messages) {
+    if (Array.isArray(m.tool_calls)) {
+      for (const tc of m.tool_calls) {
+        const fn = tc && tc.function;
+        if (fn) toolCallText += (fn.name || "") + (fn.arguments || "");
+      }
+    }
+  }
+  const toolCallTokens = toolCallText
+    ? (fmTokenCount(toolCallText) ?? estimateTokens(toolCallText))
+    : 0;
+  // 4. per-turn template framing applied once per non-system turn (the gauge
+  //    collapses this to a single overhead for the whole concatenated prompt).
+  const nonSystemTurns = messages.filter((m) => m.role !== "system").length;
+  const perTurnExtra = PER_TURN_OVERHEAD * Math.max(0, nonSystemTurns - 1);
+  const assembledTotal = msgTokens + toolTokens + toolCallTokens + perTurnExtra;
+  return { msgTokens, toolTokens, toolCallTokens, perTurnExtra,
+           turns: nonSystemTurns, assembledTotal };
+}
+
+function logBreakdown(tag, model, b) {
+  console.error(
+    `[assembled] ${tag} model=${model} turns=${b.turns} ` +
+    `gauge(msgs)=${b.msgTokens} tools=${b.toolTokens} ` +
+    `toolCalls=${b.toolCallTokens} perTurn=${b.perTurnExtra} ` +
+    `=> assembled=${b.assembledTotal}`
+  );
+}
+
+// Exact completion token count for accumulated streamed text; heuristic on fail.
+function countCompletionTokens(text) {
+  const n = fmTokenCount(text);
+  return n != null ? n : estimateTokens(text);
+}
+
+// Decorative keys fm serve ignores but that still cost prompt tokens. Stripped
+// from every property (and every embedded shape) with no loss of capability.
+const DECORATIVE = [
+  "title", "examples", "default", "$schema", "$id", "$comment",
+  "readOnly", "writeOnly",
+];
+
+const STRIP_KEYS = new Set([
+  "anyOf", "allOf", "oneOf", "if", "then", "else", "not",
+  "$defs", "definitions", "$ref", "patternProperties",
+  "description", ...DECORATIVE,
+]);
+
+// Keys to drop when embedding a nested schema as a JSON string in a param
+// description. The shape only needs to convey structure + types, so prose-heavy /
+// decorative keys are pure bloat repeated for every nested field.
+const EMBED_STRIP_KEYS = new Set([
+  "description", "additionalProperties", ...DECORATIVE,
+]);
+
+// Collapse a composition keyword (anyOf/oneOf/allOf) into a single schema, then
+// re-simplify. `mergeAll` (allOf) unions every subschema with siblings winning;
+// otherwise we pick the first typed branch (or the first) and let siblings fill
+// gaps non-destructively.
+function flattenComposite(prop, key, mergeAll) {
+  const subs = prop[key] || [];
+  let merged;
+  if (mergeAll) {
+    merged = {};
+    for (const sub of subs) if (sub && typeof sub === "object") Object.assign(merged, sub);
+    for (const [k, v] of Object.entries(prop)) if (k !== key) merged[k] = v;
+  } else {
+    const base = subs.find((s) => s && typeof s === "object" && s.type) || subs[0] || { type: "string" };
+    merged = { ...base };
+    for (const [k, v] of Object.entries(prop)) if (k !== key && !(k in merged)) merged[k] = v;
+  }
+  return simplifyProperty(merged);
+}
+
+function simplifyProperty(prop) {
+  if (!prop || typeof prop !== "object") return prop;
+
+  // Collapse composition keywords to a single schema.
+  if (prop.anyOf) return flattenComposite(prop, "anyOf", false);
+  if (prop.oneOf) return flattenComposite(prop, "oneOf", false);
+  if (prop.allOf) return flattenComposite(prop, "allOf", true);
+
+  // Objects can't be nested in a flat schema - collapse to string. Match
+  // needsJsonRoundTrip: a bare `properties` block (no explicit type) is still an
+  // object and must not survive into the forwarded schema.
+  if (prop.type === "object" || prop.properties) {
+    return { type: "string" };
+  }
+
+  // If it's an array, simplify items
+  if (prop.type === "array") {
+    const result = { type: "array" };
+    if (prop.items) {
+      result.items = simplifyProperty(prop.items);
+    }
+    if (prop.description) result.description = prop.description;
+    return result;
+  }
+
+  // Keep primitive types, strip unsupported keys
+  const result = {};
+  for (const [k, v] of Object.entries(prop)) {
+    if (!STRIP_KEYS.has(k)) result[k] = v;
+  }
+  return result;
+}
+
+// A top-level param needs the JSON-string round-trip if fm serve can't represent
+// its shape: nested objects, or arrays whose items are objects. Such a param is
+// declared to fm as a `type:"string"` carrying JSON, and the model's JSON reply is
+// re-expanded back into the real object/array before forwarding to the client.
+function needsJsonRoundTrip(prop) {
+  if (!prop || typeof prop !== "object") return false;
+  if (prop.type === "object" || prop.properties) return true;
+  // Recurse through arrays so array<array<object>> (and deeper) is caught, not
+  // just a single array<object> level.
+  if (prop.type === "array") return needsJsonRoundTrip(prop.items);
+  return false;
+}
+
+// Returns { schema, jsonFields } — jsonFields lists top-level params that were
+// turned into JSON strings and must be JSON.parse'd back on the response.
+function fixToolSchema(schema) {
+  const result = { type: "object", required: [] };
+  const jsonFields = [];
+  if (!schema || typeof schema !== "object") {
+    result.properties = {};
+    return { schema: result, jsonFields };
+  }
+
+  result.properties = {};
+  for (const [name, prop] of Object.entries(schema.properties || {})) {
+    if (needsJsonRoundTrip(prop)) {
+      jsonFields.push(name);
+      const shape = JSON.stringify(prop, (k, v) =>
+        EMBED_STRIP_KEYS.has(k) ? undefined : v);
+      const desc = prop.description ? prop.description + " " : "";
+      result.properties[name] = {
+        type: "string",
+        description: `${desc}JSON string matching: ${shape}`,
+      };
+    } else {
+      result.properties[name] = simplifyProperty(prop);
+    }
+  }
+  // Preserve the caller's `required` list. Dropping it told fm serve every param
+  // was optional, so the model would emit partial/empty tool calls (e.g. edit with
+  // `{}`) that the client then rejects against the real schema. JSON-round-tripped
+  // params keep their name (only the value becomes a string), so names carry over.
+  if (Array.isArray(schema.required)) {
+    result.required = schema.required.filter((n) => n in result.properties);
+  }
+  return { schema: result, jsonFields };
+}
+
+// Rewrites request tools into fm-serve-compatible schemas. Returns the rewritten
+// body, a coercion map (toolName -> [jsonField names]) for re-expansion on the
+// response, and the parsed request object (or null) so callers needn't re-parse.
+function fixTools(body) {
+  try {
+    const parsed = JSON.parse(body);
+    const coercion = {};
+    if (parsed.tools) {
+      parsed.tools = parsed.tools.map((tool) => {
+        const { schema, jsonFields } = fixToolSchema(tool.function?.parameters);
+        if (jsonFields.length && tool.function?.name) {
+          coercion[tool.function.name] = jsonFields;
+        }
+        return { ...tool, function: { ...tool.function, parameters: schema } };
+      });
+    }
+    return { body: JSON.stringify(parsed), coercion, parsed };
+  } catch {
+    return { body, coercion: {}, parsed: null };
+  }
+}
+
+// Re-expand JSON-string params in a tool_call's arguments back into real objects.
+// `args` is the JSON string from the model; returns a (possibly) rewritten string.
+function expandToolCallArguments(toolName, argsStr, coercion) {
+  const fields = coercion[toolName];
+  if (!fields || !fields.length) return argsStr;
+  try {
+    const obj = JSON.parse(argsStr);
+    let changed = false;
+    for (const f of fields) {
+      if (typeof obj[f] === "string") {
+        try { obj[f] = JSON.parse(obj[f]); changed = true; } catch { /* leave */ }
+      }
+    }
+    return changed ? JSON.stringify(obj) : argsStr;
+  } catch {
+    return argsStr;
+  }
+}
+
+// Apply expandToolCallArguments to every tool_call in an OpenAI tool_calls array
+// (both streaming delta and non-streaming message shapes). Mutates in place;
+// returns true if any arguments string was rewritten.
+function rewriteToolCalls(toolCalls, coercion) {
+  let changed = false;
+  for (const tc of toolCalls) {
+    const fn = tc && tc.function;
+    if (!fn || typeof fn.arguments !== "string") continue;
+    const next = expandToolCallArguments(fn.name, fn.arguments, coercion);
+    if (next !== fn.arguments) { fn.arguments = next; changed = true; }
+  }
+  return changed;
+}
+
+// Classify an upstream fm-serve error message into a distinct OpenAI-shaped error type
+// so clients can branch on the *cause* rather than string-matching Apple's prose. The two
+// failure modes (see header comment) need different client remedies:
+//   - rate-limit: transient, retry.
+//   - safety-guardrail abort: deterministic + terminal, do NOT retry.
+// `retry` tells the streaming/non-stream paths whether backoff is worthwhile.
+function classifyError(msg) {
+  const m = String(msg || "").toLowerCase();
+  if (m.includes("guardrail"))
+    return { type: "generation_aborted", code: "safety_guardrail", retry: false, label: "SAFETY-GUARDRAIL ABORT" };
+  // PCC attribution / "not available in this context" (ModelManagerError 1013, HTTP 503
+  // service_unavailable): deterministic + stable for the process's lifetime — retrying
+  // just wastes ~15s. Distinct from a transient capacity 503.
+  if (m.includes("not available in this context") || m.includes("service_unavailable"))
+    return { type: "service_unavailable", code: "model_unavailable", retry: false, label: "MODEL UNAVAILABLE (PCC attribution)" };
+  if (m.includes("languagemodelerror") || m.includes("error -1") || m.includes("rate limit") || m.includes("rate_limit"))
+    return { type: "rate_limit_exceeded", code: -1, retry: true, label: "RATE-LIMIT" };
+  return { type: "server_error", code: "internal_error", retry: true, label: "UPSTREAM ERROR" };
+}
+
+// Build an SSE error frame (`data: {"error":{...}}\n\n`) carrying a typed OpenAI error.
+function errorFrame(cls, msg) {
+  return `data: ${JSON.stringify({
+    error: { message: msg || "upstream error", type: cls.type, code: cls.code },
+  })}\n\n`;
+}
+
+// Exported for tests when required as a module; harmless when run directly.
+if (require.main !== module) {
+  module.exports = { fixTools, fixToolSchema, expandToolCallArguments, classifyError, errorFrame };
+}
+
+// CORS so browser-based OpenAI clients (open-webui, web apps hitting the base URL
+// directly) clear their preflight. Origin is `*` by default; override with
+// CORS_ORIGIN. Applied to every response via relayHead and the raw writeHead paths
+// so no response can slip out without it.
+const CORS_ORIGIN = process.env.CORS_ORIGIN || "*";
+const CORS_HEADERS = {
+  "access-control-allow-origin": CORS_ORIGIN,
+  "access-control-allow-methods": "GET, POST, OPTIONS",
+  // `*` covers Content-Type and the OpenAI SDK's x-stainless-* headers, but per
+  // the Fetch spec the wildcard does NOT cover Authorization — it must be named
+  // explicitly or browser preflight for the API key would fail.
+  "access-control-allow-headers": "Authorization, *",
+  "access-control-max-age": "86400", // cache preflight a day; fewer round-trips
+};
+function setCors(res) {
+  for (const [k, v] of Object.entries(CORS_HEADERS)) res.setHeader(k, v);
+}
+
+// Copy upstream headers and either set Content-Length (non-stream, known body) or
+// drop it (stream, chunked). One place so the two response paths can't desync.
+// CORS headers are merged in here so every committed response carries them.
+function relayHead(res, statusCode, upstreamHeaders, bodyLen) {
+  const headers = { ...upstreamHeaders, ...CORS_HEADERS };
+  // The proxy manages its own framing: it either sets Content-Length (buffered
+  // body) or streams chunked. Never relay upstream's Transfer-Encoding, or the
+  // response carries both CL and TE — illegal framing the client can't parse.
+  delete headers["transfer-encoding"];
+  if (bodyLen == null) delete headers["content-length"];
+  else headers["content-length"] = bodyLen;
+  res.writeHead(statusCode, headers);
+}
+
+const server = http.createServer((req, res) => {
+  // CORS preflight: answer immediately, before buffering any body.
+  if (req.method === "OPTIONS") {
+    setCors(res);
+    res.writeHead(204);
+    res.end();
+    return;
+  }
+
+  // Decode as UTF-8 so multibyte characters split across TCP chunk boundaries are
+  // reassembled by Node's StringDecoder instead of corrupting into U+FFFD.
+  req.setEncoding("utf8");
+  let body = "";
+  req.on("data", (chunk) => (body += chunk));
+  req.on("error", () => { /* client aborted upload; nothing to forward */ });
+  req.on("end", () => {
+    const { body: fixed, coercion, parsed: parsedReq } = fixTools(body);
+
+    const isChat = req.url && req.url.includes("/chat/completions");
+    const isStream = !!(parsedReq && parsedReq.stream);
+    // Compute the full assembled size fm serve actually frames (messages + tool
+    // schemas + assistant tool_calls + per-turn framing). This both drives the
+    // instrumentation log AND becomes the reported prompt_tokens, so Pi's context
+    // gauge reflects the real budget instead of the messages-only slice (which
+    // reads ~4x low and lets the transcript blow past PCC's ~32k ceiling
+    // unwarned). Set GAUGE_MODE=msgs to fall back to the old messages-only number.
+    let breakdown = null;
+    if (isChat && parsedReq) {
+      breakdown = assembledTokenBreakdown(parsedReq, fixed);
+      logBreakdown("req", parsedReq.model || "unknown", breakdown);
+    }
+    const promptTokens = !isChat || !parsedReq
+      ? 0
+      : process.env.GAUGE_MODE === "msgs"
+        ? breakdown.msgTokens
+        : breakdown.assembledTotal;
+
+    // One-line diagnostic binding a failure to this request's real assembled size
+    // (the empirical PCC ceiling) — shared by the HTTP-status, context-overflow,
+    // and stream-aborted cases so they stay in sync.
+    const diag = (label, extra = "") => console.error(
+      `[assembled] *** ${label} *** assembled=` +
+      `${breakdown ? breakdown.assembledTotal : "?"} (gauge ${promptTokens})` +
+      (extra ? ` ${extra}` : "")
+    );
+
+    // An SSE/JSON frame is an upstream *error* (not content) when it carries a
+    // top-level `error` and no usable choices — that's the rate-limit signature.
+    const isErrorPayload = (obj) =>
+      obj && obj.error && !(obj.choices && obj.choices.length);
+
+    // State shared across retry attempts. The client response (`res`) is the one
+    // thing that persists; we don't commit its head until a good frame arrives so
+    // a failed attempt can be replayed invisibly.
+    let clientGone = false;
+    let retryTimer = null;
+    let activeProxyReq = null;
+
+    // If the client disconnects, cancel any pending retry and tear down upstream.
+    res.on("close", () => {
+      clientGone = true;
+      if (retryTimer) { clearTimeout(retryTimer); retryTimer = null; }
+      if (activeProxyReq) activeProxyReq.destroy();
+    });
+    res.on("error", () => { if (activeProxyReq) activeProxyReq.destroy(); });
+
+    function scheduleRetry(attempt, reason) {
+      if (attempt + 1 > MAX_RETRIES || clientGone) return false;
+      const delay = Math.min(RETRY_CAP_MS, RETRY_BASE_MS * 2 ** attempt);
+      diag(`RETRY ${attempt + 1}/${MAX_RETRIES}`, `after ${reason}; waiting ${delay}ms`);
+      retryTimer = setTimeout(() => {
+        retryTimer = null;
+        if (!clientGone) forward(attempt + 1);
+      }, delay);
+      return true;
+    }
+
+    // We always forward a fully-buffered body and set our own Content-Length, so
+    // any inbound Transfer-Encoding (e.g. a client that streamed its upload with
+    // chunked encoding) must be dropped — keeping both is illegal framing and
+    // upstream rejects it with HPE_INVALID_CONTENT_LENGTH.
+    const upstreamHeaders = { ...req.headers, "content-length": Buffer.byteLength(fixed) };
+    delete upstreamHeaders["transfer-encoding"];
+
+    function forward(attempt) {
+      let aborting = false; // set when we tear the upstream down to retry
+      const proxyReq = http.request(
+        {
+          hostname: "127.0.0.1",
+          port: FM_PORT,
+          path: req.url,
+          method: req.method,
+          headers: upstreamHeaders,
+        },
+        (proxyRes) => {
+          proxyRes.setEncoding("utf8"); // same multibyte-safety as the request side
+          if (isChat) diag(`UPSTREAM RESPONSE HTTP ${proxyRes.statusCode}`);
+          proxyRes.on("error", (e) => { if (isChat) diag("UPSTREAM RES SOCKET ERROR", `— ${e.message}`); });
+
+          // Only intervene on chat completions; everything else passes through.
+          if (!isChat) {
+            res.writeHead(proxyRes.statusCode, { ...proxyRes.headers, ...CORS_HEADERS });
+            proxyRes.pipe(res);
+            return;
+          }
+
+          // The client head is "committed" once we've written it (stream) or are
+          // about to (non-stream). Before commit, a failure is retryable.
+          let committed = false;
+          const commit = () => {
+            if (committed) return;
+            committed = true;
+            if (isStream) {
+              relayHead(res, proxyRes.statusCode, proxyRes.headers, null);
+              if (proxyRes.statusCode !== 200) diag(`UPSTREAM HTTP ${proxyRes.statusCode}`);
+            }
+          };
+          // Abandon this attempt and retry if we haven't committed yet. Returns
+          // true if a retry was scheduled (caller must stop touching the stream).
+          const fail = (reason) => {
+            if (committed || aborting) return false;
+            if (!scheduleRetry(attempt, reason)) return false;
+            aborting = true;
+            proxyRes.destroy();
+            proxyReq.destroy();
+            return true;
+          };
+
+          if (isStream) {
+            // Streaming: fm sends NO usage. Accumulate completion text from the
+            // deltas, then inject a final usage chunk before [DONE].
+            let completionText = "";
+            let sawFinish = false;  // a clean finish_reason or [DONE] arrived
+            let producedOutput = false; // any content or tool_calls delta seen
+            let pending = "";       // line buffer across chunk boundaries
+            let lastChunkMeta = null;
+            let rawTail = "";       // last bytes of the upstream stream, for failure forensics
+            let surfacedError = false; // we already forwarded a typed error frame
+            let abortFinishReason = null; // set to "content_filter" on a guardrail abort
+            // PCC always opens a stream with an empty {"delta":{"role":"assistant"}}
+            // preamble, THEN either real output or an error frame. We must NOT commit
+            // the client head on that preamble, or an error arriving right after it
+            // would look post-commit and be unretryable. So buffer pre-output frames
+            // and only commit on the first meaningful frame (content/tool_calls/finish).
+            const preBuffer = [];
+            const flushPre = () => { for (const l of preBuffer) res.write(l); preBuffer.length = 0; };
+            const commitFlush = () => { commit(); flushPre(); };
+
+            function pump(s, flush) {
+              pending += s;
+              let idx;
+              while ((idx = pending.indexOf("\n")) !== -1 || (flush && pending.length)) {
+                if (aborting) return;
+                const line = idx !== -1 ? pending.slice(0, idx + 1) : pending;
+                pending = idx !== -1 ? pending.slice(idx + 1) : "";
+                const t = line.trim();
+                // Context overflow is deterministic — never retry it, just surface.
+                if (t.toLowerCase().includes("exceeded the model's context size")) {
+                  diag("CONTEXT EXCEEDED", `— line: ${t}`);
+                }
+                let obj = null, isErr = false, errCls = null, meaningful = false;
+                if (t.startsWith("data:")) {
+                  const payload = t.slice(5).trim();
+                  if (payload === "[DONE]") { sawFinish = true; if (!committed) commitFlush(); continue; }
+                  try {
+                    obj = JSON.parse(payload);
+                    isErr = isErrorPayload(obj);
+                    if (isErr) {
+                      errCls = classifyError(obj.error && obj.error.message);
+                    } else {
+                      lastChunkMeta = { id: obj.id, model: obj.model, created: obj.created };
+                      const ch0 = obj.choices && obj.choices[0];
+                      if (ch0 && ch0.finish_reason) { sawFinish = true; meaningful = true; }
+                      const delta = ch0 && ch0.delta;
+                      if (delta && typeof delta.content === "string") { completionText += delta.content; producedOutput = true; meaningful = true; }
+                      // Re-expand JSON-string tool-call args back to real objects.
+                      if (delta && Array.isArray(delta.tool_calls)) {
+                        producedOutput = true; meaningful = true;
+                        if (rewriteToolCalls(delta.tool_calls, coercion)) {
+                          if (!committed) commitFlush();
+                          res.write(`data: ${JSON.stringify(obj)}\n\n`);
+                          continue;
+                        }
+                      }
+                    }
+                  } catch { /* keepalive / non-JSON */ }
+                } else if (/languagemodelerror|error -1/i.test(t)) {
+                  isErr = true; // raw (non-data) error line
+                  errCls = classifyError(t);
+                } else if (t.startsWith("{")) {
+                  // fm serve returns non-SSE errors (e.g. HTTP 503 service_unavailable
+                  // for a missing-PCC-attribution `pcc` request) as BARE JSON, not a
+                  // `data:` frame. Parse it so we classify + surface the typed error
+                  // instead of treating the stream as empty and retrying blindly.
+                  try {
+                    obj = JSON.parse(t);
+                    if (isErrorPayload(obj)) {
+                      isErr = true;
+                      errCls = classifyError(obj.error && obj.error.message);
+                    }
+                  } catch { /* not an error JSON */ }
+                }
+                // Safety-guardrail abort → OpenAI content_filter: keep any partial that
+                // was already streamed, end the stream with finish_reason:"content_filter",
+                // and emit NO error frame (so SDK clients get the partial + a documented
+                // finish_reason instead of an exception). Only the guardrail maps to
+                // content_filter; rate-limit and service_unavailable stay typed errors
+                // (they're HTTP 429/503 analogues, not content filtering).
+                if (isErr && errCls && errCls.type === "generation_aborted") {
+                  diag(`${errCls.label}`, `— line: ${t}`);
+                  abortFinishReason = "content_filter";
+                  sawFinish = true;      // terminate the stream cleanly (no retry)
+                  continue;              // drop the error frame; end handler emits the finish
+                }
+                // Pre-commit upstream error: retry only if transient (rate-limit). A
+                // safety-guardrail abort is terminal — retrying re-fails identically —
+                // so surface it immediately instead of burning the retry budget.
+                if (isErr && !committed) {
+                  diag(`${errCls.label} (pre-commit)`, `— line: ${t}`);
+                  if (errCls.retry && fail("upstream error frame")) return;
+                  surfacedError = true; // retries exhausted OR terminal: forward typed
+                  meaningful = true;
+                }
+                if (!committed && !meaningful) {
+                  // Preamble / keepalive before any real output — hold it so a
+                  // following error frame is still pre-commit and retryable.
+                  preBuffer.push(line);
+                  continue;
+                }
+                if (!committed) commitFlush();
+                // Forward content as-is; rewrite error frames to a typed OpenAI error so
+                // clients can branch on `type` (rate_limit_exceeded / generation_aborted)
+                // without string-matching Apple's message.
+                if (isErr) {
+                  const errMsg = (obj && obj.error && obj.error.message) || t;
+                  res.write(errorFrame(errCls, errMsg));
+                  if (!surfacedError) surfacedError = true;
+                } else {
+                  res.write(line);
+                }
+              }
+            }
+
+            proxyRes.on("data", (chunk) => {
+              if (aborting) return;
+              rawTail = (rawTail + chunk).slice(-2000); // keep a bounded tail for diagnostics
+              pump(chunk, false);
+            });
+
+            proxyRes.on("end", () => {
+              if (aborting) return;
+              pump("", true); // flush any buffered partial line
+              if (aborting) return; // pump may have triggered a retry
+              if (!committed) {
+                // Nothing forwardable arrived — empty/aborted stream. Retry it;
+                // if exhausted, tell the client plainly instead of an empty 200.
+                if (!sawFinish && completionText === "" && fail("empty stream (no finish)")) return;
+                commit();
+                if (!sawFinish && completionText === "" && !surfacedError) {
+                  diag("GIVING UP (empty stream after retries)", `rawTail=${JSON.stringify(rawTail)}`);
+                  res.write(errorFrame(classifyError("rate limit"),
+                    "upstream returned no output (likely PCC rate limit) after retries"));
+                }
+              }
+              if (!sawFinish && completionText !== "") {
+                diag("UPSTREAM STREAM ABORTED (no finish)",
+                  `completionChars=${completionText.length} rawTail=${JSON.stringify(rawTail)}`);
+              }
+              // Finished cleanly but produced neither text nor tool_calls — the
+              // error path (error frame then [DONE]) that exhausted retries. Tool-
+              // call turns set producedOutput, so they don't trip this.
+              if (sawFinish && !producedOutput) {
+                diag("EMPTY COMPLETION (finished, no output)",
+                  `rawTail=${JSON.stringify(rawTail)}`);
+              }
+              const completionTokens = countCompletionTokens(completionText);
+              const usage = {
+                prompt_tokens: promptTokens,
+                completion_tokens: completionTokens,
+                total_tokens: promptTokens + completionTokens,
+              };
+              const meta = lastChunkMeta || {};
+              const usageChunk = {
+                id: meta.id || "chatcmpl-proxy",
+                object: "chat.completion.chunk",
+                created: meta.created || Math.floor(Date.now() / 1000),
+                model: meta.model || (parsedReq && parsedReq.model) || "unknown",
+                choices: [{ index: 0, delta: {}, finish_reason: abortFinishReason }],
+                usage,
+              };
+              // We always suppress the upstream [DONE] and re-emit our own after a
+              // synthetic usage chunk, so clients (Pi) that read the last
+              // usage-bearing chunk get a real prompt_tokens.
+              res.write(`data: ${JSON.stringify(usageChunk)}\n\n`);
+              res.write("data: [DONE]\n\n");
+              res.end();
+            });
+            return;
+          }
+
+          // Non-streaming: buffer fully (so we can still retry), then fix usage.
+          let raw = "";
+          proxyRes.on("data", (c) => (raw += c));
+          proxyRes.on("end", () => {
+            if (aborting) return;
+            let obj = null;
+            try { obj = JSON.parse(raw); } catch { /* not JSON */ }
+            let outStatus = proxyRes.statusCode;
+            if (isErrorPayload(obj)) {
+              const cls = classifyError(obj.error && obj.error.message);
+              diag(`${cls.label} (non-stream)`, `— ${raw.slice(0, 200)}`);
+              if (cls.type === "generation_aborted") {
+                // content_filter: return a normal completion finished by the filter
+                // (OpenAI-aligned), not an error. fm serve's non-stream error carries
+                // no partial, so content is empty; status is 200 (it's a valid completion).
+                obj = {
+                  id: "chatcmpl-proxy", object: "chat.completion",
+                  model: (parsedReq && parsedReq.model) || "unknown",
+                  choices: [{ index: 0, message: { role: "assistant", content: "" }, finish_reason: "content_filter" }],
+                  usage: { prompt_tokens: promptTokens, completion_tokens: 0, total_tokens: promptTokens },
+                };
+                outStatus = 200;
+              } else {
+                if (cls.retry && fail("non-stream error")) return;
+                // terminal (service_unavailable) OR retries exhausted (rate-limit): type it.
+                if (obj.error && typeof obj.error === "object") {
+                  obj.error = { message: obj.error.message, type: cls.type, code: cls.code };
+                }
+              }
+            }
+            let out = raw;
+            if (obj) {
+              if (obj.usage) {
+                obj.usage.prompt_tokens = promptTokens;
+                obj.usage.total_tokens = promptTokens + (obj.usage.completion_tokens || 0);
+              }
+              // Re-expand JSON-string tool-call args back to real objects.
+              const msg = obj.choices && obj.choices[0] && obj.choices[0].message;
+              if (msg && Array.isArray(msg.tool_calls)) rewriteToolCalls(msg.tool_calls, coercion);
+              out = JSON.stringify(obj);
+            }
+            committed = true;
+            relayHead(res, outStatus, proxyRes.headers, Buffer.byteLength(out));
+            res.end(out);
+          });
+        }
+      );
+      activeProxyReq = proxyReq;
+      proxyReq.on("error", (e) => {
+        // Transport-level failure (fm serve down / reset). Not the rate-limit
+        // signature, and aborting=true means we tore it down on purpose to retry.
+        if (aborting || clientGone || res.destroyed) return;
+        if (isChat) diag("UPSTREAM REQ SOCKET ERROR", `— ${e.code || ""} ${e.message}`);
+        // OpenAI-shaped error object (matches the stream-exhaustion path) so clients
+        // parsing error.message get a string, not undefined.
+        if (!res.headersSent) res.writeHead(502, { "content-type": "application/json", ...CORS_HEADERS });
+        res.end(JSON.stringify({ error: { message: `fm serve unreachable: ${e.message}`, type: "server_error", code: "upstream_unreachable" } }));
+      });
+      proxyReq.write(fixed);
+      proxyReq.end();
+    }
+
+    forward(0);
+  });
+});
+
+// Only start listening when run directly; importing for tests must not bind.
+if (require.main === module) {
+  server.listen(PROXY_PORT, () => {
+    console.log(`fm-proxy listening on http://127.0.0.1:${PROXY_PORT}`);
+    console.log(`  proxying to http://127.0.0.1:${FM_PORT}`);
+    console.log(`  simplifies tool schemas to flat format for fm serve compatibility`);
+  });
+}

--- a/extensions/statusline-pi/README.md
+++ b/extensions/statusline-pi/README.md
@@ -7,13 +7,13 @@ Compact project statusline footer for Pi.
 Format:
 
 ```text
-current-dir │ branch [changed files] PR #x │ estimated session cost │ remaining context tokens (percentage) context zone │ average response speed │ provider/model
+current-dir │ branch [changed files] PR #x │ estimated session cost │ CPU % · MEM % │ remaining context tokens (percentage) context zone │ average response speed │ provider/model
 ```
 
 Example:
 
 ```text
-pi-extensions │ main [2] PR #12 │ $0.18 │ 840,037 (84.0%) Plan │ 42.5 tok/s │ openai-codex/gpt-5.5
+pi-extensions │ main [2] PR #12 │ $0.18 │ CPU 42% · MEM 68% │ 840,037 (84.0%) Plan │ 42.5 tok/s │ openai-codex/gpt-5.5
 ```
 
 ## Behavior
@@ -22,7 +22,8 @@ pi-extensions │ main [2] PR #12 │ $0.18 │ 840,037 (84.0%) Plan │ 42.5 to
 - Replaces Pi's default footer with a compact responsive statusline.
 - Uses one line when the terminal is wide enough, then wraps into multiple width-safe
   lines on narrow terminals so long branch names do not hide context, speed, or model details.
-- Refreshes git change count every 5 seconds.
+- Refreshes git change count and host CPU/memory usage every 5 seconds.
+- Shows **CPU** and **MEM** utilization for the local machine (`CPU 42% · MEM 68%`). CPU is derived from `os.cpus()` time deltas (omitted until the second sample). Memory is `(total - free) / total`. Colors follow the same thresholds as other indicators: default success, warning at ≥85%, error at ≥95%.
 - Shows average model response speed as output tokens per second (`tok/s`) across completed assistant responses.
 - Shows an **estimated accumulated session cost** in USD, summed from each assistant response's token usage (`input`, `output`, `cache-read`, `cache-write`) and the active model's per-million token rates from Pi's model catalog (aligned with [pi.dev/models](https://pi.dev/models)). This is an estimate only—actual billing may differ by provider, discounts, or OAuth subscriptions.
 - Updates the cost after each assistant response and when you switch models; omits the cost segment when the active model has no pricing, and displays `cost ?` when usage was reported without a computable price.

--- a/extensions/statusline-pi/src/index.ts
+++ b/extensions/statusline-pi/src/index.ts
@@ -9,6 +9,13 @@ import {
 	formatCostSection,
 	type SessionCostState,
 } from "./cost.js";
+import {
+	createCpuSampler,
+	formatSystemSection,
+	refreshSystemUsage,
+	type CpuSampler,
+	type SystemUsageSnapshot,
+} from "./system.js";
 
 interface GitInfo {
 	branch?: string;
@@ -56,6 +63,8 @@ export default function statuslinePiExtension(pi: ExtensionAPI) {
 	let liveOutputTokenEstimate = 0;
 	let lastSpeedRender = 0;
 	let sessionCost = createEmptySessionCostState();
+	let cpuSampler: CpuSampler = createCpuSampler();
+	let systemUsage: SystemUsageSnapshot = refreshSystemUsage(cpuSampler);
 
 	pi.on("session_start", async (_event, ctx) => {
 		if (!ctx.hasUI) return;
@@ -68,6 +77,8 @@ export default function statuslinePiExtension(pi: ExtensionAPI) {
 		renderRequested = undefined;
 		resetResponseSpeed();
 		sessionCost = createEmptySessionCostState();
+		cpuSampler = createCpuSampler();
+		systemUsage = refreshSystemUsage(cpuSampler);
 	});
 
 	pi.on("model_select", async (_event, ctx) => {
@@ -162,6 +173,8 @@ export default function statuslinePiExtension(pi: ExtensionAPI) {
 		if (!enabled || !ctx.hasUI) return;
 
 		sessionCost = aggregateSessionCostFromContext(ctx);
+		cpuSampler = createCpuSampler();
+		systemUsage = refreshSystemUsage(cpuSampler);
 		refreshGit(ctx.cwd, { forceGit: true, forcePr: true });
 
 		ctx.ui.setFooter((tui, theme, footerData) => {
@@ -203,6 +216,7 @@ export default function statuslinePiExtension(pi: ExtensionAPI) {
 							context: formatContextSection(theme, usage, zone),
 							speed: formatSpeedSection(theme, responseSpeed),
 							cost,
+							sys: formatSystemSection(theme, systemUsage),
 							model: theme.fg("mdLink", model),
 						},
 						separator,
@@ -220,6 +234,7 @@ export default function statuslinePiExtension(pi: ExtensionAPI) {
 		if (refreshTimer) clearInterval(refreshTimer);
 		refreshTimer = setInterval(() => {
 			refreshGit(ctx.cwd);
+			systemUsage = refreshSystemUsage(cpuSampler);
 			requestRender();
 		}, GIT_REFRESH_MS);
 	}
@@ -361,19 +376,20 @@ export interface StatuslineSegments {
 	context: string;
 	speed: string;
 	cost: string;
+	sys: string;
 	model: string;
 }
 
 export function formatResponsiveStatusline(segments: StatuslineSegments, separator: string, width: number): string[] {
 	const safeWidth = Math.max(1, width);
-	const wideLine = [segments.dir, segments.git, segments.cost, segments.context, segments.speed, segments.model]
+	const wideLine = [segments.dir, segments.git, segments.cost, segments.sys, segments.context, segments.speed, segments.model]
 		.filter(Boolean)
 		.join(separator);
 	if (visibleWidth(wideLine) <= safeWidth) return [wideLine];
 
 	return [
 		...formatStatuslineGroup([segments.dir, segments.compactGit, segments.cost], separator, safeWidth),
-		...formatStatuslineGroup([segments.context, segments.speed, segments.model], separator, safeWidth),
+		...formatStatuslineGroup([segments.context, segments.sys, segments.speed, segments.model], separator, safeWidth),
 	];
 }
 

--- a/extensions/statusline-pi/src/system.ts
+++ b/extensions/statusline-pi/src/system.ts
@@ -1,0 +1,96 @@
+import os from "node:os";
+
+export interface SystemUsageSnapshot {
+	cpuPercent?: number;
+	memPercent?: number;
+}
+
+export function getMemoryPercentUsed(): number {
+	const total = os.totalmem();
+	if (total <= 0) return 0;
+	const free = os.freemem();
+	const used = total - free;
+	const percent = (used / total) * 100;
+	return clampPercent(percent);
+}
+
+function clampPercent(value: number): number {
+	if (!Number.isFinite(value)) return 0;
+	return Math.min(100, Math.max(0, value));
+}
+
+function sumCpuTimes(cpus: os.CpuInfo[]): { idle: number; total: number } {
+	let idle = 0;
+	let total = 0;
+	for (const cpu of cpus) {
+		const t = cpu.times;
+		idle += t.idle;
+		total += t.user + t.nice + t.sys + t.idle + t.irq;
+	}
+	return { idle, total };
+}
+
+export interface CpuSampler {
+	sample(): number | undefined;
+}
+
+/** CPU utilization from deltas between consecutive `sample()` calls. First sample returns undefined. */
+export function createCpuSampler(): CpuSampler {
+	let previous: { idle: number; total: number } | undefined;
+
+	return {
+		sample(): number | undefined {
+			const cpus = os.cpus();
+			const current = sumCpuTimes(cpus);
+			if (previous === undefined) {
+				previous = current;
+				return undefined;
+			}
+
+			const idleDelta = current.idle - previous.idle;
+			const totalDelta = current.total - previous.total;
+			previous = current;
+
+			if (totalDelta <= 0) return undefined;
+			const busy = totalDelta - idleDelta;
+			const percent = (busy / totalDelta) * 100;
+			return clampPercent(percent);
+		},
+	};
+}
+
+type ThemeFg = (color: "success" | "warning" | "error" | "dim", text: string) => string;
+
+export function getUsageLevelColor(percent: number | undefined): "success" | "warning" | "error" | "dim" {
+	if (percent === undefined) return "dim";
+	if (percent >= 95) return "error";
+	if (percent >= 85) return "warning";
+	return "success";
+}
+
+function formatPercentPart(
+	theme: { fg: ThemeFg },
+	label: "CPU" | "MEM",
+	percent: number | undefined,
+): string | undefined {
+	if (percent === undefined) return undefined;
+	const rounded = Math.round(percent);
+	return theme.fg(getUsageLevelColor(percent), `${label} ${rounded}%`);
+}
+
+export function formatSystemSection(
+	theme: { fg: ThemeFg },
+	usage: SystemUsageSnapshot,
+): string {
+	const cpu = formatPercentPart(theme, "CPU", usage.cpuPercent);
+	const mem = formatPercentPart(theme, "MEM", usage.memPercent);
+	const parts = [cpu, mem].filter((p): p is string => p !== undefined);
+	return parts.join(" · ");
+}
+
+export function refreshSystemUsage(sampler: CpuSampler): SystemUsageSnapshot {
+	return {
+		cpuPercent: sampler.sample(),
+		memPercent: getMemoryPercentUsed(),
+	};
+}

--- a/extensions/statusline-pi/test/layout.test.mjs
+++ b/extensions/statusline-pi/test/layout.test.mjs
@@ -28,10 +28,11 @@ describe("responsive statusline layout", () => {
 			context: "840,037 (84.0%) Plan",
 			speed: "42.5 tok/s",
 			cost: "$0.12",
+			sys: "CPU 42% · MEM 68%",
 			model: "openai/gpt-5.5 [T]",
 		};
 
-		const wideLine = [segments.dir, segments.git, segments.cost, segments.context, segments.speed, segments.model].join(separator);
+		const wideLine = [segments.dir, segments.git, segments.cost, segments.sys, segments.context, segments.speed, segments.model].join(separator);
 		const lines = formatResponsiveStatusline(segments, separator, visibleWidth(wideLine));
 
 		assert.deepEqual(lines, [wideLine]);
@@ -50,6 +51,7 @@ describe("responsive statusline layout", () => {
 				context: "58,261 (45.5%) Code",
 				speed: "87.5 tok/s",
 				cost: "$0.04",
+				sys: "MEM 55%",
 				model: "advisor:3",
 			},
 			separator,
@@ -82,6 +84,7 @@ describe("responsive statusline layout", () => {
 				context: "58,261 (45.5%) Code",
 				speed: "87.5 tok/s",
 				cost: "",
+				sys: "",
 				model: "openai/gpt-5.5 [T]",
 			},
 			" │ ",

--- a/extensions/statusline-pi/test/system.test.mjs
+++ b/extensions/statusline-pi/test/system.test.mjs
@@ -1,0 +1,91 @@
+import { describe, it, mock } from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import {
+	createCpuSampler,
+	formatSystemSection,
+	getMemoryPercentUsed,
+	getUsageLevelColor,
+} from "../dist/system.js";
+
+const theme = {
+	fg: (color, text) => `${color}:${text}`,
+};
+
+describe("system usage formatting", () => {
+	it("colors usage by threshold like speed/cost patterns", () => {
+		assert.equal(getUsageLevelColor(50), "success");
+		assert.equal(getUsageLevelColor(84), "success");
+		assert.equal(getUsageLevelColor(85), "warning");
+		assert.equal(getUsageLevelColor(94), "warning");
+		assert.equal(getUsageLevelColor(95), "error");
+		assert.equal(getUsageLevelColor(undefined), "dim");
+	});
+
+	it("omits CPU on first sample and includes MEM", () => {
+		const out = formatSystemSection(theme, { cpuPercent: undefined, memPercent: 68 });
+		assert.equal(out, "success:MEM 68%");
+	});
+
+	it("joins CPU and MEM with middle dot", () => {
+		const out = formatSystemSection(theme, { cpuPercent: 42.4, memPercent: 68.1 });
+		assert.equal(out, "success:CPU 42% · success:MEM 68%");
+	});
+
+	it("returns empty string when both parts undefined", () => {
+		assert.equal(formatSystemSection(theme, {}), "");
+	});
+});
+
+describe("memory percent", () => {
+	it("clamps to 0-100 from os mem", () => {
+		const totalmem = mock.method(os, "totalmem", () => 1000);
+		const freemem = mock.method(os, "freemem", () => 320);
+		try {
+			assert.equal(getMemoryPercentUsed(), 68);
+		} finally {
+			totalmem.mock.restore();
+			freemem.mock.restore();
+		}
+	});
+
+	it("returns 0 when total mem is zero", () => {
+		const totalmem = mock.method(os, "totalmem", () => 0);
+		const freemem = mock.method(os, "freemem", () => 0);
+		try {
+			assert.equal(getMemoryPercentUsed(), 0);
+		} finally {
+			totalmem.mock.restore();
+			freemem.mock.restore();
+		}
+	});
+});
+
+describe("CPU sampler", () => {
+	it("computes percent from cpu time deltas", () => {
+		let call = 0;
+		const cpusMock = mock.method(os, "cpus", () => {
+			call += 1;
+			if (call === 1) {
+				return [
+					{ times: { user: 100, nice: 0, sys: 50, idle: 850, irq: 0 } },
+					{ times: { user: 100, nice: 0, sys: 50, idle: 850, irq: 0 } },
+				];
+			}
+			return [
+				{ times: { user: 150, nice: 0, sys: 60, idle: 890, irq: 0 } },
+				{ times: { user: 150, nice: 0, sys: 60, idle: 890, irq: 0 } },
+			];
+		});
+
+		try {
+			const sampler = createCpuSampler();
+			assert.equal(sampler.sample(), undefined);
+			const pct = sampler.sample();
+			// two identical CPUs: idle +80, total +200 => busy 120 => 60%
+			assert.ok(Math.abs(pct - 60) < 0.01, `expected ~60%, got ${pct}`);
+		} finally {
+			cpusMock.mock.restore();
+		}
+	});
+});


### PR DESCRIPTION
Closes #22

## Summary

Adds host CPU and memory utilization percentages to the `statusline-pi` footer, refreshed every 5 seconds alongside git data, with threshold-based theme colors and responsive layout integration.

## Approach

**Balanced (option 2):** New `system.ts` module for memory % (`os` APIs), CPU % via `os.cpus()` delta sampling, `formatSystemSection` for display, wired into `formatResponsiveStatusline` between cost and context segments.

## Decision Record

- **Root cause:** N/A (feature). Users lacked machine resource visibility in the status line.
- **Options considered:** Option 1 — Minimal inline-only; Option 2 — Balanced `system.ts` + tests; Option 3 — Comprehensive toggles/CLI
- **Options rejected:** Option 1 — weak CPU warm-up testing; Option 3 — scope beyond issue
- **Selected option:** Option 2 — Balanced
- **Residual risk:** CPU % omitted until second sample (~5s after mount); acceptable per existing refresh cadence.

Analyzed at: `feat/22-cpu-memory-statusline @ 6941754` (2026-06-19)

## Changes

| File | Change |
|------|--------|
| `extensions/statusline-pi/src/system.ts` | CPU sampler, memory %, themed formatting |
| `extensions/statusline-pi/src/index.ts` | 5s refresh, `sys` segment in wide/narrow layout |
| `extensions/statusline-pi/test/system.test.mjs` | Unit tests for format, memory, CPU math |
| `extensions/statusline-pi/test/layout.test.mjs` | Layout fixtures with sys segment |
| `extensions/statusline-pi/README.md` | Document CPU/MEM indicators |

## Test Results

- Unit tests: 16 passed
- Integration tests: skipped
- E2e tests: skipped
- Build: passed (`npm run build` in statusline-pi)
- QA cycles: 1 (PASS)

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| `statusline-pi` displays current CPU usage as a percentage | pass | `formatSystemSection` + CPU sampler; `system.test.mjs` |
| `statusline-pi` displays current memory usage as a percentage | pass | `getMemoryPercentUsed`; `system.test.mjs`; `index.ts` render |
| Displayed values help users understand machine status at a glance | pass | `CPU n% · MEM n%` with thresholds; README |
