### PR TITLE
feat(grok-pi): subscription usage helper and /grok-pi usage

### DIFF
--- a/extensions/grok-pi/README.md
+++ b/extensions/grok-pi/README.md
@@ -199,7 +199,8 @@ extensions/grok-pi/
 ├── bin/
 │   ├── grok-api-key          # token + refresh for Pi apiKey command
 │   ├── grok-client-version   # x-grok-client-version header value
-│   └── grok-user-agent       # User-Agent header value
+│   ├── grok-user-agent       # User-Agent header value
+│   └── grok-usage            # JSON subscription usage helper
 ├── src/index.ts              # registers grok-cli provider + /grok-pi command
 ├── package.json
 └── README.md
@@ -212,7 +213,16 @@ extensions/grok-pi/
 | `/grok-pi` or `/grok-pi status` | Provider URL, auth presence, model list |
 | `/grok-pi models` | List models registered from cache/defaults |
 | `/grok-pi test` | Print a one-line smoke-test command |
+| `/grok-pi usage` | Print Grok subscription credit usage as JSON |
 | `/grok-pi help` | Short usage |
+
+The usage command delegates to the standalone helper:
+
+```bash
+extensions/grok-pi/bin/grok-usage --pretty
+```
+
+It starts Grok in a pseudo-terminal to refresh the CLI billing log, then prints one JSON object.
 
 ## Official xAI API vs this bridge
 

