### PR TITLE
fix: use 'tps' instead of 'tok/s' in statusline-pi

### DIFF
--- a/extensions/statusline-pi/README.md
+++ b/extensions/statusline-pi/README.md
@@ -1,6 +1,6 @@
 # statusline-pi
 
-![statusline-pi — cost, context, tok/s](../../assets/statusline-pi-150toks-haiku-4.5.png)
+![statusline-pi — cost, context, tps](../../assets/statusline-pi-150toks-haiku-4.5.png)
 
 ![statusline-pi — two-line wrap on narrow terminals](../../assets/statusline-pi-2-lines.png)
 
@@ -17,7 +17,7 @@ current-dir │ branch [changed files] PR #x │ estimated session cost │ CPU 
 Example:
 
 ```text
-pi-extensions │ main [2] PR #12 │ $0.18 │ CPU 42% · MEM 68% │ 840,037 (84.0%) Plan │ 42.5 tok/s │ openai-codex/gpt-5.5
+pi-extensions │ main [2] PR #12 │ $0.18 │ CPU 42% · MEM 68% │ 840,037 (84.0%) Plan │ 42.5 tps │ openai-codex/gpt-5.5
 ```
 
 ## Behavior
@@ -28,7 +28,7 @@ pi-extensions │ main [2] PR #12 │ $0.18 │ CPU 42% · MEM 68% │ 840,037 (
   lines on narrow terminals so long branch names do not hide context, speed, or model details.
 - Refreshes git change count and host CPU/memory usage every 5 seconds.
 - Shows **CPU** and **MEM** utilization for the local machine (`CPU 42% · MEM 68%`). CPU is derived from `os.cpus()` time deltas (omitted until the second sample). Memory is `(total - free) / total`. Colors follow the same thresholds as other indicators: default success, warning at ≥85%, error at ≥95%.
-- Shows average model response speed as output tokens per second (`tok/s`) across completed assistant responses.
+- Shows average model response speed as output tokens per second (`tps`) across completed assistant responses.
 - Shows an **estimated accumulated session cost** in USD, summed from each assistant response's token usage (`input`, `output`, `cache-read`, `cache-write`) and the active model's per-million token rates from Pi's model catalog (aligned with [pi.dev/models](https://pi.dev/models)). This is an estimate only—actual billing may differ by provider, discounts, or OAuth subscriptions.
 - Updates the cost after each assistant response and when you switch models; omits the cost segment when the active model has no pricing, and displays `cost ?` when usage was reported without a computable price.
 - Includes the active assistant response in the average while it is streaming, then keeps the completed average visible while idle.

--- a/extensions/statusline-pi/src/index.ts
+++ b/extensions/statusline-pi/src/index.ts
@@ -440,11 +440,11 @@ function formatContextSection(
 }
 
 function formatSpeedSection(theme: ExtensionContext["ui"]["theme"], speed: ResponseSpeedInfo | undefined): string {
-	if (!speed) return theme.fg("dim", "-- tok/s");
+	if (!speed) return theme.fg("dim", "-- tps");
 
 	const speedText = speed.tokensPerSecond === undefined ? "--" : formatTokensPerSecond(speed.tokensPerSecond);
 	const suffix = speed.inProgress ? "…" : "";
-	return theme.fg(getSpeedColor(speed), `${speedText} tok/s${suffix}`);
+	return theme.fg(getSpeedColor(speed), `${speedText} tps${suffix}`);
 }
 
 function getZoneColor(zone: string): "success" | "warning" | "error" | "dim" {

--- a/extensions/statusline-pi/test/layout.test.mjs
+++ b/extensions/statusline-pi/test/layout.test.mjs
@@ -26,7 +26,7 @@ describe("responsive statusline layout", () => {
 			git: "main [2] PR #12",
 			compactGit: "main [2] PR #12",
 			context: "840,037 (84.0%) Plan",
-			speed: "42.5 tok/s",
+			speed: "42.5 tps",
 			cost: "$0.12",
 			sys: "CPU 42% · MEM 68%",
 			model: "openai/gpt-5.5 [T]",
@@ -49,7 +49,7 @@ describe("responsive statusline layout", () => {
 				git: formatGitSection(theme, branch, 3, 79),
 				compactGit,
 				context: "58,261 (45.5%) Code",
-				speed: "87.5 tok/s",
+				speed: "87.5 tps",
 				cost: "$0.04",
 				sys: "MEM 55%",
 				model: "advisor:3",
@@ -61,7 +61,7 @@ describe("responsive statusline layout", () => {
 		assert.ok(lines.length >= 2);
 		assertWidthSafe(lines, width);
 		assert.ok(lines.some((line) => line.includes("58,261")), "context segment should remain visible");
-		assert.ok(lines.some((line) => line.includes("87.5 tok/s")), "speed segment should remain visible");
+		assert.ok(lines.some((line) => line.includes("87.5 tps")), "speed segment should remain visible");
 		assert.ok(lines.some((line) => line.includes("advisor:3")), "model segment should remain visible");
 		assert.ok(lines.some((line) => line.includes("[3]") && line.includes("PR #79")), "git metadata should remain visible");
 	});
@@ -82,7 +82,7 @@ describe("responsive statusline layout", () => {
 				git: "issue/very-long-branch [3] PR #79",
 				compactGit: "issue/ve… [3] PR #79",
 				context: "58,261 (45.5%) Code",
-				speed: "87.5 tok/s",
+				speed: "87.5 tps",
 				cost: "",
 				sys: "",
 				model: "openai/gpt-5.5 [T]",


### PR DESCRIPTION
## Summary

Rename the token speed unit label from `tok/s` to `tps` in the statusline-pi extension.

### Changes
- `src/index.ts` — update `formatSpeedSection` to render `tps`
- `test/layout.test.mjs` — update all test assertions to match
- `README.md` — update alt text, example line, and description
- `dist/index.js` — rebuilt

All 4 tests pass ✅