### PR TITLE
feat(install): add selective installation with CLI flags and interactive menu (#27)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -621,8 +621,8 @@ if [[ -n "$SELECT_EXTENSIONS" ]] || [[ -n "$SELECT_THEMES" ]] || [[ -n "$SELECT_
     fi
 fi
 
-# Interactive mode: show selection menu (only when no CLI flags and not --auto)
-if [[ "$MODE" == "interactive" ]] && \
+# Interactive/default from-clone mode: show selection menu (only when no CLI flags and not --auto)
+if [[ ( "$MODE" == "interactive" || "$MODE" == "from-clone" ) ]] && \
    [[ -z "$SELECT_EXTENSIONS" ]] && \
    [[ -z "$SELECT_THEMES" ]] && \
    [[ -z "$SELECT_SKILLS" ]]; then

--- a/install.sh
+++ b/install.sh
@@ -361,7 +361,9 @@ install() {
                 local d="$SRC_DIR/extensions/${name}"
                 if [ -d "$d" ]; then
                     info "  → $name"
-                    cp -r "$d" "$PI_EXTENSIONS/${name}"
+                    local dest="$PI_EXTENSIONS/${name}"
+                    mkdir -p "$dest"
+                    cp -R "$d"/. "$dest/"
                     ext_count=$((ext_count + 1))
                 else
                     warn "  ! Extension not found: $name"
@@ -437,7 +439,9 @@ install() {
                 local d="$SRC_DIR/skills/${name}"
                 if [ -d "$d" ]; then
                     info "  → $name"
-                    cp -r "$d" "$PI_SKILLS/${name}"
+                    local dest="$PI_SKILLS/${name}"
+                    mkdir -p "$dest"
+                    cp -R "$d"/. "$dest/"
                     skill_count=$((skill_count + 1))
                 else
                     warn "  ! Skill not found: $name"

--- a/install.sh
+++ b/install.sh
@@ -126,13 +126,59 @@ discover_items() {
     fi
 }
 
-# ─── Interactive selection menu ──────────────────────────────────────────────
+# ─── TTY helpers ─────────────────────────────────────────────────────────────
+TTY_OPEN=false
+TTY_UNAVAILABLE=false
+TTY_WARNED=false
+
+open_tty() {
+    if [[ "$TTY_OPEN" == "true" ]]; then
+        return 0
+    fi
+    if [[ "$TTY_UNAVAILABLE" == "true" ]]; then
+        return 1
+    fi
+
+    if { exec 3</dev/tty; } 2>/dev/null; then
+        TTY_OPEN=true
+        return 0
+    fi
+
+    TTY_UNAVAILABLE=true
+    return 1
+}
+
+warn_no_tty_once() {
+    if [[ "$TTY_WARNED" != "true" ]]; then
+        warn "No interactive TTY available — using safe defaults (existing repo when present, install all items)."
+        TTY_WARNED=true
+    fi
+}
+
 read_tty_key() {
     local key
-    IFS= read -r -s -n 1 key < /dev/tty || key=""
+    if ! open_tty; then
+        REPLY=""
+        return 1
+    fi
+    IFS= read -r -s -n 1 -u 3 key || key=""
     printf '\n'
     REPLY="$key"
 }
+
+read_tty_line() {
+    local prompt="$1"
+    local line
+    if ! open_tty; then
+        REPLY=""
+        return 1
+    fi
+    printf "%s" "$prompt" > /dev/tty 2>/dev/null || printf "%s" "$prompt"
+    IFS= read -r -u 3 line || line=""
+    REPLY="$line"
+}
+
+# ─── Interactive selection menu ──────────────────────────────────────────────
 
 prompt_toggle_item() {
     local label="$1"
@@ -173,8 +219,8 @@ select_items_interactive() {
     fi
 
     # Read from /dev/tty so curl|bash still has an interactive input source.
-    if [ ! -r /dev/tty ]; then
-        warn "No interactive TTY available — falling back to installing all items (--auto behavior)."
+    if ! open_tty; then
+        warn_no_tty_once
         return
     fi
 
@@ -456,9 +502,15 @@ SRC_DIR=""
 if [[ "$MODE" == "from-clone" ]]; then
     SRC_DIR="$SCRIPT_DIR"
 elif [[ -d "${HOME}/.pi/pi-extensions" ]] && [[ "$MODE" != "auto" ]]; then
-    # Already cloned — ask user
+    # Already cloned — ask user via /dev/tty when available. Without a TTY,
+    # use the safe default (existing repo) without reading from stdin.
     info "Found existing repo at ${HOME}/.pi/pi-extensions"
-    read -rp "  Use it? [Y/n] " ans
+    if read_tty_line "  Use it? [Y/n] "; then
+        ans="$REPLY"
+    else
+        ans="Y"
+        warn_no_tty_once
+    fi
     ans="${ans:-Y}"
     if [[ "$ans" =~ ^[Nn]$ ]]; then
         # Download fresh

--- a/install.sh
+++ b/install.sh
@@ -39,6 +39,8 @@ SELECT_EXTENSIONS=""   # comma-separated list of extension names
 SELECT_THEMES=""       # comma-separated list of theme filenames
 SELECT_SKILLS=""       # comma-separated list of skill names
 SELECTIVE_INSTALL=false # true when CLI or interactive selection should skip unselected categories
+CLI_SELECTIVE_INSTALL=false # true when selective install was requested via CLI flags
+SELECTIVE_INSTALL_ERRORS=0 # missing/invalid explicit CLI selective requests
 
 SEL_EXT_ITEMS=()
 SEL_THEME_ITEMS=()
@@ -351,6 +353,9 @@ install() {
                 # Sanitize: reject path traversal attempts
                 if [[ "$name" == *..* ]] || [[ "$name" == */* ]]; then
                     warn "  ! Invalid extension name (path traversal blocked): $name"
+                    if [[ "$CLI_SELECTIVE_INSTALL" == "true" ]]; then
+                        SELECTIVE_INSTALL_ERRORS=$((SELECTIVE_INSTALL_ERRORS + 1))
+                    fi
                     continue
                 fi
                 local d="$SRC_DIR/extensions/${name}"
@@ -360,6 +365,9 @@ install() {
                     ext_count=$((ext_count + 1))
                 else
                     warn "  ! Extension not found: $name"
+                    if [[ "$CLI_SELECTIVE_INSTALL" == "true" ]]; then
+                        SELECTIVE_INSTALL_ERRORS=$((SELECTIVE_INSTALL_ERRORS + 1))
+                    fi
                 fi
             done
         else
@@ -383,6 +391,9 @@ install() {
                 # Sanitize: reject path traversal attempts
                 if [[ "$name" == *..* ]] || [[ "$name" == */* ]]; then
                     warn "  ! Invalid theme name (path traversal blocked): $name"
+                    if [[ "$CLI_SELECTIVE_INSTALL" == "true" ]]; then
+                        SELECTIVE_INSTALL_ERRORS=$((SELECTIVE_INSTALL_ERRORS + 1))
+                    fi
                     continue
                 fi
                 local f="$SRC_DIR/themes/${name}"
@@ -392,6 +403,9 @@ install() {
                     theme_count=$((theme_count + 1))
                 else
                     warn "  ! Theme not found: $name"
+                    if [[ "$CLI_SELECTIVE_INSTALL" == "true" ]]; then
+                        SELECTIVE_INSTALL_ERRORS=$((SELECTIVE_INSTALL_ERRORS + 1))
+                    fi
                 fi
             done
         else
@@ -415,6 +429,9 @@ install() {
                 # Sanitize: reject path traversal attempts
                 if [[ "$name" == *..* ]] || [[ "$name" == */* ]]; then
                     warn "  ! Invalid skill name (path traversal blocked): $name"
+                    if [[ "$CLI_SELECTIVE_INSTALL" == "true" ]]; then
+                        SELECTIVE_INSTALL_ERRORS=$((SELECTIVE_INSTALL_ERRORS + 1))
+                    fi
                     continue
                 fi
                 local d="$SRC_DIR/skills/${name}"
@@ -424,6 +441,9 @@ install() {
                     skill_count=$((skill_count + 1))
                 else
                     warn "  ! Skill not found: $name"
+                    if [[ "$CLI_SELECTIVE_INSTALL" == "true" ]]; then
+                        SELECTIVE_INSTALL_ERRORS=$((SELECTIVE_INSTALL_ERRORS + 1))
+                    fi
                 fi
             done
         else
@@ -545,6 +565,7 @@ fi
 # Selective install via CLI flags — discover items and set selection arrays
 if [[ -n "$SELECT_EXTENSIONS" ]] || [[ -n "$SELECT_THEMES" ]] || [[ -n "$SELECT_SKILLS" ]]; then
     SELECTIVE_INSTALL=true
+    CLI_SELECTIVE_INSTALL=true
     discover_items "$SRC_DIR"
 
     # Parse extension selection (filter empty elements, validate paths)
@@ -556,6 +577,7 @@ if [[ -n "$SELECT_EXTENSIONS" ]] || [[ -n "$SELECT_THEMES" ]] || [[ -n "$SELECT_
             [ -z "$_item" ] && continue
             if [[ "$_item" == *..* ]] || [[ "$_item" == */* ]]; then
                 warn "  ! Invalid extension name (path traversal blocked): $_item"
+                SELECTIVE_INSTALL_ERRORS=$((SELECTIVE_INSTALL_ERRORS + 1))
                 continue
             fi
             SEL_EXT_ITEMS+=("$_item")
@@ -571,6 +593,7 @@ if [[ -n "$SELECT_EXTENSIONS" ]] || [[ -n "$SELECT_THEMES" ]] || [[ -n "$SELECT_
             [ -z "$_item" ] && continue
             if [[ "$_item" == *..* ]] || [[ "$_item" == */* ]]; then
                 warn "  ! Invalid theme name (path traversal blocked): $_item"
+                SELECTIVE_INSTALL_ERRORS=$((SELECTIVE_INSTALL_ERRORS + 1))
                 continue
             fi
             SEL_THEME_ITEMS+=("$_item")
@@ -586,6 +609,7 @@ if [[ -n "$SELECT_EXTENSIONS" ]] || [[ -n "$SELECT_THEMES" ]] || [[ -n "$SELECT_
             [ -z "$_item" ] && continue
             if [[ "$_item" == *..* ]] || [[ "$_item" == */* ]]; then
                 warn "  ! Invalid skill name (path traversal blocked): $_item"
+                SELECTIVE_INSTALL_ERRORS=$((SELECTIVE_INSTALL_ERRORS + 1))
                 continue
             fi
             SEL_SKILL_ITEMS+=("$_item")
@@ -619,6 +643,15 @@ if [[ "$SELECTIVE_INSTALL" == "true" ]]; then
 fi
 
 install "$SRC_DIR"
+
+if [[ "$CLI_SELECTIVE_INSTALL" == "true" ]] && [ "$SELECTIVE_INSTALL_ERRORS" -gt 0 ]; then
+    echo
+    fail "Selective install failed: $SELECTIVE_INSTALL_ERRORS requested item(s) were missing or invalid."
+    if [[ "$MODE" == "auto" ]] || [[ "$MODE" == "interactive" && "$KEEP_REPO" != "true" ]]; then
+        cleanup "$TMP_DIR"
+    fi
+    exit 1
+fi
 
 echo
 ok "Installation complete!"

--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@
 #     curl -fsSL https://raw.githubusercontent.com/luongnv89/pi-extensions/main/install.sh | bash
 #
 #   Selective CLI (no menu):
-#     install.sh --auto --extensions advisor-pi,opencode-pi --themes neon-green
+#     install.sh --auto --extensions advisor-pi,opencode-pi --themes neon-green.json
 #
 #   Everything (backward compatible):
 #     curl -fsSL https://raw.githubusercontent.com/luongnv89/pi-extensions/main/install.sh | bash -s -- --auto

--- a/install.sh
+++ b/install.sh
@@ -38,6 +38,11 @@ KEEP_REPO=false         # or "true"
 SELECT_EXTENSIONS=""   # comma-separated list of extension names
 SELECT_THEMES=""       # comma-separated list of theme filenames
 SELECT_SKILLS=""       # comma-separated list of skill names
+SELECTIVE_INSTALL=false # true when CLI or interactive selection should skip unselected categories
+
+SEL_EXT_ITEMS=()
+SEL_THEME_ITEMS=()
+SEL_SKILL_ITEMS=()
 
 # Auto-detect: if run from within the repo, skip bootstrap entirely
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -195,6 +200,7 @@ select_items_interactive() {
     fi
 
     # Item selection per category
+    SELECTIVE_INSTALL=true
     SEL_EXT_ITEMS=()
     SEL_THEME_ITEMS=()
     SEL_SKILL_ITEMS=()
@@ -267,11 +273,19 @@ select_items_from_list() {
     fi
 
     # Show final summary
+    local category_lc
+    case "$category" in
+        Extensions) category_lc="extensions" ;;
+        Themes)     category_lc="themes" ;;
+        Skills)     category_lc="skills" ;;
+        *)          category_lc="$category" ;;
+    esac
+
     echo ""
     if [ ${#selected[@]} -eq 0 ]; then
-        echo -e "  ${YELLOW}  ⚠ No ${category,,} selected — skipping.${NC}"
+        echo -e "  ${YELLOW}  ⚠ No ${category_lc} selected — skipping.${NC}"
     else
-        echo -e "  ${GREEN}  ✓ ${#selected[@]} ${category,,} selected:${NC}"
+        echo -e "  ${GREEN}  ✓ ${#selected[@]} ${category_lc} selected:${NC}"
         for item in "${selected[@]}"; do
             echo -e "    ${GREEN}  →${NC} ${item}"
         done
@@ -300,7 +314,7 @@ install() {
 
     # Install extensions
     if [ -d "$SRC_DIR/extensions" ]; then
-        if [ -n "${SEL_EXT_ITEMS:-}" ]; then
+        if [[ "$SELECTIVE_INSTALL" == "true" ]]; then
             # Selective install
             for name in "${SEL_EXT_ITEMS[@]}"; do
                 # Sanitize: reject path traversal attempts
@@ -332,7 +346,7 @@ install() {
 
     # Install themes
     if [ -d "$SRC_DIR/themes" ]; then
-        if [ -n "${SEL_THEME_ITEMS:-}" ]; then
+        if [[ "$SELECTIVE_INSTALL" == "true" ]]; then
             # Selective install
             for name in "${SEL_THEME_ITEMS[@]}"; do
                 # Sanitize: reject path traversal attempts
@@ -364,7 +378,7 @@ install() {
 
     # Install skills
     if [ -d "$SRC_DIR/skills" ]; then
-        if [ -n "${SEL_SKILL_ITEMS:-}" ]; then
+        if [[ "$SELECTIVE_INSTALL" == "true" ]]; then
             # Selective install
             for name in "${SEL_SKILL_ITEMS[@]}"; do
                 # Sanitize: reject path traversal attempts
@@ -490,6 +504,7 @@ fi
 
 # Selective install via CLI flags — discover items and set selection arrays
 if [[ -n "$SELECT_EXTENSIONS" ]] || [[ -n "$SELECT_THEMES" ]] || [[ -n "$SELECT_SKILLS" ]]; then
+    SELECTIVE_INSTALL=true
     discover_items "$SRC_DIR"
 
     # Parse extension selection (filter empty elements, validate paths)
@@ -547,7 +562,7 @@ if [[ "$MODE" == "interactive" ]] && \
 fi
 
 # Show what will be installed
-if [[ -n "${SEL_EXT_ITEMS:-}" ]] || [[ -n "${SEL_THEME_ITEMS:-}" ]] || [[ -n "${SEL_SKILL_ITEMS:-}" ]]; then
+if [[ "$SELECTIVE_INSTALL" == "true" ]]; then
     echo -e "  ${BLUE}──────────────────────────────────────────${NC}"
     echo -e "  ${BLUE}Selective install mode${NC}"
     echo -e "  ${BLUE}──────────────────────────────────────────${NC}"

--- a/install.sh
+++ b/install.sh
@@ -4,16 +4,22 @@
 # Installs all extensions, skills, and themes to your Pi setup
 #
 # Usage:
-#   Interactive (default):
+#   Interactive (default) — shows selection menu:
 #     curl -fsSL https://raw.githubusercontent.com/luongnv89/pi-extensions/main/install.sh | bash
 #
-#   Silent / automated:
+#   Selective CLI (no menu):
+#     install.sh --auto --extensions advisor-pi,opencode-pi --themes neon-green
+#
+#   Everything (backward compatible):
 #     curl -fsSL https://raw.githubusercontent.com/luongnv89/pi-extensions/main/install.sh | bash -s -- --auto
 #
 #   From cloned repo:
 #     ~/.pi/pi-extensions/install.sh
 #     ~/.pi/pi-extensions/install.sh --auto
-#     ~/.pi/pi-extensions/install.sh --auto --keep      # keep the repo after install
+#     ~/.pi/pi-extensions/install.sh --auto --keep
+#
+#   Dry-run (list available items):
+#     install.sh --dry-run
 
 set -e
 
@@ -28,6 +34,11 @@ PI_SKILLS="${HOME}/.pi/agent/skills"
 MODE="interactive"     # or "auto", "from-clone", "dry-run"
 KEEP_REPO=false         # or "true"
 
+# Selective install flags
+SELECT_EXTENSIONS=""   # comma-separated list of extension names
+SELECT_THEMES=""       # comma-separated list of theme filenames
+SELECT_SKILLS=""       # comma-separated list of skill names
+
 # Auto-detect: if run from within the repo, skip bootstrap entirely
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 if [[ "$SCRIPT_DIR" == "${HOME}/.pi/pi-extensions" ]]; then
@@ -37,11 +48,29 @@ fi
 # ─── Parse flags ─────────────────────────────────────────────────────────────
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --auto)       MODE="auto"; shift ;;
-        --keep)       KEEP_REPO=true; shift ;;
-        --dry-run)    MODE="dry-run"; shift ;;
-        --repo-url)   GITHUB_REPO="$2"; shift 2 ;;
-        --branch)     REMOTE_BRANCH="$2"; shift 2 ;;
+        --auto)           MODE="auto"; shift ;;
+        --keep)           KEEP_REPO=true; shift ;;
+        --dry-run)        MODE="dry-run"; shift ;;
+        --repo-url)       GITHUB_REPO="$2"; shift 2 ;;
+        --branch)         REMOTE_BRANCH="$2"; shift 2 ;;
+        --extensions)
+            if [[ -z "$2" || "$2" == --* ]]; then
+                echo "Error: --extensions requires a value (comma-separated list of names)"
+                exit 1
+            fi
+            SELECT_EXTENSIONS="$2"; shift 2 ;;
+        --themes)
+            if [[ -z "$2" || "$2" == --* ]]; then
+                echo "Error: --themes requires a value (comma-separated list of filenames)"
+                exit 1
+            fi
+            SELECT_THEMES="$2"; shift 2 ;;
+        --skills)
+            if [[ -z "$2" || "$2" == --* ]]; then
+                echo "Error: --skills requires a value (comma-separated list of names)"
+                exit 1
+            fi
+            SELECT_SKILLS="$2"; shift 2 ;;
         *) echo "Unknown option: $1"; exit 1 ;;
     esac
 done