--- a/extensions/grok-pi/bin/grok-usage
+++ b/extensions/grok-pi/bin/grok-usage
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Fetch Grok CLI subscription usage and print JSON.
+
+The Grok CLI writes subscription credit data to ~/.grok/logs/unified.jsonl
+when its TUI starts. This helper starts Grok in a pseudo-terminal, waits for a
+fresh "billing: fetched credits config" log entry, then prints that entry as a
+stable JSON object for grok-pi.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pathlib
+import pty
+import select
+import signal
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from typing import Any
+
+BILLING_LOG_MESSAGE = "billing: fetched credits config"
+DEFAULT_TIMEOUT = 10.0
+POLL_INTERVAL = 0.25
+
+
+def grok_home() -> pathlib.Path:
+    configured = os.environ.get("GROK_HOME")
+    return pathlib.Path(configured).expanduser() if configured else pathlib.Path.home() / ".grok"
+
+
+def iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def parse_ts(value: Any) -> float:
+    if not isinstance(value, str) or not value:
+        return 0.0
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
+    except Exception:
+        return 0.0
+
+
+def money_value(value: Any) -> int | float | str:
+    if isinstance(value, dict):
+        raw = value.get("val", 0)
+    else:
+        raw = value
+    return raw if isinstance(raw, (int, float, str)) else 0
+
+
+def read_last_billing_entry(log_file: pathlib.Path) -> dict[str, Any] | None:
+    if not log_file.exists():
+        return None
+
+    try:
+        lines = log_file.read_text(errors="replace").splitlines()
+    except Exception:
+        return None
+
+    for line in reversed(lines):
+        if BILLING_LOG_MESSAGE not in line:
+            continue
+        try:
+            parsed = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, dict):
+            return parsed
+    return None
+
+
+def drain_fd(fd: int) -> None:
+    while True:
+        readable, _, _ = select.select([fd], [], [], 0)
+        if not readable:
+            return
+        try:
+            chunk = os.read(fd, 65536)
+        except OSError:
+            return
+        if not chunk:
+            return
+
+
+def terminate_process(proc: subprocess.Popen[bytes]) -> None:
+    if proc.poll() is not None:
+        return
+    try:
+        os.killpg(proc.pid, signal.SIGTERM)
+    except Exception:
+        try:
+            proc.terminate()
+        except Exception:
+            pass
+    try:
+        proc.wait(timeout=2)
+    except Exception:
+        try:
+            os.killpg(proc.pid, signal.SIGKILL)
+        except Exception:
+            try:
+                proc.kill()
+            except Exception:
+                pass
+
+
+def refresh_billing_log(grok_bin: str, log_file: pathlib.Path, previous_ts: float, timeout: float) -> str | None:
+    """Start `grok` in a PTY and wait until a newer billing log appears.
+
+    Returns None on fresh success, otherwise an explanatory refresh error.
+    """
+
+    master_fd: int | None = None
+    proc: subprocess.Popen[bytes] | None = None
+    started_at = time.time()
+
+    try:
+        master_fd, slave_fd = pty.openpty()
+        proc = subprocess.Popen(
+            [grok_bin],
+            stdin=slave_fd,
+            stdout=slave_fd,
+            stderr=slave_fd,
+            start_new_session=True,
+            env={**os.environ, "TERM": os.environ.get("TERM", "xterm-256color")},
+        )
+        os.close(slave_fd)
+
+        deadline = started_at + timeout
+        while time.time() < deadline:
+            drain_fd(master_fd)
+            latest = read_last_billing_entry(log_file)
+            latest_ts = parse_ts(latest.get("ts") if latest else None)
+            # Allow a little clock skew between Python and Grok log timestamps.
+            if latest_ts > previous_ts and latest_ts >= started_at - 2:
+                return None
+            if proc.poll() is not None:
+                latest = read_last_billing_entry(log_file)
+                latest_ts = parse_ts(latest.get("ts") if latest else None)
+                if latest_ts > previous_ts:
+                    return None
+                return f"grok exited with code {proc.returncode} before billing data was refreshed"
+            time.sleep(POLL_INTERVAL)
+        return f"timed out after {timeout:g}s waiting for Grok billing data"
+    except FileNotFoundError:
+        return f"grok executable not found: {grok_bin}"
+    except Exception as exc:
+        return str(exc)
+    finally:
+        if proc is not None:
+            terminate_process(proc)
+        if master_fd is not None:
+            try:
+                os.close(master_fd)
+            except OSError:
+                pass
+
+
+def usage_json(entry: dict[str, Any], *, log_file: pathlib.Path, refresh_error: str | None, previous_ts: float) -> dict[str, Any]:
+    ctx = entry.get("ctx") if isinstance(entry.get("ctx"), dict) else {}
+    config = ctx.get("config") if isinstance(ctx.get("config"), dict) else {}
+    period = config.get("currentPeriod") if isinstance(config.get("currentPeriod"), dict) else {}
+
+    fetched_at = entry.get("ts") if isinstance(entry.get("ts"), str) else None
+    fetched_ts = parse_ts(fetched_at)
+
+    return {
+        "ok": True,
+        "source": "cached" if refresh_error or fetched_ts <= previous_ts else "fresh",
+        "fetched_at": fetched_at,
+        "subscription_tier": ctx.get("subscriptionTier") or config.get("subscriptionTier") or "Unknown",
+        "credit_usage_percent": config.get("creditUsagePercent", 0),
+        "period": {
+            "type": str(period.get("type") or "").replace("USAGE_PERIOD_TYPE_", "").lower() or None,
+            "start": period.get("start") or config.get("billingPeriodStart"),
+            "end": period.get("end") or config.get("billingPeriodEnd"),
+        },
+        "on_demand": {
+            "enabled": ctx.get("onDemandEnabled"),
+            "used": money_value(config.get("onDemandUsed")),
+            "cap": money_value(config.get("onDemandCap")),
+        },
+        "prepaid_balance": money_value(config.get("prepaidBalance")),
+        "history_len": config.get("historyLen"),
+        "refresh_error": refresh_error,
+        "log_file": str(log_file),
+    }
+
+
+def error_json(message: str, *, log_file: pathlib.Path | None = None) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "ok": False,
+        "error": message,
+        "generated_at": iso_now(),
+        "grok_home": str(grok_home()),
+    }
+    if log_file is not None:
+        payload["log_file"] = str(log_file)
+    return payload
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Print Grok CLI subscription usage as JSON")
+    parser.add_argument("--no-refresh", action="store_true", help="do not start Grok; only parse the latest cached billing log")
+    parser.add_argument("--pretty", action="store_true", help="pretty-print JSON")
+    parser.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT, help="seconds to wait for a fresh Grok billing log")
+    args = parser.parse_args()
+
+    home = grok_home()
+    auth_file = home / "auth.json"
+    log_file = home / "logs" / "unified.jsonl"
+    grok_bin = os.environ.get("GROK_PI_BIN", "grok")
+
+    if not auth_file.exists():
+        print(json.dumps(error_json("auth file not found; run `grok login` first", log_file=log_file), indent=2 if args.pretty else None))
+        return 1
+
+    previous = read_last_billing_entry(log_file)
+    previous_ts = parse_ts(previous.get("ts") if previous else None)
+    refresh_error = None if args.no_refresh else refresh_billing_log(grok_bin, log_file, previous_ts, max(args.timeout, 0.1))
+
+    latest = read_last_billing_entry(log_file)
+    if latest is None:
+        message = "no Grok billing data found"
+        if refresh_error:
+            message = f"{message}: {refresh_error}"
+        print(json.dumps(error_json(message, log_file=log_file), indent=2 if args.pretty else None))
+        return 1
+
+    print(json.dumps(usage_json(latest, log_file=log_file, refresh_error=refresh_error, previous_ts=previous_ts), indent=2 if args.pretty else None))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/extensions/grok-pi/package.json
+++ b/extensions/grok-pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grok-pi",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Bridge Grok CLI session models (Composer 2.5, Grok Build) into Pi via cli-chat-proxy",
   "type": "module",
   "main": "./src/index.ts",
@@ -11,6 +11,7 @@
   ],
   "scripts": {
     "build": "tsc",
+    "test": "node --test test/*.test.mjs",
     "prepublishOnly": "npm run build"
   },
   "pi": {

--- a/extensions/grok-pi/src/index.ts
+++ b/extensions/grok-pi/src/index.ts
@@ -1,8 +1,10 @@
+import { execFile } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { promisify } from "node:util";
+import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 
 const PROVIDER_ID = "grok-cli";
 const PROXY_BASE = "https://cli-chat-proxy.grok.com/v1";
@@ -17,6 +19,8 @@ const binDir = join(packageRoot, "bin");
 const apiKeyHelper = join(binDir, "grok-api-key");
 const clientVersionHelper = join(binDir, "grok-client-version");
 const userAgentHelper = join(binDir, "grok-user-agent");
+const usageHelper = join(binDir, "grok-usage");
+const execFileAsync = promisify(execFile);
 
 type GrokModelInfo = {
 	model: string;
@@ -154,6 +158,24 @@ function statusLines(): string[] {
 	return lines;
 }
 
+async function fetchGrokUsage(ctx: ExtensionCommandContext): Promise<string | null> {
+	try {
+		const { stdout } = await execFileAsync(usageHelper, [], {
+			timeout: 15_000,
+			maxBuffer: 200_000,
+		});
+		return stdout.trim();
+	} catch (error) {
+		const maybeOutput = error as { stdout?: string | Buffer; stderr?: string | Buffer; message?: string };
+		const stdout = maybeOutput.stdout?.toString().trim();
+		if (stdout) return stdout;
+
+		const detail = maybeOutput.stderr?.toString().trim() || maybeOutput.message || String(error);
+		ctx.ui.notify(`grok-pi usage failed: ${detail}`, "warning");
+		return null;
+	}
+}
+
 export default function grokPiExtension(pi: ExtensionAPI) {
 	registerGrokProvider(pi);
 
@@ -203,8 +225,16 @@ export default function grokPiExtension(pi: ExtensionAPI) {
 				return;
 			}
 
+			if (sub === "usage") {
+				const result = await fetchGrokUsage(ctx);
+				if (result) {
+					ctx.ui.notify(result, "info");
+				}
+				return;
+			}
+
 			if (sub === "help") {
-				ctx.ui.notify("Usage: /grok-pi [status|models|test|help]", "info");
+				ctx.ui.notify("Usage: /grok-pi [status|models|test|usage|help]", "info");
 				ctx.ui.notify("Authenticate first with: grok login", "info");
 				return;
 			}

--- a/extensions/grok-pi/test/grok-usage.test.mjs
+++ b/extensions/grok-pi/test/grok-usage.test.mjs
@@ -1,0 +1,87 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const execFileAsync = promisify(execFile);
+const helper = new URL("../bin/grok-usage", import.meta.url).pathname;
+
+async function makeFakeHome() {
+  const home = await mkdtemp(join(tmpdir(), "grok-usage-test-"));
+  await mkdir(join(home, ".grok", "logs"), { recursive: true });
+  await writeFile(join(home, ".grok", "auth.json"), "{}\n", { mode: 0o600 });
+  return home;
+}
+
+test("grok-usage prints fresh usage JSON", async () => {
+  const home = await makeFakeHome();
+  const fakeGrok = join(home, "fake-grok");
+  const billingEntry = {
+    ts: "2030-01-02T03:04:05.000Z",
+    src: "shell",
+    lvl: "info",
+    msg: "billing: fetched credits config",
+    ctx: {
+      config: {
+        creditUsagePercent: 42.5,
+        currentPeriod: {
+          type: "USAGE_PERIOD_TYPE_MONTHLY",
+          start: "2030-01-01T00:00:00+00:00",
+          end: "2030-02-01T00:00:00+00:00",
+        },
+        onDemandCap: { val: 100 },
+        onDemandUsed: { val: 12 },
+        prepaidBalance: { val: 3 },
+        historyLen: 7,
+      },
+      onDemandEnabled: true,
+      subscriptionTier: "SuperGrok",
+    },
+  };
+
+  await writeFile(
+    fakeGrok,
+    `#!/bin/sh\nprintf '%s\\n' '${JSON.stringify(billingEntry)}' >> "$HOME/.grok/logs/unified.jsonl"\nsleep 30\n`,
+    { mode: 0o700 },
+  );
+
+  try {
+    const { stdout } = await execFileAsync(helper, ["--timeout", "3"], {
+      env: { ...process.env, HOME: home, GROK_PI_BIN: fakeGrok },
+      timeout: 10_000,
+    });
+    const payload = JSON.parse(stdout);
+
+    assert.equal(payload.ok, true);
+    assert.equal(payload.source, "fresh");
+    assert.equal(payload.subscription_tier, "SuperGrok");
+    assert.equal(payload.credit_usage_percent, 42.5);
+    assert.equal(payload.period.type, "monthly");
+    assert.equal(payload.on_demand.used, 12);
+    assert.equal(payload.on_demand.cap, 100);
+    assert.equal(payload.prepaid_balance, 3);
+    assert.equal(payload.refresh_error, null);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("grok-usage prints JSON errors", async () => {
+  const home = await mkdtemp(join(tmpdir(), "grok-usage-test-no-auth-"));
+  try {
+    await assert.rejects(
+      execFileAsync(helper, [], { env: { ...process.env, HOME: home }, timeout: 10_000 }),
+      (error) => {
+        const payload = JSON.parse(error.stdout);
+        assert.equal(payload.ok, false);
+        assert.match(payload.error, /auth file not found/);
+        return true;
+      },
+    );
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Adds Grok CLI subscription credit usage reporting to the `grok-pi` extension.

## Changes

- **`bin/grok-usage`** — Python helper that starts Grok in a PTY to refresh billing logs, then prints a stable JSON object (tier, credit %, period, on-demand/prepaid).
- **`/grok-pi usage`** — Pi command that runs the helper and surfaces JSON in the UI.
- **README** — Documents the new command and layout entry for `grok-usage`.
- **Tests** — `test/grok-usage.test.mjs` (fresh usage + auth error paths).
- **Version** — `grok-pi` bumped to **1.1.0**.

## Verification

```bash
cd extensions/grok-pi && npm run build && npm test
```

Both tests pass locally.

## Notes

Requires Grok CLI login (`~/.grok/auth.json`) for live usage; helper degrades with JSON errors when auth is missing.

Closes #26

## Decision Record

- **Root cause:** Users had no in-Pi view of Grok subscription credit usage; data only appears in Grok CLI billing logs after TUI start.
- **Options considered:** Parse logs only; call undocumented APIs; PTY-spawn Grok to refresh logs.
- **Options rejected:** Undocumented APIs (fragile); logs-only without refresh (stale data).
- **Selected option:** Python helper spawns Grok in PTY, waits for fresh billing log line, emits stable JSON; Pi command execs helper.
- **Residual risk:** Depends on Grok CLI log format and local `grok` binary; refresh can time out (surfaced in JSON).

## Acceptance Criteria Verification

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | bin/grok-usage stable JSON | pass | extensions/grok-pi/bin/grok-usage usage_json() |
| 2 | PTY refresh / --no-refresh | pass | refresh_billing_log(); --no-refresh flag |
| 3 | /grok-pi usage command | pass | extensions/grok-pi/src/index.ts fetchGrokUsage |
| 4 | README | pass | extensions/grok-pi/README.md |
| 5 | Tests | pass | extensions/grok-pi/test/grok-usage.test.mjs (2 cases) |
| 6 | Version bump | pass | extensions/grok-pi/package.json 1.1.0 |