@@ -51,12 +80,211 @@ GREEN='\033[0;32m'
 BLUE='\033[0;34m'
 YELLOW='\033[1;33m'
 RED='\033[0;31m'
+CYAN='\033[0;36m'
 NC='\033[0m'
 
 info()  { echo -e "${BLUE}ℹ️  $*${NC}"; }
 ok()    { echo -e "${GREEN}✅ $*${NC}"; }
 warn()  { echo -e "${YELLOW}⚠️  $*${NC}"; }
 fail()  { echo -e "${RED}❌ $*${NC}"; }
+select_style() { echo -e "${CYAN}◉ $*${NC}"; }
+
+# ─── Inventory helpers ───────────────────────────────────────────────────────
+discover_items() {
+    local SRC_DIR="$1"
+
+    # Discover extensions
+    EXT_ITEMS=()
+    if [ -d "$SRC_DIR/extensions" ]; then
+        for d in "$SRC_DIR"/extensions/*/; do
+            [ -d "$d" ] || continue
+            EXT_ITEMS+=("$(basename "$d")")
+        done
+    fi
+
+    # Discover themes
+    THEME_ITEMS=()
+    if [ -d "$SRC_DIR/themes" ]; then
+        for f in "$SRC_DIR"/themes/*; do
+            [ -f "$f" ] || continue
+            THEME_ITEMS+=("$(basename "$f")")
+        done
+    fi
+
+    # Discover skills
+    SKILL_ITEMS=()
+    if [ -d "$SRC_DIR/skills" ]; then
+        for d in "$SRC_DIR"/skills/*/; do
+            [ -d "$d" ] || continue
+            SKILL_ITEMS+=("$(basename "$d")")
+        done
+    fi
+}
+
+# ─── Interactive selection menu ──────────────────────────────────────────────
+select_items_interactive() {
+    local SRC_DIR="$1"
+
+    # If CLI selective flags were provided, skip interactive menu entirely
+    if [[ -n "$SELECT_EXTENSIONS" ]] || [[ -n "$SELECT_THEMES" ]] || [[ -n "$SELECT_SKILLS" ]]; then
+        return
+    fi
+
+    # Check if we have a TTY for interactive input
+    if [ ! -t 0 ]; then
+        warn "No TTY detected — falling back to installing all items (--auto behavior)."
+        return
+    fi
+
+    discover_items "$SRC_DIR"
+
+    # Show category selection
+    echo ""
+    echo -e "  ${CYAN}══════════════════════════════════════════${NC}"
+    echo -e "  ${CYAN}Select categories to install${NC}"
+    echo -e "  ${CYAN}══════════════════════════════════════════${NC}"
+    echo ""
+    echo -e "  ${YELLOW}[space] to toggle, [enter] to confirm${NC}"
+    echo ""
+
+    local cat_count=${#EXT_ITEMS[@]}
+    [ ${#THEME_ITEMS[@]} -gt 0 ] && cat_count=$((cat_count + 1))
+    [ ${#SKILL_ITEMS[@]} -gt 0 ] && cat_count=$((cat_count + 1))
+
+    # Default: all categories selected
+    local sel_ext=1 sel_theme=1 sel_skill=1
+
+    local idx=1
+    if [ ${#EXT_ITEMS[@]} -gt 0 ]; then
+        select_style "[ ] Extensions (${#EXT_ITEMS[@]} available)"
+        idx=$((idx + 1))
+    fi
+    if [ ${#THEME_ITEMS[@]} -gt 0 ]; then
+        select_style "[ ] Themes (${#THEME_ITEMS[@]} available)"
+        idx=$((idx + 1))
+    fi
+    if [ ${#SKILL_ITEMS[@]} -gt 0 ]; then
+        select_style "[ ] Skills (${#SKILL_ITEMS[@]} available)"
+        idx=$((idx + 1))
+    fi
+
+    if [ $cat_count -eq 0 ]; then
+        warn "No items found to install."
+        return
+    fi
+
+    # Category selection loop
+    echo ""
+    idx=1
+    if [ ${#EXT_ITEMS[@]} -gt 0 ]; then
+        read -rp "  Extensions [${sel_ext}]? " ans
+        ans="${ans:-$sel_ext}"
+        [[ "$ans" =~ ^[Yy1]$ ]] && sel_ext=1 || sel_ext=0
+        idx=$((idx + 1))
+    fi
+    if [ ${#THEME_ITEMS[@]} -gt 0 ]; then
+        read -rp "  Themes [${sel_theme}]? " ans
+        ans="${ans:-$sel_theme}"
+        [[ "$ans" =~ ^[Yy1]$ ]] && sel_theme=1 || sel_theme=0
+        idx=$((idx + 1))
+    fi
+    if [ ${#SKILL_ITEMS[@]} -gt 0 ]; then
+        read -rp "  Skills [${sel_skill}]? " ans
+        ans="${ans:-$sel_skill}"
+        [[ "$ans" =~ ^[Yy1]$ ]] && sel_skill=1 || sel_skill=0
+    fi
+
+    # Item selection per category
+    SEL_EXT_ITEMS=()
+    SEL_THEME_ITEMS=()
+    SEL_SKILL_ITEMS=()
+
+    if [ "$sel_ext" -eq 1 ]; then
+        select_items_from_list "Extensions" "${EXT_ITEMS[@]}" SEL_EXT_ITEMS
+    fi
+
+    if [ "$sel_theme" -eq 1 ]; then
+        select_items_from_list "Themes" "${THEME_ITEMS[@]}" SEL_THEME_ITEMS
+    fi
+
+    if [ "$sel_skill" -eq 1 ]; then
+        select_items_from_list "Skills" "${SKILL_ITEMS[@]}" SEL_SKILL_ITEMS
+    fi
+}
+
+select_items_from_list() {
+    local category="$1"
+    shift
+    local -a items=("$@")
+
+    if [ ${#items[@]} -eq 0 ]; then
+        return
+    fi
+
+    echo ""
+    echo -e "  ${CYAN}══════════════════════════════════════════${NC}"
+    echo -e "  ${CYAN}${category} — select items to install${NC}"
+    echo -e "  ${CYAN}══════════════════════════════════════════${NC}"
+    echo ""
+    echo -e "  ${YELLOW}[space] to toggle, [enter] to confirm${NC}"
+    echo ""
+
+    # Default: all selected
+    local -a selected=()
+    for item in "${items[@]}"; do
+        selected+=("$item")
+    done
+
+    # Show selection menu
+    local idx=1
+    for item in "${items[@]}"; do
+        local mark="◉"
+        if printf '%s\n' "${selected[@]}" | grep -qxF "$item"; then
+            mark="◉"
+        else
+            mark="○"
+        fi
+        echo -e "    ${mark} ${idx}) ${item}"
+        idx=$((idx + 1))
+    done
+    echo ""
+    echo -e "  ${YELLOW}Enter numbers to toggle (e.g. 1 3 5), or press Enter to keep current selection${NC}"
+    echo ""
+
+    read -rp "  Selection> " selection_input
+    selection_input="${selection_input:-all}"
+
+    # Reset to empty if user explicitly types something
+    if [ "$selection_input" = "all" ] || [ -z "$selection_input" ]; then
+        selected=("${items[@]}")
+    else
+        selected=()
+        for num in $selection_input; do
+            if [[ "$num" =~ ^[0-9]+$ ]] && [ "$num" -ge 1 ] && [ "$num" -le ${#items[@]} ]; then
+                selected+=("${items[$((num - 1))]}")
+            fi
+        done
+    fi
+
+    # Show final summary
+    echo ""
+    if [ ${#selected[@]} -eq 0 ]; then
+        echo -e "  ${YELLOW}  ⚠ No ${category,,} selected — skipping.${NC}"
+    else
+        echo -e "  ${GREEN}  ✓ ${#selected[@]} ${category,,} selected:${NC}"
+        for item in "${selected[@]}"; do
+            echo -e "    ${GREEN}  →${NC} ${item}"
+        done
+    fi
+    echo ""
+
+    # Export selected items via global variable
+    case "$category" in
+        Extensions) SEL_EXT_ITEMS=("${selected[@]}");;
+        Themes)     SEL_THEME_ITEMS=("${selected[@]}");;
+        Skills)     SEL_SKILL_ITEMS=("${selected[@]}");;
+    esac
+}
 
 # ─── Bootstrap ───────────────────────────────────────────────────────────────
 install() {
@@ -70,36 +298,99 @@ install() {
 
     local ext_count=0 theme_count=0 skill_count=0
 
+    # Install extensions
     if [ -d "$SRC_DIR/extensions" ]; then
-        for d in "$SRC_DIR"/extensions/*/; do
-            [ -d "$d" ] || continue
-            local name; name="$(basename "$d")"
-            info "  → $name"
-            cp -r "$d" "$PI_EXTENSIONS/${name}"
-            ext_count=$((ext_count + 1))
-        done
+        if [ -n "${SEL_EXT_ITEMS:-}" ]; then
+            # Selective install
+            for name in "${SEL_EXT_ITEMS[@]}"; do
+                # Sanitize: reject path traversal attempts
+                if [[ "$name" == *..* ]] || [[ "$name" == */* ]]; then
+                    warn "  ! Invalid extension name (path traversal blocked): $name"
+                    continue
+                fi
+                local d="$SRC_DIR/extensions/${name}"
+                if [ -d "$d" ]; then
+                    info "  → $name"
+                    cp -r "$d" "$PI_EXTENSIONS/${name}"
+                    ext_count=$((ext_count + 1))
+                else
+                    warn "  ! Extension not found: $name"
+                fi
+            done
+        else
+            # Install all
+            for d in "$SRC_DIR"/extensions/*/; do
+                [ -d "$d" ] || continue
+                local name; name="$(basename "$d")"
+                info "  → $name"
+                cp -r "$d" "$PI_EXTENSIONS/${name}"
+                ext_count=$((ext_count + 1))
+            done
+        fi
         ok "$ext_count extension(s) installed"
     fi
 
+    # Install themes
     if [ -d "$SRC_DIR/themes" ]; then
-        for f in "$SRC_DIR"/themes/*; do
-            [ -f "$f" ] || continue
-            local name; name="$(basename "$f")"
-            info "  → $name"
-            cp "$f" "$PI_THEMES/${name}"
-            theme_count=$((theme_count + 1))
-        done
+        if [ -n "${SEL_THEME_ITEMS:-}" ]; then
+            # Selective install
+            for name in "${SEL_THEME_ITEMS[@]}"; do
+                # Sanitize: reject path traversal attempts
+                if [[ "$name" == *..* ]] || [[ "$name" == */* ]]; then
+                    warn "  ! Invalid theme name (path traversal blocked): $name"
+                    continue
+                fi
+                local f="$SRC_DIR/themes/${name}"
+                if [ -f "$f" ]; then
+                    info "  → $name"
+                    cp "$f" "$PI_THEMES/${name}"
+                    theme_count=$((theme_count + 1))
+                else
+                    warn "  ! Theme not found: $name"
+                fi
+            done
+        else
+            # Install all
+            for f in "$SRC_DIR"/themes/*; do
+                [ -f "$f" ] || continue
+                local name; name="$(basename "$f")"
+                info "  → $name"
+                cp "$f" "$PI_THEMES/${name}"
+                theme_count=$((theme_count + 1))
+            done
+        fi
         ok "$theme_count theme(s) installed"
     fi
 
+    # Install skills
     if [ -d "$SRC_DIR/skills" ]; then
-        for d in "$SRC_DIR"/skills/*/; do
-            [ -d "$d" ] || continue
-            local name; name="$(basename "$d")"
-            info "  → $name"
-            cp -r "$d" "$PI_SKILLS/${name}"
-            skill_count=$((skill_count + 1))
-        done
+        if [ -n "${SEL_SKILL_ITEMS:-}" ]; then
+            # Selective install
+            for name in "${SEL_SKILL_ITEMS[@]}"; do
+                # Sanitize: reject path traversal attempts
+                if [[ "$name" == *..* ]] || [[ "$name" == */* ]]; then
+                    warn "  ! Invalid skill name (path traversal blocked): $name"
+                    continue
+                fi
+                local d="$SRC_DIR/skills/${name}"
+                if [ -d "$d" ]; then
+                    info "  → $name"
+                    cp -r "$d" "$PI_SKILLS/${name}"
+                    skill_count=$((skill_count + 1))
+                else
+                    warn "  ! Skill not found: $name"
+                fi
+            done
+        else
+            # Install all
+            for d in "$SRC_DIR"/skills/*/; do
+                [ -d "$d" ] || continue
+                local name; name="$(basename "$d")"
+                info "  → $name"
+                cp -r "$d" "$PI_SKILLS/${name}"
+                skill_count=$((skill_count + 1))
+            done
+        fi
         ok "$skill_count skill(s) installed"
     fi
 
@@ -117,9 +408,47 @@ cleanup() {
     ok "Temporary directory removed"
 }
 
+# ─── Dry-run: list available items ───────────────────────────────────────────
+dry_run() {
+    echo ""
+    echo -e "  ${CYAN}══════════════════════════════════════════${NC}"
+    echo -e "  ${CYAN}Available items${NC}"
+    echo -e "  ${CYAN}══════════════════════════════════════════${NC}"
+    echo ""
+
+    discover_items "$SRC_DIR"
+
+    if [ ${#EXT_ITEMS[@]} -gt 0 ]; then
+        echo -e "  ${YELLOW}Extensions (${#EXT_ITEMS[@]}):${NC}"
+        for item in "${EXT_ITEMS[@]}"; do
+            echo -e "    ◉ $item"
+        done
+        echo ""
+    fi
+
+    if [ ${#THEME_ITEMS[@]} -gt 0 ]; then
+        echo -e "  ${YELLOW}Themes (${#THEME_ITEMS[@]}):${NC}"
+        for item in "${THEME_ITEMS[@]}"; do
+            echo -e "    ◉ $item"
+        done
+        echo ""
+    fi
+
+    if [ ${#SKILL_ITEMS[@]} -gt 0 ]; then
+        echo -e "  ${YELLOW}Skills (${#SKILL_ITEMS[@]}):${NC}"
+        for item in "${SKILL_ITEMS[@]}"; do
+            echo -e "    ◉ $item"
+        done
+        echo ""
+    fi
+
+    echo -e "  ${BLUE}Use --extensions, --themes, --skills to select specific items${NC}"
+    echo -e "  ${BLUE}Run without flags for interactive selection${NC}"
+}
+
 # ─── Main ────────────────────────────────────────────────────────────────────
 echo -e "${BLUE}╔═══════════════════════════════════════╗${NC}"
-echo -e "${BLUE}║   Pi Extensions Installer v1.0.0     ║${NC}"
+echo -e "${BLUE}║   Pi Extensions Installer v1.1.0     ║${NC}"
 echo -e "${BLUE}╚═══════════════════════════════════════╝${NC}"
 echo
 
@@ -151,6 +480,87 @@ fi
 if [[ ! -d "$SRC_DIR" ]]; then
     fail "Source directory not found: $SRC_DIR"
     exit 1
+fi
+
+# Dry-run: list available items
+if [[ "$MODE" == "dry-run" ]]; then
+    dry_run
+    exit 0
+fi
+
+# Selective install via CLI flags — discover items and set selection arrays
+if [[ -n "$SELECT_EXTENSIONS" ]] || [[ -n "$SELECT_THEMES" ]] || [[ -n "$SELECT_SKILLS" ]]; then
+    discover_items "$SRC_DIR"
+
+    # Parse extension selection (filter empty elements, validate paths)
+    if [ -n "$SELECT_EXTENSIONS" ]; then
+        IFS=',' read -ra _raw_ext <<< "$SELECT_EXTENSIONS"
+        SEL_EXT_ITEMS=()
+        for _item in "${_raw_ext[@]}"; do
+            _item="$(echo "$_item" | xargs)"  # trim whitespace
+            [ -z "$_item" ] && continue
+            if [[ "$_item" == *..* ]] || [[ "$_item" == */* ]]; then
+                warn "  ! Invalid extension name (path traversal blocked): $_item"
+                continue
+            fi
+            SEL_EXT_ITEMS+=("$_item")
+        done
+    fi
+
+    # Parse theme selection (filter empty elements, validate paths)
+    if [ -n "$SELECT_THEMES" ]; then
+        IFS=',' read -ra _raw_theme <<< "$SELECT_THEMES"
+        SEL_THEME_ITEMS=()
+        for _item in "${_raw_theme[@]}"; do
+            _item="$(echo "$_item" | xargs)"
+            [ -z "$_item" ] && continue
+            if [[ "$_item" == *..* ]] || [[ "$_item" == */* ]]; then
+                warn "  ! Invalid theme name (path traversal blocked): $_item"
+                continue
+            fi
+            SEL_THEME_ITEMS+=("$_item")
+        done
+    fi
+
+    # Parse skill selection (filter empty elements, validate paths)
+    if [ -n "$SELECT_SKILLS" ]; then
+        IFS=',' read -ra _raw_skill <<< "$SELECT_SKILLS"
+        SEL_SKILL_ITEMS=()
+        for _item in "${_raw_skill[@]}"; do
+            _item="$(echo "$_item" | xargs)"
+            [ -z "$_item" ] && continue
+            if [[ "$_item" == *..* ]] || [[ "$_item" == */* ]]; then
+                warn "  ! Invalid skill name (path traversal blocked): $_item"
+                continue
+            fi
+            SEL_SKILL_ITEMS+=("$_item")
+        done
+    fi
+fi
+
+# Interactive mode: show selection menu (only when no CLI flags and not --auto)
+if [[ "$MODE" == "interactive" ]] && \
+   [[ -z "$SELECT_EXTENSIONS" ]] && \
+   [[ -z "$SELECT_THEMES" ]] && \
+   [[ -z "$SELECT_SKILLS" ]]; then
+    select_items_interactive "$SRC_DIR"
+fi
+
+# Show what will be installed
+if [[ -n "${SEL_EXT_ITEMS:-}" ]] || [[ -n "${SEL_THEME_ITEMS:-}" ]] || [[ -n "${SEL_SKILL_ITEMS:-}" ]]; then
+    echo -e "  ${BLUE}──────────────────────────────────────────${NC}"
+    echo -e "  ${BLUE}Selective install mode${NC}"
+    echo -e "  ${BLUE}──────────────────────────────────────────${NC}"
+    if [ ${#SEL_EXT_ITEMS[@]} -gt 0 ]; then
+        echo -e "  Extensions: ${SEL_EXT_ITEMS[*]}"
+    fi
+    if [ ${#SEL_THEME_ITEMS[@]} -gt 0 ]; then
+        echo -e "  Themes:     ${SEL_THEME_ITEMS[*]}"
+    fi
+    if [ ${#SEL_SKILL_ITEMS[@]} -gt 0 ]; then
+        echo -e "  Skills:     ${SEL_SKILL_ITEMS[*]}"
+    fi
+    echo ""
 fi
 
 install "$SRC_DIR"

--- a/install.sh
+++ b/install.sh
@@ -127,6 +127,43 @@ discover_items() {
 }
 
 # ─── Interactive selection menu ──────────────────────────────────────────────
+read_tty_key() {
+    local key
+    IFS= read -r -s -n 1 key < /dev/tty || key=""
+    printf '\n'
+    REPLY="$key"
+}
+
+prompt_toggle_item() {
+    local label="$1"
+    local selected="$2"
+    local key mark
+
+    while true; do
+        if [ "$selected" -eq 1 ]; then
+            mark="x"
+        else
+            mark=" "
+        fi
+        printf "  [%s] %s  (space toggle, y/n set, enter keep) " "$mark" "$label"
+        read_tty_key
+        key="$REPLY"
+        case "$key" in
+            ""|$'\r') PROMPT_SELECTION="$selected"; return ;;
+            " ")
+                if [ "$selected" -eq 1 ]; then
+                    selected=0
+                else
+                    selected=1
+                fi
+                ;;
+            y|Y|1) PROMPT_SELECTION=1; return ;;
+            n|N|0) PROMPT_SELECTION=0; return ;;
+            *) warn "Use space, y, n, or Enter." ;;
+        esac
+    done
+}
+
 select_items_interactive() {
     local SRC_DIR="$1"
 
@@ -135,86 +172,63 @@ select_items_interactive() {
         return
     fi
 
-    # Check if we have a TTY for interactive input
-    if [ ! -t 0 ]; then
-        warn "No TTY detected — falling back to installing all items (--auto behavior)."
+    # Read from /dev/tty so curl|bash still has an interactive input source.
+    if [ ! -r /dev/tty ]; then
+        warn "No interactive TTY available — falling back to installing all items (--auto behavior)."
         return
     fi
 
     discover_items "$SRC_DIR"
 
-    # Show category selection
     echo ""
     echo -e "  ${CYAN}══════════════════════════════════════════${NC}"
     echo -e "  ${CYAN}Select categories to install${NC}"
     echo -e "  ${CYAN}══════════════════════════════════════════${NC}"
     echo ""
-    echo -e "  ${YELLOW}[space] to toggle, [enter] to confirm${NC}"
+    echo -e "  ${YELLOW}Defaults are selected. Use space to toggle, y/n to set, Enter to keep.${NC}"
     echo ""
 
-    local cat_count=${#EXT_ITEMS[@]}
+    local cat_count=0
+    [ ${#EXT_ITEMS[@]} -gt 0 ] && cat_count=$((cat_count + 1))
     [ ${#THEME_ITEMS[@]} -gt 0 ] && cat_count=$((cat_count + 1))
     [ ${#SKILL_ITEMS[@]} -gt 0 ] && cat_count=$((cat_count + 1))
-
-    # Default: all categories selected
-    local sel_ext=1 sel_theme=1 sel_skill=1
-
-    local idx=1
-    if [ ${#EXT_ITEMS[@]} -gt 0 ]; then
-        select_style "[ ] Extensions (${#EXT_ITEMS[@]} available)"
-        idx=$((idx + 1))
-    fi
-    if [ ${#THEME_ITEMS[@]} -gt 0 ]; then
-        select_style "[ ] Themes (${#THEME_ITEMS[@]} available)"
-        idx=$((idx + 1))
-    fi
-    if [ ${#SKILL_ITEMS[@]} -gt 0 ]; then
-        select_style "[ ] Skills (${#SKILL_ITEMS[@]} available)"
-        idx=$((idx + 1))
-    fi
 
     if [ $cat_count -eq 0 ]; then
         warn "No items found to install."
         return
     fi
 
-    # Category selection loop
-    echo ""
-    idx=1
+    # Default: all categories selected
+    local sel_ext=1 sel_theme=1 sel_skill=1
+
     if [ ${#EXT_ITEMS[@]} -gt 0 ]; then
-        read -rp "  Extensions [${sel_ext}]? " ans
-        ans="${ans:-$sel_ext}"
-        [[ "$ans" =~ ^[Yy1]$ ]] && sel_ext=1 || sel_ext=0
-        idx=$((idx + 1))
+        prompt_toggle_item "Extensions (${#EXT_ITEMS[@]} available)" "$sel_ext"
+        sel_ext="$PROMPT_SELECTION"
     fi
     if [ ${#THEME_ITEMS[@]} -gt 0 ]; then
-        read -rp "  Themes [${sel_theme}]? " ans
-        ans="${ans:-$sel_theme}"
-        [[ "$ans" =~ ^[Yy1]$ ]] && sel_theme=1 || sel_theme=0
-        idx=$((idx + 1))
+        prompt_toggle_item "Themes (${#THEME_ITEMS[@]} available)" "$sel_theme"
+        sel_theme="$PROMPT_SELECTION"
     fi
     if [ ${#SKILL_ITEMS[@]} -gt 0 ]; then
-        read -rp "  Skills [${sel_skill}]? " ans
-        ans="${ans:-$sel_skill}"
-        [[ "$ans" =~ ^[Yy1]$ ]] && sel_skill=1 || sel_skill=0
+        prompt_toggle_item "Skills (${#SKILL_ITEMS[@]} available)" "$sel_skill"
+        sel_skill="$PROMPT_SELECTION"
     fi
 
-    # Item selection per category
     SELECTIVE_INSTALL=true
     SEL_EXT_ITEMS=()
     SEL_THEME_ITEMS=()
     SEL_SKILL_ITEMS=()
 
     if [ "$sel_ext" -eq 1 ]; then
-        select_items_from_list "Extensions" "${EXT_ITEMS[@]}" SEL_EXT_ITEMS
+        select_items_from_list "Extensions" "${EXT_ITEMS[@]}"
     fi
 
     if [ "$sel_theme" -eq 1 ]; then
-        select_items_from_list "Themes" "${THEME_ITEMS[@]}" SEL_THEME_ITEMS
+        select_items_from_list "Themes" "${THEME_ITEMS[@]}"
     fi
 
     if [ "$sel_skill" -eq 1 ]; then
-        select_items_from_list "Skills" "${SKILL_ITEMS[@]}" SEL_SKILL_ITEMS
+        select_items_from_list "Skills" "${SKILL_ITEMS[@]}"
     fi
 }
 
@@ -232,47 +246,19 @@ select_items_from_list() {
     echo -e "  ${CYAN}${category} — select items to install${NC}"
     echo -e "  ${CYAN}══════════════════════════════════════════${NC}"
     echo ""
-    echo -e "  ${YELLOW}[space] to toggle, [enter] to confirm${NC}"
+    echo -e "  ${YELLOW}Defaults are selected. Use space to toggle, y/n to set, Enter to keep.${NC}"
     echo ""
 
-    # Default: all selected
     local -a selected=()
+    local item keep
     for item in "${items[@]}"; do
-        selected+=("$item")
-    done
-
-    # Show selection menu
-    local idx=1
-    for item in "${items[@]}"; do
-        local mark="◉"
-        if printf '%s\n' "${selected[@]}" | grep -qxF "$item"; then
-            mark="◉"
-        else
-            mark="○"
+        prompt_toggle_item "$item" 1
+        keep="$PROMPT_SELECTION"
+        if [ "$keep" -eq 1 ]; then
+            selected+=("$item")
         fi
-        echo -e "    ${mark} ${idx}) ${item}"
-        idx=$((idx + 1))
     done
-    echo ""
-    echo -e "  ${YELLOW}Enter numbers to toggle (e.g. 1 3 5), or press Enter to keep current selection${NC}"
-    echo ""
 
-    read -rp "  Selection> " selection_input
-    selection_input="${selection_input:-all}"
-
-    # Reset to empty if user explicitly types something
-    if [ "$selection_input" = "all" ] || [ -z "$selection_input" ]; then
-        selected=("${items[@]}")
-    else
-        selected=()
-        for num in $selection_input; do
-            if [[ "$num" =~ ^[0-9]+$ ]] && [ "$num" -ge 1 ] && [ "$num" -le ${#items[@]} ]; then
-                selected+=("${items[$((num - 1))]}")
-            fi
-        done
-    fi
-
-    # Show final summary
     local category_lc
     case "$category" in
         Extensions) category_lc="extensions" ;;
@@ -292,7 +278,6 @@ select_items_from_list() {
     fi
     echo ""
 
-    # Export selected items via global variable
     case "$category" in
         Extensions) SEL_EXT_ITEMS=("${selected[@]}");;
         Themes)     SEL_THEME_ITEMS=("${selected[@]}");;
@@ -499,6 +484,9 @@ fi
 # Dry-run: list available items
 if [[ "$MODE" == "dry-run" ]]; then
     dry_run
+    if [ -n "$TMP_DIR" ]; then
+        cleanup "$TMP_DIR"
+    fi
     exit 0
 fi
 


### PR DESCRIPTION
## Summary

Closes #27. Addresses #27: Users can now selectively choose which extensions, themes, and skills to install instead of installing everything unconditionally.

## Approach

**Balanced approach** — CLI flags for automation + interactive text-based menu with space-bar toggles for discoverability. Uses only bash builtins (no `dialog`/`whiptail` dependency).

- `--extensions name1,name2` — install only specified extensions
- `--themes theme1.json,theme2.json` — install only specified themes  
- `--skills skill1,skill2` — install only specified skills
- `--dry-run` — list all available items with names
- Default interactive mode — category selection → item selection with numbered toggles
- `--auto` — installs everything (backward compatible)

## Decision Record

| Field | Value |
|-------|-------|
| **Issue** | #27 |
| **Complexity** | Medium |
| **Approach** | Balanced: CLI flags + interactive prompt |
| **Risk** | Low — single file change, backward compatible |

## Changes

| Action | File | What changed |
|--------|------|-------------|
| Modified | `install.sh` | Added selective install CLI flags, interactive menu, dry-run listing, path traversal sanitization |

## Test Results

- `bash -n install.sh` — syntax OK
- `install.sh --dry-run` — lists all 7 extensions, 4 themes, 1 skill
- `install.sh --auto` — installs all 7+4+1 (backward compatible)
- `install.sh --auto --extensions advisor-pi,opencode-pi --themes neon-green.json --skills pi-delegator` — selective install works
- `install.sh --auto --extensions a
