### PR TITLE
feat(subagents-pi): add subagent fleet metrics extension (#29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ More assets live in [`assets/`](assets/) (e.g. `statusline-pi-gpt-5-mini-195toks
 - **apple-fm-pi** — Bridge Apple Foundation Models (`fm` CLI: on-device `system`, `pcc`) into Pi with auto-start `fm serve` and `/apple-fm-pi` commands.
 - **grok-pi** — Bridge Grok CLI session models (Composer 2.5, Grok Build) into Pi via `grok-cli` and `~/.grok/auth.json`.
 - **opencode-pi** — Bridge local OpenCode CLI free models into Pi without OpenCode login, with OpenCode tools disabled and Pi tool calls prompt-bridged back into Pi.
+- **subagents-pi** — Fleet metrics panel for managed subagents (context, TPS, model, thinking); works with `@tintinweb/pi-subagents`.
 - **pi-delegator** — Agent skill for delegating approved tasks to a monitored Pi subprocess, preferring free `opencode-cli` models and reporting session metrics.
 - **Neon Green themes** — Futuristic dark (`neon-green`) and light (`neon-green-light`) themes with neon green, cyan, and magenta accents.
 - **npm packages** — Several extensions publish to npm; install with Pi’s package manager (`pi install npm:<name>`).
@@ -67,7 +68,7 @@ pi install -l npm:statusline-pi
 | [`opencode-pi`](https://www.npmjs.com/package/opencode-pi) | `opencode-cli` free models |
 | [`model-debugger`](https://www.npmjs.com/package/model-debugger) | Model request logging to `~/.pi/agent/logs/` |
 
-**Not on npm yet** (install from repo below): `apple-fm-pi`, `claude-code-pi`.
+**Not on npm yet** (install from repo below): `apple-fm-pi`, `claude-code-pi`, `subagents-pi`.
 
 Try without installing (current session only):
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **subagents-pi**: New extension listing managed subagents with per-agent context usage, output TPS, model, and thinking level (companion to `@tintinweb/pi-subagents`).
+
 ### Changed
 
 - **README**: Document npm install via `pi install npm:<package>` and table of published extensions.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -235,6 +235,14 @@ Key implementation points:
 - `/advisor-pi` manages enable/disable, model, max uses, cache preference, and
   use-count reset.
 
+### subagents-pi
+
+`subagents-pi` renders a below-editor fleet panel for subagents managed by
+`@tintinweb/pi-subagents`. It subscribes to `pi.events` lifecycle channels
+(`subagents:ready`, `subagents:created`, `subagents:started`, …) and reads
+agent records from the `Symbol.for("pi-subagents:manager")` registry for live
+context, TPS, model, and thinking labels.
+
 ### statusline-pi
 
 `statusline-pi` replaces the footer with compact git, PR, context, and model

--- a/extensions/subagents-pi/README.md
+++ b/extensions/subagents-pi/README.md
@@ -33,7 +33,7 @@ Reload Pi: `/reload`
 
 | Field | Source |
 |-------|--------|
-| Context | Current context token estimate + context-window % (when available) + compaction count |
+| Context | Current context tokens (or `—` when unavailable) + context-window % (when available) + compaction count |
 | TPS | Output tokens ÷ elapsed time (approximate session average) |
 | Model | Runtime session provider/model, with the invocation label as fallback |
 | Thinking | Runtime session thinking level, with invocation settings as fallback |

--- a/extensions/subagents-pi/README.md
+++ b/extensions/subagents-pi/README.md
@@ -27,13 +27,13 @@ Reload Pi: `/reload`
 - The panel appears **below the editor** when subagents are tracked.
 - Each agent uses a compact identity line followed by width-safe metric lines.
 - `/subagents-pi` — toggle the panel
-- `/subagents-pi-refresh` — refresh and prune finished agents
+- `/subagents-pi-refresh` — refresh metrics and discard records removed by the companion
 
 ## What each row shows
 
 | Field | Source |
 |-------|--------|
-| Context | Current session tokens + context-window % (when available) + compaction count |
+| Context | Current context token estimate + context-window % (when available) + compaction count |
 | TPS | Output tokens ÷ elapsed time (approximate session average) |
 | Model | Runtime session provider/model, with the invocation label as fallback |
 | Thinking | Runtime session thinking level, with invocation settings as fallback |

--- a/extensions/subagents-pi/README.md
+++ b/extensions/subagents-pi/README.md
@@ -1,0 +1,57 @@
+# subagents-pi
+
+Pi extension that shows a **fleet metrics panel** for every managed subagent: **context usage**, **output TPS**, **model**, and **thinking level**.
+
+Designed as a companion to [`@tintinweb/pi-subagents`](https://www.npmjs.com/package/@tintinweb/pi-subagents), which handles spawning, FleetView, and the `Agent` tool. This extension listens to the `pi.events` lifecycle bus and reads the shared agent registry for live stats.
+
+## Install
+
+```bash
+# Orchestration (required for subagents)
+pi install npm:@tintinweb/pi-subagents
+
+# Metrics panel (this extension)
+pi install npm:subagents-pi
+```
+
+From this monorepo:
+
+```bash
+./install.sh --auto
+```
+
+Reload Pi: `/reload`
+
+## Usage
+
+- The panel appears **below the editor** when subagents are tracked.
+- `/subagents-pi` — toggle the panel
+- `/subagents-pi-refresh` — refresh and prune finished agents
+
+## What each row shows
+
+| Field | Source |
+|-------|--------|
+| Context | Lifetime tokens + context-window % (when available) + compaction count |
+| TPS | Output tokens ÷ elapsed time (approximate session average) |
+| Model | Spawn-time model label from agent invocation |
+| Thinking | Spawn-time thinking level from agent invocation |
+
+## Acceptance criteria (issue #29)
+
+- Dedicated installable Pi extension — `subagents-pi` npm package / `extensions/subagents-pi/`
+- View listing managed subagents — below-editor widget + status key `subagents-pi`
+- Per-agent context, TPS, model, thinking — rendered on each row
+
+## Development
+
+```bash
+cd extensions/subagents-pi
+npm install
+npm run build
+npm test
+```
+
+## License
+
+MIT

--- a/extensions/subagents-pi/README.md
+++ b/extensions/subagents-pi/README.md
@@ -25,6 +25,7 @@ Reload Pi: `/reload`
 ## Usage
 
 - The panel appears **below the editor** when subagents are tracked.
+- Each agent uses a compact identity line followed by width-safe metric lines.
 - `/subagents-pi` — toggle the panel
 - `/subagents-pi-refresh` — refresh and prune finished agents
 
@@ -32,10 +33,10 @@ Reload Pi: `/reload`
 
 | Field | Source |
 |-------|--------|
-| Context | Lifetime tokens + context-window % (when available) + compaction count |
+| Context | Current session tokens + context-window % (when available) + compaction count |
 | TPS | Output tokens ÷ elapsed time (approximate session average) |
-| Model | Spawn-time model label from agent invocation |
-| Thinking | Spawn-time thinking level from agent invocation |
+| Model | Runtime session provider/model, with the invocation label as fallback |
+| Thinking | Runtime session thinking level, with invocation settings as fallback |
 
 ## Acceptance criteria (issue #29)
 

--- a/extensions/subagents-pi/package-lock.json
+++ b/extensions/subagents-pi/package-lock.json
@@ -1,0 +1,1996 @@
+{
+  "name": "subagents-pi",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "subagents-pi",
+      "version": "1.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "typescript": "^5.6.0"
+      },
+      "peerDependencies": {
+        "@earendil-works/pi-coding-agent": "^0.75.4",
+        "@earendil-works/pi-tui": "^0.75.4"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent": {
+      "version": "0.75.5",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.75.5.tgz",
+      "integrity": "sha512-O3CCQDYy28D4uwtP6zZkdEwzHN6X22v49Sb0+SZTC7x37V/YfmogrWPiaFoWeoc2hmdKhSATI7ZAK5bQbJG5NA==",
+      "hasShrinkwrap": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@earendil-works/pi-agent-core": "^0.75.5",
+        "@earendil-works/pi-ai": "^0.75.5",
+        "@earendil-works/pi-tui": "^0.75.5",
+        "@silvia-odwyer/photon-node": "0.3.4",
+        "chalk": "5.6.2",
+        "cross-spawn": "7.0.6",
+        "diff": "8.0.4",
+        "glob": "13.0.6",
+        "highlight.js": "10.7.3",
+        "hosted-git-info": "9.0.3",
+        "ignore": "7.0.5",
+        "jiti": "2.7.0",
+        "minimatch": "10.2.5",
+        "proper-lockfile": "4.1.2",
+        "typebox": "1.1.38",
+        "undici": "8.3.0",
+        "yaml": "2.9.0"
+      },
+      "bin": {
+        "pi": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      },
+      "optionalDependencies": {
+        "@mariozechner/clipboard": "0.3.6"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@anthropic-ai/sdk": {
+      "version": "0.91.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/client-bedrock-runtime": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
+      "integrity": "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/credential-provider-node": "^3.972.42",
+        "@aws-sdk/eventstream-handler-node": "^3.972.16",
+        "@aws-sdk/middleware-eventstream": "^3.972.12",
+        "@aws-sdk/middleware-websocket": "^3.972.19",
+        "@aws-sdk/token-providers": "3.1048.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/core": {
+      "version": "3.974.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.11.tgz",
+      "integrity": "sha512-QpnINq5FZH6EOaDEkmHdT7eUunbvD27pDNQypaWjFyYz7Zl1q3UCMQErBZxpmfGfI7MvI2TlK8KTkgNpv8b1ug==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/xml-builder": "^3.972.24",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.37.tgz",
+      "integrity": "sha512-/jpPvEh6f7ntmIzf7dNxoNX6Q8vt8UpesCjbW6mFfk4V1NW6bIy9qxcQ6WbA8As5yQhsZOe+xeNd4xHX8kdY2Q==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.39.tgz",
+      "integrity": "sha512-pIgTpisWyWg7X1bUbzSjuUYosYTD0Ghz2M0hkSTmb3a6i3qV3uU+NYJPI/E2XSC0HcsZh5rsLPzeXrkb2DS0Cg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.41.tgz",
+      "integrity": "sha512-u2tyjaxJJzW8UtW4SM1ZcPMDwO6y+kV+llvou+Adts0FAKyzes5jG4izQN+KX3yE8ZROpS5y1LJ//xL2iSf76w==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/credential-provider-env": "^3.972.37",
+        "@aws-sdk/credential-provider-http": "^3.972.39",
+        "@aws-sdk/credential-provider-login": "^3.972.41",
+        "@aws-sdk/credential-provider-process": "^3.972.37",
+        "@aws-sdk/credential-provider-sso": "^3.972.41",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.41",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/credential-provider-imds": "^4.3.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.41.tgz",
+      "integrity": "sha512-0LBitxXiAiaE5nlFPfpNIww/8FRY/I7WIndWsc9GmNFOM7cE1wNpVNQEGEk9Outg5l8xl+3vybxFyUy4l9q/LQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.42.tgz",
+      "integrity": "sha512-D4oon2zbqqsWOJUM99Gm3/ZyJ0IJvTXVN3PyloGb3kQEyI36fjCZheZj422lAgTWWd6TSHgiImLt3RIaLdv3dQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.37",
+        "@aws-sdk/credential-provider-http": "^3.972.39",
+        "@aws-sdk/credential-provider-ini": "^3.972.41",
+        "@aws-sdk/credential-provider-process": "^3.972.37",
+        "@aws-sdk/credential-provider-sso": "^3.972.41",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.41",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/credential-provider-imds": "^4.3.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.37.tgz",
+      "integrity": "sha512-7nVaHBUaWIddASYfVaA9O4D5ZVjewU3sCol9WqZPGfW0nR+0WqE0xHZnD/U2L33PlOB8KNXGKZ6wOES/QijKzg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.41.tgz",
+      "integrity": "sha512-IOWAWEHe5LkjSKkkUUX9ciV6Y1scHTsnfEkdt5yyC4Slrc7AGbkLPrpntjqh18ksJAMOaVhoBsO8p2WyTcY2wQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/token-providers": "3.1048.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.41.tgz",
+      "integrity": "sha512-mbACk9Yypa8nm4iGZLs0PofOXEcTDOUw6wDnsPXNDNSd2WNXs1tSo+6nc/fh0jLYdfVZThhBL98PHW4aXFsG5A==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/eventstream-handler-node": {
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.16.tgz",
+      "integrity": "sha512-yedpPgKftqjU5SlPFHfqWpOw6xSCRieWRG1euWOlXn4WJxt2VX92VprCa2PpSOXjVCAeK6dTjW9eJRXVig9yGA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/middleware-eventstream": {
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.12.tgz",
+      "integrity": "sha512-tHTHHCHNrq6XklQvlzHBDJG4Iuhh7NVPRdtmvP+nHFA+5sxPlIDzlAHHgfoYHGvT3NXP1yVP/L5c3opUn6T3Qg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/middleware-websocket": {
+      "version": "3.972.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.19.tgz",
+      "integrity": "sha512-mkEhOGYozqKQkbFaVrjwr0faiwwZza1v5/jSY6Tucm3bD+uKTazIUH/4Yo6aMnQD2ua2W9cMP6s8mvwTcjtqHw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.9.tgz",
+      "integrity": "sha512-jPR3rnmRI4hWYyzfmTGBr7NblMp8QYYeflHXba1H6+7CGrWVqWKQzaXFQ4qbExqPRsXN3T3L3JxFhr6aouXUGQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.27",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.27.tgz",
+      "integrity": "sha512-0Phbz4t6HI3D3skxvG2uI+VWU034/nSIw1T8d+FPzzQG9EQTrw94o9mOKO2Gv3n3Oc8P7JD7RAUxkoneLWv5Eg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
+      "integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/types": {
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.24.tgz",
+      "integrity": "sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@nodable/entities": "2.1.0",
+        "@smithy/types": "^4.14.1",
+        "fast-xml-parser": "5.7.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
+      "version": "0.75.5",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.75.5.tgz",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@earendil-works/pi-ai": "^0.75.5",
+        "ignore": "7.0.5",
+        "typebox": "1.1.38",
+        "yaml": "2.9.0"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
+      "version": "0.75.5",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.75.5.tgz",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@anthropic-ai/sdk": "0.91.1",
+        "@aws-sdk/client-bedrock-runtime": "3.1048.0",
+        "@google/genai": "1.52.0",
+        "@mistralai/mistralai": "2.2.1",
+        "@smithy/node-http-handler": "4.7.3",
+        "http-proxy-agent": "7.0.2",
+        "https-proxy-agent": "7.0.6",
+        "openai": "6.26.0",
+        "partial-json": "0.1.7",
+        "typebox": "1.1.38"
+      },
+      "bin": {
+        "pi-ai": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
+      "version": "0.75.5",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.75.5.tgz",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "get-east-asian-width": "1.6.0",
+        "marked": "15.0.12"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@google/genai": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
+      "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.6.tgz",
+      "integrity": "sha512-MXdtr+6+ntlIVHdrZYuZNQydu6o8yZswFJ2Ln81j2O/Y9B/LDHvEaIm95xWNPkjGTWriSOeLnQJRFs6dYb60bg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@mariozechner/clipboard-darwin-arm64": "0.3.6",
+        "@mariozechner/clipboard-darwin-universal": "0.3.6",
+        "@mariozechner/clipboard-darwin-x64": "0.3.6",
+        "@mariozechner/clipboard-linux-arm64-gnu": "0.3.6",
+        "@mariozechner/clipboard-linux-arm64-musl": "0.3.6",
+        "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.6",
+        "@mariozechner/clipboard-linux-x64-gnu": "0.3.6",
+        "@mariozechner/clipboard-linux-x64-musl": "0.3.6",
+        "@mariozechner/clipboard-win32-arm64-msvc": "0.3.6",
+        "@mariozechner/clipboard-win32-x64-msvc": "0.3.6"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-arm64": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.6.tgz",
+      "integrity": "sha512-HjaisYCAbHi/1+N1yDAQHc8ZXGffufIUT5NSOSVR3f3AuMDusxTtnbK8tZ7JFDkShua1oNGZoNwQHsc8MPtE0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-universal": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.6.tgz",
+      "integrity": "sha512-8BWtPjOtJOJoykml3w0fx0zRrfWP31mXrJwfoA7xzNprkZw1uolCNfgmjDiVBseoKjp16EGITz7bN+61qn8dWA==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-x64": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.6.tgz",
+      "integrity": "sha512-p9syiZD1kU4I+1ya7f7g+zD1GiUvR8fdlRlNmgsZNWlyjtc8rlV2EjTLd/35x1LsdBq020GVvtzp0ZmPgBI09Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-arm64-gnu": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.6.tgz",
+      "integrity": "sha512-5JFf5rGofrm+V29HNF+wLthXphHdQpMbKDUYJ5tML6/Z5DLlLOV/9Ak4kDPtYyZ+Dzf+kAusE0VsFg4+tfP1IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-arm64-musl": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.6.tgz",
+      "integrity": "sha512-JlVjxxw0GbGC0djXYWRIqyteO3J1KZ/QG3udlEFaOD5TLOM1FnmXXAPDQBqr+aBVr720ef9K00dirYnJ0LDCtw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-riscv64-gnu": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.6.tgz",
+      "integrity": "sha512-4t8BUi5zZ+L77otFQVnVSlaTyAX4TVk9EqQm4syMrEQp96trFEHEwwNHcNEBGzYv5+K7mxay50TthYkz47OWzQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-x64-gnu": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.6.tgz",
+      "integrity": "sha512-trtPwcNLW37irwQCJLtCxLw757jjJZk3TSnY/MU9bhtWtA3K9b/eLW0e4RGhUXDoFRds9opNWWaUDuFLa8dm0w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-x64-musl": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.6.tgz",
+      "integrity": "sha512-WfnzIvOCCWQiN0MmltCEo6cLceUDbYe+I7xyFZjaps5A+2Op/M2CY7Rey+C4ucQhrvmpoHmTSFgY9ODWk7snoA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-win32-arm64-msvc": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.6.tgz",
+      "integrity": "sha512-+8+1aHYsBPUjmW3otmWlg+Hijt0iJvoBBs5e0mxFeUd4gDaKMB8Bn6x7c6KVtscg7E5j5NFXnwQqNSIAO4p8zQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-win32-x64-msvc": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.6.tgz",
+      "integrity": "sha512-S4xfPmERC8ZkiLHe3vekZCjdDwNEETCuvCgQK2kP6/TnvmUkq1y2Pk+DjM4t8uh9KMX9bH4zs5ePcKa8GTXmfg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mistralai/mistralai": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.1.tgz",
+      "integrity": "sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-to-json-schema": "^3.25.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/inquire": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@silvia-odwyer/photon-node": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
+      "integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
+      "license": "Apache-2.0",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/core": {
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.3.tgz",
+      "integrity": "sha512-Ep/7tPamGY8mgESE3LyLKtxJyy6U52WWAqr/3wial47Sj4u3PiIF73AOGI27UyLy9duTkhZbgzodOfLV4TduZg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/credential-provider-imds": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.3.tgz",
+      "integrity": "sha512-I2Bti0DKFo2IJyN28ijCsx51BAumEYR4/1yZ1FXyBygy9MqbnMqCev4JPth/MbpRfBSRAX35hITSnAdJRo1u5w==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/fetch-http-handler": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.3.tgz",
+      "integrity": "sha512-F+DRf8IJazRJgYog2A/yJK7eYVc0rqTlRzO+5ZxjJd4WkZoKz0IJRncf7G6t1pdVT3kryJcwuTFhN1c5m6N47A==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/node-http-handler": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
+      "integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/signature-v4": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.3.tgz",
+      "integrity": "sha512-53+75QuPl6DL+ct6vVEB51FDO5oulXr20TPV46VvJZg76lIlXNWfxi8j+G2V/t0I2qxCBOa3vX/8bmjrpFVo9g==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/types": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
+      "integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-parser": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "peer": true,
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/google-auth-library": {
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/hosted-git-info": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+      "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "lru-cache": "^11.1.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/lru-cache": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.4.0.tgz",
+      "integrity": "sha512-W+R+kFL4HgVxONq2bhXPi3bGpzGe/yEhVOp233qw9wCRtgncJ15P3bC+e4zZMu4Cq7d+WAJjXGW0uUkifhcatA==",
+      "license": "BlueOak-1.0.0",
+      "peer": true,
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/marked": {
+      "version": "15.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "peer": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/openai": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
+      "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/p-retry/node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/partial-json": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
+      "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "peer": true,
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/proper-lockfile/node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/protobufjs": {
+      "version": "7.5.9",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.9.tgz",
+      "integrity": "sha512-Od4muIm3HW1AouyHF5lONOf1FWo3hY1NbFDoy191X9GzhpgW1clCoaFjfVs2rKJNFYpTNJbje4cbAIDBZJ63ZA==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/strnum": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/typebox": {
+      "version": "1.1.38",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
+      "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/undici": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.3.0.tgz",
+      "integrity": "sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peer": true,
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    },
+    "node_modules/@earendil-works/pi-tui": {
+      "version": "0.75.5",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.75.5.tgz",
+      "integrity": "sha512-LkXUM1/49pvzzeI39Y5wjBMlgafcCf67HCLhB9Z7yuXHy4XgT+VqxWcZVW5hBdhQsHZd0znjJotfGH1BzxMfiA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "get-east-asian-width": "1.6.0",
+        "marked": "15.0.12"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/marked": {
+      "version": "15.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/extensions/subagents-pi/package.json
+++ b/extensions/subagents-pi/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "files": ["dist", "README.md"],
+  "files": ["dist", "src", "README.md"],
   "exports": {
     ".": {
       "import": "./dist/index.js",

--- a/extensions/subagents-pi/package.json
+++ b/extensions/subagents-pi/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "subagents-pi",
+  "version": "1.0.0",
+  "description": "Pi extension for subagent fleet metrics — context, TPS, model, and thinking per agent (companion to @tintinweb/pi-subagents)",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": ["dist", "README.md"],
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "npm run build && node --test test/*.test.mjs",
+    "prepublishOnly": "npm run build"
+  },
+  "pi": {
+    "extensions": ["./src/index.ts"]
+  },
+  "keywords": [
+    "pi-package",
+    "pi",
+    "subagents",
+    "agents",
+    "metrics",
+    "context-window",
+    "tokens-per-second"
+  ],
+  "author": "pi-extensions contributors",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/luongnv89/pi-extensions.git"
+  },
+  "bugs": {
+    "url": "https://github.com/luongnv89/pi-extensions/issues"
+  },
+  "homepage": "https://github.com/luongnv89/pi-extensions/tree/main/extensions/subagents-pi",
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": "^0.75.4",
+    "@earendil-works/pi-tui": "^0.75.4"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/extensions/subagents-pi/src/format.ts
+++ b/extensions/subagents-pi/src/format.ts
@@ -1,0 +1,60 @@
+export type LifetimeUsage = { input: number; output: number; cacheWrite: number };
+
+export function getLifetimeTotal(usage?: LifetimeUsage): number {
+	if (!usage) return 0;
+	return usage.input + usage.output + usage.cacheWrite;
+}
+
+export function formatCompactTokenCount(count: number): string {
+	if (count >= 1_000_000) return `${(count / 1_000_000).toFixed(1)}M`;
+	if (count >= 1_000) return `${(count / 1_000).toFixed(1)}k`;
+	return String(count);
+}
+
+export function formatContextLabel(
+	totalTokens: number,
+	contextPercent: number | null | undefined,
+	compactionCount?: number,
+): string {
+	const base = formatCompactTokenCount(totalTokens);
+	const parts: string[] = [];
+	if (contextPercent != null && Number.isFinite(contextPercent)) {
+		parts.push(`${Math.round(contextPercent)}%`);
+	}
+	if (compactionCount && compactionCount > 0) {
+		parts.push(`⇊${compactionCount}`);
+	}
+	if (parts.length === 0) return base;
+	return `${base} (${parts.join(" · ")})`;
+}
+
+export function computeOutputTps(outputTokens: number, durationMs: number): number | undefined {
+	if (durationMs <= 0 || outputTokens <= 0) return undefined;
+	return outputTokens / (durationMs / 1000);
+}
+
+export function formatTps(tps: number | undefined): string {
+	if (tps === undefined || !Number.isFinite(tps) || tps <= 0) return "—";
+	if (tps >= 100) return `${Math.round(tps)}`;
+	if (tps >= 10) return tps.toFixed(1);
+	return tps.toFixed(2);
+}
+
+export function formatThinkingLevel(level: string | undefined): string {
+	if (!level) return "—";
+	return level;
+}
+
+export function formatModelLabel(modelName: string | undefined, agentType: string): string {
+	if (modelName && modelName.trim()) return modelName;
+	return agentType;
+}
+
+export function formatDurationMs(durationMs: number): string {
+	if (durationMs < 1000) return `${durationMs}ms`;
+	const seconds = durationMs / 1000;
+	if (seconds < 60) return `${seconds.toFixed(1)}s`;
+	const minutes = Math.floor(seconds / 60);
+	const rem = Math.round(seconds % 60);
+	return `${minutes}m${rem}s`;
+}

--- a/extensions/subagents-pi/src/format.ts
+++ b/extensions/subagents-pi/src/format.ts
@@ -45,9 +45,9 @@ export function formatThinkingLevel(level: string | undefined): string {
 	return level;
 }
 
-export function formatModelLabel(modelName: string | undefined, agentType: string): string {
-	if (modelName && modelName.trim()) return modelName;
-	return agentType;
+export function formatModelLabel(modelName: string | undefined): string {
+	if (modelName && modelName.trim()) return modelName.trim();
+	return "—";
 }
 
 export function formatDurationMs(durationMs: number): string {

--- a/extensions/subagents-pi/src/format.ts
+++ b/extensions/subagents-pi/src/format.ts
@@ -12,11 +12,11 @@ export function formatCompactTokenCount(count: number): string {
 }
 
 export function formatContextLabel(
-	totalTokens: number,
+	totalTokens: number | undefined,
 	contextPercent: number | null | undefined,
 	compactionCount?: number,
 ): string {
-	const base = formatCompactTokenCount(totalTokens);
+	const base = totalTokens === undefined ? "—" : formatCompactTokenCount(totalTokens);
 	const parts: string[] = [];
 	if (contextPercent != null && Number.isFinite(contextPercent)) {
 		parts.push(`${Math.round(contextPercent)}%`);

--- a/extensions/subagents-pi/src/index.ts
+++ b/extensions/subagents-pi/src/index.ts
@@ -55,6 +55,7 @@ export default function subagentsPiExtension(pi: ExtensionAPI) {
 
 	pi.on("session_start", async (_event, ctx) => {
 		store.reset();
+		wireEventBus();
 		if (isCompanionLoaded()) store.markCompanionReady();
 		if (!ctx.hasUI) return;
 		mount(ctx);

--- a/extensions/subagents-pi/src/index.ts
+++ b/extensions/subagents-pi/src/index.ts
@@ -4,7 +4,16 @@ import { renderFleetLines, WIDGET_KEY } from "./render.js";
 import { SubagentMetricsStore } from "./store.js";
 
 interface LifecyclePayload {
-	id?: string;
+	id?: unknown;
+}
+
+interface RpcSpawnRequest {
+	requestId?: unknown;
+}
+
+interface RpcSpawnReply {
+	success?: unknown;
+	data?: { id?: unknown };
 }
 
 const REFRESH_MS = 500;
@@ -18,13 +27,20 @@ export default function subagentsPiExtension(pi: ExtensionAPI) {
 	const store = new SubagentMetricsStore();
 
 	const unsubscribers: Array<() => void> = [];
+	const rpcReplyUnsubscribers = new Set<() => void>();
+
+	function nonEmptyString(value: unknown): string | undefined {
+		return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+	}
 
 	function trackFromPayload(payload: unknown): void {
-		const id = (payload as LifecyclePayload)?.id;
-		if (typeof id === "string") store.trackId(id);
+		const id = nonEmptyString((payload as LifecyclePayload)?.id);
+		if (id) store.trackId(id);
 	}
 
 	function tearDownEventBus(): void {
+		for (const unsub of rpcReplyUnsubscribers) unsub();
+		rpcReplyUnsubscribers.clear();
 		for (const unsub of unsubscribers) unsub();
 		unsubscribers.length = 0;
 	}
@@ -34,6 +50,22 @@ export default function subagentsPiExtension(pi: ExtensionAPI) {
 		const events = pi.events;
 		if (!events?.on) return;
 
+		const trackRpcSpawn = (payload: unknown): void => {
+			const requestId = nonEmptyString((payload as RpcSpawnRequest)?.requestId);
+			if (!requestId) return;
+
+			let unsubscribe: (() => void) | undefined;
+			unsubscribe = events.on(`subagents:rpc:spawn:reply:${requestId}`, (replyPayload) => {
+				unsubscribe?.();
+				if (unsubscribe) rpcReplyUnsubscribers.delete(unsubscribe);
+
+				const reply = replyPayload as RpcSpawnReply;
+				const id = reply?.success === true ? nonEmptyString(reply.data?.id) : undefined;
+				if (id) store.trackId(id);
+			});
+			rpcReplyUnsubscribers.add(unsubscribe);
+		};
+
 		const handlers: Array<[string, (data: unknown) => void]> = [
 			["subagents:ready", () => store.markCompanionReady()],
 			["subagents:created", trackFromPayload],
@@ -42,6 +74,7 @@ export default function subagentsPiExtension(pi: ExtensionAPI) {
 			["subagents:failed", trackFromPayload],
 			["subagents:compacted", trackFromPayload],
 			["subagents:steered", trackFromPayload],
+			["subagents:rpc:spawn", trackRpcSpawn],
 		];
 
 		for (const [name, handler] of handlers) {
@@ -86,7 +119,7 @@ export default function subagentsPiExtension(pi: ExtensionAPI) {
 	pi.registerCommand("subagents-pi-refresh", {
 		description: "Refresh subagent fleet metrics display",
 		handler: async (_args, ctx) => {
-			store.pruneFinished();
+			store.pruneMissing();
 			requestRender();
 			ctx.ui.notify("subagents-pi refreshed", "info");
 		},
@@ -106,7 +139,7 @@ export default function subagentsPiExtension(pi: ExtensionAPI) {
 					_tui.requestRender();
 				},
 				render(width: number): string[] {
-					store.pruneFinished();
+					store.pruneMissing();
 					const rows = store.listRows();
 					return renderFleetLines(theme, rows, {
 						companionReady: store.isCompanionReady() || isCompanionLoaded(),
@@ -123,7 +156,7 @@ export default function subagentsPiExtension(pi: ExtensionAPI) {
 
 		if (refreshTimer) clearInterval(refreshTimer);
 		refreshTimer = setInterval(() => {
-			store.pruneFinished();
+			store.pruneMissing();
 			requestRender();
 			updateStatus(ctx);
 		}, REFRESH_MS);

--- a/extensions/subagents-pi/src/index.ts
+++ b/extensions/subagents-pi/src/index.ts
@@ -1,0 +1,143 @@
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { isCompanionLoaded } from "./registry.js";
+import { renderFleetLines, WIDGET_KEY } from "./render.js";
+import { SubagentMetricsStore } from "./store.js";
+
+interface LifecyclePayload {
+	id?: string;
+}
+
+const REFRESH_MS = 500;
+
+export default function subagentsPiExtension(pi: ExtensionAPI) {
+	let enabled = true;
+	let mounted = false;
+	let activeCtx: ExtensionContext | undefined;
+	let refreshTimer: ReturnType<typeof setInterval> | undefined;
+	let renderRequested: (() => void) | undefined;
+	const store = new SubagentMetricsStore();
+
+	const unsubscribers: Array<() => void> = [];
+
+	function trackFromPayload(payload: unknown): void {
+		const id = (payload as LifecyclePayload)?.id;
+		if (typeof id === "string") store.trackId(id);
+	}
+
+	function wireEventBus(): void {
+		const events = pi.events;
+		if (!events?.on) return;
+
+		const handlers: Array<[string, (data: unknown) => void]> = [
+			["subagents:ready", () => store.markCompanionReady()],
+			["subagents:created", trackFromPayload],
+			["subagents:started", trackFromPayload],
+			["subagents:completed", trackFromPayload],
+			["subagents:failed", trackFromPayload],
+			["subagents:compacted", trackFromPayload],
+			["subagents:steered", trackFromPayload],
+		];
+
+		for (const [name, handler] of handlers) {
+			const unsub = events.on(name, handler);
+			if (typeof unsub === "function") unsubscribers.push(unsub);
+		}
+	}
+
+	wireEventBus();
+	if (isCompanionLoaded()) store.markCompanionReady();
+
+	pi.on("session_start", async (_event, ctx) => {
+		store.reset();
+		if (isCompanionLoaded()) store.markCompanionReady();
+		if (!ctx.hasUI) return;
+		mount(ctx);
+	});
+
+	pi.on("session_shutdown", async () => {
+		unmount(activeCtx);
+		activeCtx = undefined;
+		store.reset();
+	});
+
+	pi.registerCommand("subagents-pi", {
+		description: "Toggle subagent fleet metrics panel (context, TPS, model, thinking)",
+		handler: async (_args, ctx) => {
+			if (!ctx.hasUI) return;
+			enabled = !enabled;
+			if (enabled) {
+				mount(ctx);
+				ctx.ui.notify("subagents-pi enabled", "info");
+			} else {
+				unmount(ctx);
+				ctx.ui.notify("subagents-pi disabled", "info");
+			}
+		},
+	});
+
+	pi.registerCommand("subagents-pi-refresh", {
+		description: "Refresh subagent fleet metrics display",
+		handler: async (_args, ctx) => {
+			store.pruneFinished();
+			requestRender();
+			ctx.ui.notify("subagents-pi refreshed", "info");
+		},
+	});
+
+	function mount(ctx: ExtensionContext): void {
+		if (!enabled || !ctx.hasUI) return;
+		if (mounted && activeCtx === ctx) return;
+		if (mounted) unmount(activeCtx);
+		mounted = true;
+		activeCtx = ctx;
+
+		ctx.ui.setWidget(WIDGET_KEY, (_tui, theme) => {
+			renderRequested = () => _tui.requestRender();
+			return {
+				invalidate() {
+					_tui.requestRender();
+				},
+				render(width: number): string[] {
+					store.pruneFinished();
+					const rows = store.listRows();
+					return renderFleetLines(theme, rows, {
+						companionReady: store.isCompanionReady() || isCompanionLoaded(),
+						enabled: true,
+					}, width);
+				},
+			};
+		}, { placement: "belowEditor" });
+
+		ctx.ui.setStatus(
+			"subagents-pi",
+			ctx.ui.theme.fg("accent", `subagents:${store.visibleCount()}`),
+		);
+
+		if (refreshTimer) clearInterval(refreshTimer);
+		refreshTimer = setInterval(() => {
+			store.pruneFinished();
+			requestRender();
+			updateStatus(ctx);
+		}, REFRESH_MS);
+	}
+
+	function unmount(ctx?: ExtensionContext): void {
+		if (refreshTimer) clearInterval(refreshTimer);
+		refreshTimer = undefined;
+		renderRequested = undefined;
+		mounted = false;
+		if (activeCtx === ctx) activeCtx = undefined;
+		if (ctx?.hasUI) {
+			ctx.ui.setWidget(WIDGET_KEY, undefined);
+			ctx.ui.setStatus("subagents-pi", undefined);
+		}
+	}
+
+	function updateStatus(ctx: ExtensionContext): void {
+		ctx.ui.setStatus("subagents-pi", ctx.ui.theme.fg("accent", `subagents:${store.visibleCount()}`));
+	}
+
+	function requestRender(): void {
+		renderRequested?.();
+	}
+}

--- a/extensions/subagents-pi/src/index.ts
+++ b/extensions/subagents-pi/src/index.ts
@@ -24,7 +24,13 @@ export default function subagentsPiExtension(pi: ExtensionAPI) {
 		if (typeof id === "string") store.trackId(id);
 	}
 
+	function tearDownEventBus(): void {
+		for (const unsub of unsubscribers) unsub();
+		unsubscribers.length = 0;
+	}
+
 	function wireEventBus(): void {
+		tearDownEventBus();
 		const events = pi.events;
 		if (!events?.on) return;
 
@@ -58,6 +64,7 @@ export default function subagentsPiExtension(pi: ExtensionAPI) {
 		unmount(activeCtx);
 		activeCtx = undefined;
 		store.reset();
+		tearDownEventBus();
 	});
 
 	pi.registerCommand("subagents-pi", {
@@ -102,7 +109,7 @@ export default function subagentsPiExtension(pi: ExtensionAPI) {
 					const rows = store.listRows();
 					return renderFleetLines(theme, rows, {
 						companionReady: store.isCompanionReady() || isCompanionLoaded(),
-						enabled: true,
+						enabled,
 					}, width);
 				},
 			};

--- a/extensions/subagents-pi/src/registry.ts
+++ b/extensions/subagents-pi/src/registry.ts
@@ -37,7 +37,11 @@ export interface AgentRecordSnapshot {
 				cacheWrite: number;
 				total?: number;
 			};
-			contextUsage?: { percent: number | null };
+			contextUsage?: {
+				tokens: number | null;
+				contextWindow: number;
+				percent: number | null;
+			};
 		};
 	};
 }

--- a/extensions/subagents-pi/src/registry.ts
+++ b/extensions/subagents-pi/src/registry.ts
@@ -1,0 +1,52 @@
+/** Cross-package registry published by @tintinweb/pi-subagents. */
+const MANAGER_KEY = Symbol.for("pi-subagents:manager");
+
+export type AgentStatus =
+	| "queued"
+	| "running"
+	| "completed"
+	| "steered"
+	| "aborted"
+	| "stopped"
+	| "error";
+
+export interface AgentInvocationSnapshot {
+	modelName?: string;
+	thinking?: string;
+}
+
+export interface AgentRecordSnapshot {
+	id: string;
+	type: string;
+	description: string;
+	status: AgentStatus;
+	toolUses: number;
+	startedAt: number;
+	completedAt?: number;
+	lifetimeUsage: { input: number; output: number; cacheWrite: number };
+	compactionCount: number;
+	invocation?: AgentInvocationSnapshot;
+	session?: {
+		getSessionStats(): {
+			tokens: { input: number; output: number; cacheWrite: number };
+			contextUsage?: { percent: number | null };
+		};
+	};
+}
+
+export interface SubagentsRegistry {
+	getRecord: (id: string) => AgentRecordSnapshot | undefined;
+	hasRunning: () => boolean;
+}
+
+export function getSubagentsRegistry(): SubagentsRegistry | undefined {
+	const entry = (globalThis as Record<symbol, unknown>)[MANAGER_KEY];
+	if (!entry || typeof entry !== "object") return undefined;
+	const registry = entry as Partial<SubagentsRegistry>;
+	if (typeof registry.getRecord !== "function") return undefined;
+	return registry as SubagentsRegistry;
+}
+
+export function isCompanionLoaded(): boolean {
+	return getSubagentsRegistry() !== undefined;
+}

--- a/extensions/subagents-pi/src/registry.ts
+++ b/extensions/subagents-pi/src/registry.ts
@@ -27,8 +27,16 @@ export interface AgentRecordSnapshot {
 	compactionCount: number;
 	invocation?: AgentInvocationSnapshot;
 	session?: {
+		model?: { provider: string; id: string };
+		thinkingLevel?: string;
 		getSessionStats(): {
-			tokens: { input: number; output: number; cacheWrite: number };
+			tokens: {
+				input: number;
+				output: number;
+				cacheRead?: number;
+				cacheWrite: number;
+				total?: number;
+			};
 			contextUsage?: { percent: number | null };
 		};
 	};

--- a/extensions/subagents-pi/src/render.ts
+++ b/extensions/subagents-pi/src/render.ts
@@ -1,9 +1,8 @@
-import { truncateToWidth } from "@earendil-works/pi-tui";
+import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { AgentMetricsRow } from "./store.js";
 
 const WIDGET_KEY = "subagents-pi-fleet";
-const MAX_LINES = 14;
 
 export { WIDGET_KEY };
 
@@ -13,30 +12,25 @@ export function renderFleetLines(
 	options: { companionReady: boolean; enabled: boolean },
 	width: number,
 ): string[] {
-	const safeWidth = Math.max(20, width);
+	const safeWidth = Math.max(1, width);
 	if (!options.enabled) return [];
 
 	if (!options.companionReady) {
 		return [
-			theme.fg("warning", "subagents-pi: install @tintinweb/pi-subagents and /reload"),
-			theme.fg("dim", "  pi install npm:@tintinweb/pi-subagents"),
+			truncateToWidth(theme.fg("warning", "subagents-pi: install @tintinweb/pi-subagents and /reload"), safeWidth),
+			truncateToWidth(theme.fg("dim", "  pi install npm:@tintinweb/pi-subagents"), safeWidth),
 		];
 	}
 
 	if (rows.length === 0) {
-		return [theme.fg("dim", "subagents-pi: no managed subagents in this session")];
+		return [truncateToWidth(theme.fg("dim", "subagents-pi: no managed subagents in this session"), safeWidth)];
 	}
 
 	const header = theme.bold(theme.fg("mdHeading", `Subagents (${rows.length})`));
 	const lines: string[] = [truncateToWidth(header, safeWidth)];
 
-	const displayRows = rows.slice(0, MAX_LINES);
-	for (const row of displayRows) {
-		lines.push(truncateToWidth(formatAgentLine(theme, row), safeWidth));
-	}
-
-	if (rows.length > MAX_LINES) {
-		lines.push(theme.fg("dim", truncateToWidth(`  … +${rows.length - MAX_LINES} more`, safeWidth)));
+	for (const row of rows) {
+		lines.push(...formatAgentLines(theme, row, safeWidth));
 	}
 
 	lines.push(
@@ -51,17 +45,48 @@ export function renderFleetLines(
 	return lines;
 }
 
-function formatAgentLine(theme: ExtensionContext["ui"]["theme"], row: AgentMetricsRow): string {
+function formatAgentLines(
+	theme: ExtensionContext["ui"]["theme"],
+	row: AgentMetricsRow,
+	width: number,
+): string[] {
 	const statusColor = statusToColor(row.status);
 	const status = theme.fg(statusColor, row.status.padEnd(9));
 	const name = theme.fg("mdLink", row.type);
 	const desc = theme.fg("dim", row.description);
-	const metrics = theme.fg(
-		"accent",
-		`ctx ${row.context} · ${row.tps} tps · ${row.model} · think ${row.thinking}`,
-	);
-	const meta = theme.fg("dim", ` · ${row.duration} · ${row.toolUses} tools`);
-	return `  ${status} ${name} ${desc} — ${metrics}${meta}`;
+	const identity = truncateToWidth(`  ${status} ${name} ${desc}`, width);
+	const metrics = [
+		theme.fg("accent", `ctx ${row.context}`),
+		theme.fg("accent", `tps ${row.tps}`),
+		theme.fg("accent", `model ${row.model}`),
+		theme.fg("accent", `think ${row.thinking}`),
+		theme.fg("dim", `${row.duration} · ${row.toolUses} tools`),
+	];
+	return [identity, ...wrapSegments(metrics, theme.fg("dim", " · "), "    ", width)];
+}
+
+function wrapSegments(segments: string[], separator: string, indent: string, width: number): string[] {
+	const lines: string[] = [];
+	let line = indent;
+
+	for (const segment of segments) {
+		const candidate = line === indent ? `${indent}${segment}` : `${line}${separator}${segment}`;
+		if (visibleWidth(candidate) <= width) {
+			line = candidate;
+			continue;
+		}
+		if (line !== indent) lines.push(line);
+		const standalone = `${indent}${segment}`;
+		if (visibleWidth(standalone) <= width) {
+			line = standalone;
+		} else {
+			lines.push(truncateToWidth(standalone, width));
+			line = indent;
+		}
+	}
+
+	if (line !== indent) lines.push(line);
+	return lines;
 }
 
 function statusToColor(status: string): "success" | "warning" | "error" | "dim" | "accent" {

--- a/extensions/subagents-pi/src/render.ts
+++ b/extensions/subagents-pi/src/render.ts
@@ -1,0 +1,82 @@
+import { truncateToWidth } from "@earendil-works/pi-tui";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { AgentMetricsRow } from "./store.js";
+
+const WIDGET_KEY = "subagents-pi-fleet";
+const MAX_LINES = 14;
+
+export { WIDGET_KEY };
+
+export function renderFleetLines(
+	theme: ExtensionContext["ui"]["theme"],
+	rows: AgentMetricsRow[],
+	options: { companionReady: boolean; enabled: boolean },
+	width: number,
+): string[] {
+	const safeWidth = Math.max(20, width);
+	if (!options.enabled) return [];
+
+	if (!options.companionReady) {
+		return [
+			theme.fg("warning", "subagents-pi: install @tintinweb/pi-subagents and /reload"),
+			theme.fg("dim", "  pi install npm:@tintinweb/pi-subagents"),
+		];
+	}
+
+	if (rows.length === 0) {
+		return [theme.fg("dim", "subagents-pi: no managed subagents in this session")];
+	}
+
+	const header = theme.bold(theme.fg("mdHeading", `Subagents (${rows.length})`));
+	const lines: string[] = [truncateToWidth(header, safeWidth)];
+
+	const displayRows = rows.slice(0, MAX_LINES);
+	for (const row of displayRows) {
+		lines.push(truncateToWidth(formatAgentLine(theme, row), safeWidth));
+	}
+
+	if (rows.length > MAX_LINES) {
+		lines.push(theme.fg("dim", truncateToWidth(`  … +${rows.length - MAX_LINES} more`, safeWidth)));
+	}
+
+	lines.push(
+		truncateToWidth(
+			theme.fg(
+				"dim",
+				"context · tps · model · thinking — /subagents-pi to toggle",
+			),
+			safeWidth,
+		),
+	);
+	return lines;
+}
+
+function formatAgentLine(theme: ExtensionContext["ui"]["theme"], row: AgentMetricsRow): string {
+	const statusColor = statusToColor(row.status);
+	const status = theme.fg(statusColor, row.status.padEnd(9));
+	const name = theme.fg("mdLink", row.type);
+	const desc = theme.fg("dim", row.description);
+	const metrics = theme.fg(
+		"accent",
+		`ctx ${row.context} · ${row.tps} tps · ${row.model} · think ${row.thinking}`,
+	);
+	const meta = theme.fg("dim", ` · ${row.duration} · ${row.toolUses} tools`);
+	return `  ${status} ${name} ${desc} — ${metrics}${meta}`;
+}
+
+function statusToColor(status: string): "success" | "warning" | "error" | "dim" | "accent" {
+	switch (status) {
+		case "running":
+			return "accent";
+		case "queued":
+			return "warning";
+		case "completed":
+			return "success";
+		case "error":
+		case "aborted":
+		case "stopped":
+			return "error";
+		default:
+			return "dim";
+	}
+}

--- a/extensions/subagents-pi/src/store.ts
+++ b/extensions/subagents-pi/src/store.ts
@@ -1,0 +1,129 @@
+import {
+	computeOutputTps,
+	formatContextLabel,
+	formatDurationMs,
+	formatModelLabel,
+	formatThinkingLevel,
+	formatTps,
+	getLifetimeTotal,
+	type LifetimeUsage,
+} from "./format.js";
+import { type AgentRecordSnapshot, getSubagentsRegistry } from "./registry.js";
+
+export interface AgentMetricsRow {
+	id: string;
+	type: string;
+	description: string;
+	status: string;
+	model: string;
+	thinking: string;
+	context: string;
+	tps: string;
+	duration: string;
+	toolUses: number;
+}
+
+export class SubagentMetricsStore {
+	private readonly trackedIds = new Set<string>();
+	private companionReady = false;
+
+	markCompanionReady(): void {
+		this.companionReady = true;
+	}
+
+	isCompanionReady(): boolean {
+		return this.companionReady;
+	}
+
+	reset(): void {
+		this.trackedIds.clear();
+		this.companionReady = false;
+	}
+
+	trackId(id: string): void {
+		if (id) this.trackedIds.add(id);
+	}
+
+	untrackId(id: string): void {
+		this.trackedIds.delete(id);
+	}
+
+	/** Keep finished agents visible briefly, then drop from the fleet view. */
+	pruneFinished(maxFinishedAgeMs = 30_000): void {
+		const registry = getSubagentsRegistry();
+		if (!registry) return;
+		const now = Date.now();
+		for (const id of [...this.trackedIds]) {
+			const record = registry.getRecord(id);
+			if (!record) {
+				this.trackedIds.delete(id);
+				continue;
+			}
+			if (record.status === "running" || record.status === "queued") continue;
+			const completedAt = record.completedAt ?? now;
+			if (now - completedAt > maxFinishedAgeMs) {
+				this.trackedIds.delete(id);
+			}
+		}
+	}
+
+	listRows(): AgentMetricsRow[] {
+		const registry = getSubagentsRegistry();
+		if (!registry) return [];
+
+		const rows: AgentMetricsRow[] = [];
+		for (const id of this.trackedIds) {
+			const record = registry.getRecord(id);
+			if (!record) continue;
+			try {
+				rows.push(buildRow(record));
+			} catch {
+				this.trackedIds.delete(id);
+			}
+		}
+
+		rows.sort((a, b) => {
+			const rank = (status: string) => (status === "running" ? 0 : status === "queued" ? 1 : 2);
+			const diff = rank(a.status) - rank(b.status);
+			if (diff !== 0) return diff;
+			return a.description.localeCompare(b.description);
+		});
+		return rows;
+	}
+
+	visibleCount(): number {
+		return this.listRows().length;
+	}
+}
+
+function buildRow(record: AgentRecordSnapshot): AgentMetricsRow {
+	const usage: LifetimeUsage = record.lifetimeUsage ?? { input: 0, output: 0, cacheWrite: 0 };
+	const totalTokens = getLifetimeTotal(usage);
+	let contextPercent: number | null | undefined;
+	try {
+		contextPercent = record.session?.getSessionStats().contextUsage?.percent ?? null;
+	} catch {
+		contextPercent = null;
+	}
+
+	const durationMs =
+		record.status === "running" || record.status === "queued"
+			? Math.max(0, Date.now() - record.startedAt)
+			: Math.max(0, (record.completedAt ?? Date.now()) - record.startedAt);
+
+	const tps =
+		record.status === "queued" ? undefined : computeOutputTps(usage.output, durationMs);
+
+	return {
+		id: record.id,
+		type: record.type,
+		description: record.description,
+		status: record.status,
+		model: formatModelLabel(record.invocation?.modelName, record.type),
+		thinking: formatThinkingLevel(record.invocation?.thinking),
+		context: formatContextLabel(totalTokens, contextPercent, record.compactionCount),
+		tps: formatTps(tps),
+		duration: formatDurationMs(durationMs),
+		toolUses: record.toolUses,
+	};
+}

--- a/extensions/subagents-pi/src/store.ts
+++ b/extensions/subagents-pi/src/store.ts
@@ -98,14 +98,18 @@ export class SubagentMetricsStore {
 
 function buildRow(record: AgentRecordSnapshot): AgentMetricsRow {
 	const usage: LifetimeUsage = record.lifetimeUsage ?? { input: 0, output: 0, cacheWrite: 0 };
-	const totalTokens = getLifetimeTotal(usage);
+	let totalTokens = getLifetimeTotal(usage);
 	let contextPercent: number | null | undefined;
 	try {
-		contextPercent = record.session?.getSessionStats().contextUsage?.percent ?? null;
+		const stats = record.session?.getSessionStats();
+		const sessionTokens = getSessionTokenTotal(stats?.tokens);
+		if (sessionTokens !== undefined) totalTokens = sessionTokens;
+		contextPercent = stats?.contextUsage?.percent ?? null;
 	} catch {
 		contextPercent = null;
 	}
 
+	const sessionModel = formatSessionModel(record.session?.model);
 	const durationMs =
 		record.status === "running" || record.status === "queued"
 			? Math.max(0, Date.now() - record.startedAt)
@@ -119,11 +123,35 @@ function buildRow(record: AgentRecordSnapshot): AgentMetricsRow {
 		type: record.type,
 		description: record.description,
 		status: record.status,
-		model: formatModelLabel(record.invocation?.modelName, record.type),
-		thinking: formatThinkingLevel(record.invocation?.thinking),
+		model: formatModelLabel(sessionModel ?? record.invocation?.modelName),
+		thinking: formatThinkingLevel(record.session?.thinkingLevel ?? record.invocation?.thinking),
 		context: formatContextLabel(totalTokens, contextPercent, record.compactionCount),
 		tps: formatTps(tps),
 		duration: formatDurationMs(durationMs),
 		toolUses: record.toolUses,
 	};
+}
+
+function formatSessionModel(model: { provider: string; id: string } | undefined): string | undefined {
+	const provider = model?.provider?.trim();
+	const id = model?.id?.trim();
+	if (!provider || !id) return undefined;
+	return `${provider}/${id}`;
+}
+
+function getSessionTokenTotal(
+	tokens:
+		| {
+				input: number;
+				output: number;
+				cacheRead?: number;
+				cacheWrite: number;
+				total?: number;
+		  }
+		| undefined,
+): number | undefined {
+	if (!tokens) return undefined;
+	if (Number.isFinite(tokens.total) && tokens.total! >= 0) return tokens.total;
+	const total = tokens.input + tokens.output + (tokens.cacheRead ?? 0) + tokens.cacheWrite;
+	return Number.isFinite(total) && total >= 0 ? total : undefined;
 }

--- a/extensions/subagents-pi/src/store.ts
+++ b/extensions/subagents-pi/src/store.ts
@@ -48,37 +48,38 @@ export class SubagentMetricsStore {
 		this.trackedIds.delete(id);
 	}
 
-	/** Keep finished agents visible briefly, then drop from the fleet view. */
-	pruneFinished(maxFinishedAgeMs = 30_000): void {
+	/** Drop tracked IDs only after their companion registry records disappear. */
+	pruneMissing(): void {
 		const registry = getSubagentsRegistry();
 		if (!registry) return;
+		for (const id of this.trackedIds) {
+			if (!registry.getRecord(id)) this.trackedIds.delete(id);
+		}
+	}
+
+	listRows(maxFinishedAgeMs = 30_000): AgentMetricsRow[] {
+		const registry = getSubagentsRegistry();
+		if (!registry) return [];
+
 		const now = Date.now();
-		for (const id of [...this.trackedIds]) {
+		const rows: AgentMetricsRow[] = [];
+		for (const id of this.trackedIds) {
 			const record = registry.getRecord(id);
 			if (!record) {
 				this.trackedIds.delete(id);
 				continue;
 			}
-			if (record.status === "running" || record.status === "queued") continue;
-			const completedAt = record.completedAt ?? now;
-			if (now - completedAt > maxFinishedAgeMs) {
-				this.trackedIds.delete(id);
+			if (
+				record.status !== "running" &&
+				record.status !== "queued" &&
+				now - (record.completedAt ?? now) > maxFinishedAgeMs
+			) {
+				continue;
 			}
-		}
-	}
-
-	listRows(): AgentMetricsRow[] {
-		const registry = getSubagentsRegistry();
-		if (!registry) return [];
-
-		const rows: AgentMetricsRow[] = [];
-		for (const id of this.trackedIds) {
-			const record = registry.getRecord(id);
-			if (!record) continue;
 			try {
 				rows.push(buildRow(record));
 			} catch {
-				this.trackedIds.delete(id);
+				continue;
 			}
 		}
 
@@ -102,8 +103,12 @@ function buildRow(record: AgentRecordSnapshot): AgentMetricsRow {
 	let contextPercent: number | null | undefined;
 	try {
 		const stats = record.session?.getSessionStats();
-		const sessionTokens = getSessionTokenTotal(stats?.tokens);
-		if (sessionTokens !== undefined) totalTokens = sessionTokens;
+		const contextTokens = stats?.contextUsage?.tokens;
+		const currentTokens =
+			typeof contextTokens === "number" && Number.isFinite(contextTokens) && contextTokens >= 0
+				? contextTokens
+				: getSessionTokenTotal(stats?.tokens);
+		if (currentTokens !== undefined) totalTokens = currentTokens;
 		contextPercent = stats?.contextUsage?.percent ?? null;
 	} catch {
 		contextPercent = null;

--- a/extensions/subagents-pi/src/store.ts
+++ b/extensions/subagents-pi/src/store.ts
@@ -57,23 +57,15 @@ export class SubagentMetricsStore {
 		}
 	}
 
-	listRows(maxFinishedAgeMs = 30_000): AgentMetricsRow[] {
+	listRows(): AgentMetricsRow[] {
 		const registry = getSubagentsRegistry();
 		if (!registry) return [];
 
-		const now = Date.now();
 		const rows: AgentMetricsRow[] = [];
 		for (const id of this.trackedIds) {
 			const record = registry.getRecord(id);
 			if (!record) {
 				this.trackedIds.delete(id);
-				continue;
-			}
-			if (
-				record.status !== "running" &&
-				record.status !== "queued" &&
-				now - (record.completedAt ?? now) > maxFinishedAgeMs
-			) {
 				continue;
 			}
 			try {
@@ -99,17 +91,23 @@ export class SubagentMetricsStore {
 
 function buildRow(record: AgentRecordSnapshot): AgentMetricsRow {
 	const usage: LifetimeUsage = record.lifetimeUsage ?? { input: 0, output: 0, cacheWrite: 0 };
-	let totalTokens = getLifetimeTotal(usage);
+	let totalTokens: number | undefined = getLifetimeTotal(usage);
 	let contextPercent: number | null | undefined;
 	try {
 		const stats = record.session?.getSessionStats();
-		const contextTokens = stats?.contextUsage?.tokens;
-		const currentTokens =
-			typeof contextTokens === "number" && Number.isFinite(contextTokens) && contextTokens >= 0
-				? contextTokens
-				: getSessionTokenTotal(stats?.tokens);
-		if (currentTokens !== undefined) totalTokens = currentTokens;
-		contextPercent = stats?.contextUsage?.percent ?? null;
+		const contextUsage = stats?.contextUsage;
+		if (contextUsage) {
+			const contextTokens = contextUsage.tokens;
+			totalTokens =
+				typeof contextTokens === "number" && Number.isFinite(contextTokens) && contextTokens >= 0
+					? contextTokens
+					: undefined;
+			contextPercent = contextUsage.percent;
+		} else {
+			const sessionTokens = getSessionTokenTotal(stats?.tokens);
+			if (sessionTokens !== undefined) totalTokens = sessionTokens;
+			contextPercent = null;
+		}
 	} catch {
 		contextPercent = null;
 	}

--- a/extensions/subagents-pi/test/format.test.mjs
+++ b/extensions/subagents-pi/test/format.test.mjs
@@ -20,6 +20,7 @@ describe("subagents-pi format", () => {
 
 	it("formats context with percent and compaction", () => {
 		assert.equal(formatContextLabel(33_800, 62, 2), "33.8k (62% · ⇊2)");
+		assert.equal(formatContextLabel(undefined, 62, 2), "— (62% · ⇊2)");
 	});
 
 	it("computes output TPS", () => {

--- a/extensions/subagents-pi/test/format.test.mjs
+++ b/extensions/subagents-pi/test/format.test.mjs
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+	computeOutputTps,
+	formatCompactTokenCount,
+	formatContextLabel,
+	formatTps,
+	getLifetimeTotal,
+} from "../dist/format.js";
+
+describe("subagents-pi format", () => {
+	it("sums lifetime usage", () => {
+		assert.equal(getLifetimeTotal({ input: 10, output: 20, cacheWrite: 5 }), 35);
+	});
+
+	it("formats compact token counts", () => {
+		assert.equal(formatCompactTokenCount(900), "900");
+		assert.equal(formatCompactTokenCount(12_400), "12.4k");
+	});
+
+	it("formats context with percent and compaction", () => {
+		assert.equal(formatContextLabel(33_800, 62, 2), "33.8k (62% · ⇊2)");
+	});
+
+	it("computes output TPS", () => {
+		const tps = computeOutputTps(100, 2000);
+		assert.ok(tps !== undefined && Math.abs(tps - 50) < 0.01);
+	});
+
+	it("formats TPS placeholder", () => {
+		assert.equal(formatTps(undefined), "—");
+		assert.equal(formatTps(42.3), "42.3");
+	});
+});

--- a/extensions/subagents-pi/test/index.test.mjs
+++ b/extensions/subagents-pi/test/index.test.mjs
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+import subagentsPiExtension from "../dist/index.js";
+
+const MANAGER_KEY = Symbol.for("pi-subagents:manager");
+
+function createEventBus() {
+	const listeners = new Map();
+	return {
+		emit(channel, data) {
+			for (const handler of [...(listeners.get(channel) ?? [])]) handler(data);
+		},
+		on(channel, handler) {
+			const handlers = listeners.get(channel) ?? new Set();
+			handlers.add(handler);
+			listeners.set(channel, handlers);
+			return () => handlers.delete(handler);
+		},
+		listenerCount(channel) {
+			return listeners.get(channel)?.size ?? 0;
+		},
+	};
+}
+
+function createHarness(records) {
+	const events = createEventBus();
+	const lifecycleHandlers = new Map();
+	const widgets = new Map();
+	const theme = {
+		bold: (text) => text,
+		fg: (_color, text) => text,
+	};
+	const ctx = {
+		hasUI: true,
+		ui: {
+			theme,
+			notify() {},
+			setStatus() {},
+			setWidget(key, widget) {
+				if (widget) widgets.set(key, widget);
+				else widgets.delete(key);
+			},
+		},
+	};
+	const pi = {
+		events,
+		on(name, handler) {
+			lifecycleHandlers.set(name, handler);
+		},
+		registerCommand() {},
+	};
+
+	globalThis[MANAGER_KEY] = {
+		getRecord: (id) => records.get(id),
+		hasRunning: () => [...records.values()].some((record) => record.status === "running"),
+	};
+
+	subagentsPiExtension(pi);
+	return { ctx, events, lifecycleHandlers, theme, widgets };
+}
+
+afterEach(() => {
+	delete globalThis[MANAGER_KEY];
+});
+
+describe("subagents-pi extension", () => {
+	it("tracks queued agents from scoped RPC replies and cleans reply listeners", async () => {
+		const record = {
+			id: "rpc-agent",
+			type: "general-purpose",
+			description: "RPC queued agent",
+			status: "queued",
+			toolUses: 0,
+			startedAt: Date.now(),
+			lifetimeUsage: { input: 0, output: 0, cacheWrite: 0 },
+			compactionCount: 0,
+		};
+		const records = new Map([[record.id, record]]);
+		const { ctx, events, lifecycleHandlers, theme, widgets } = createHarness(records);
+		await lifecycleHandlers.get("session_start")({}, ctx);
+
+		const requestId = "request-1";
+		const replyChannel = `subagents:rpc:spawn:reply:${requestId}`;
+		events.emit("subagents:rpc:spawn", { requestId });
+		assert.equal(events.listenerCount(replyChannel), 1);
+
+		events.emit(replyChannel, { success: true, data: { id: record.id } });
+		assert.equal(events.listenerCount(replyChannel), 0);
+
+		const widgetFactory = widgets.get("subagents-pi-fleet");
+		const widget = widgetFactory({ requestRender() {} }, theme);
+		assert.match(widget.render(120).join("\n"), /RPC queued agent/);
+
+		const pendingReplyChannel = "subagents:rpc:spawn:reply:request-2";
+		events.emit("subagents:rpc:spawn", { requestId: "request-2" });
+		assert.equal(events.listenerCount(pendingReplyChannel), 1);
+		await lifecycleHandlers.get("session_shutdown")();
+		assert.equal(events.listenerCount(pendingReplyChannel), 0);
+		assert.equal(events.listenerCount("subagents:rpc:spawn"), 0);
+	});
+});

--- a/extensions/subagents-pi/test/package.test.mjs
+++ b/extensions/subagents-pi/test/package.test.mjs
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { describe, it } from "node:test";
+
+const packageJson = JSON.parse(
+	await readFile(new URL("../package.json", import.meta.url), "utf8"),
+);
+
+describe("package manifest", () => {
+	it("ships the Pi source extension entry", () => {
+		assert.deepEqual(packageJson.pi.extensions, ["./src/index.ts"]);
+		assert.ok(packageJson.files.includes("src"));
+	});
+});

--- a/extensions/subagents-pi/test/render.test.mjs
+++ b/extensions/subagents-pi/test/render.test.mjs
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { stripVTControlCharacters } from "node:util";
+import { describe, it } from "node:test";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { renderFleetLines } from "../dist/render.js";
+
+const theme = {
+	bold: (text) => `\u001b[1m${text}\u001b[22m`,
+	fg: (_color, text) => `\u001b[36m${text}\u001b[39m`,
+};
+
+function row(index = 1) {
+	return {
+		id: `agent-${index}`,
+		type: `general-purpose-${index}`,
+		description: "Investigate a deliberately long task description without hiding metrics",
+		status: "running",
+		model: "openai-codex/gpt-5.5",
+		thinking: "high",
+		context: "12.4k (62% · ⇊2)",
+		tps: "42.3",
+		duration: "8.2s",
+		toolUses: 7,
+	};
+}
+
+function render(rows, width) {
+	return renderFleetLines(theme, rows, { companionReady: true, enabled: true }, width);
+}
+
+describe("renderFleetLines", () => {
+	for (const width of [80, 120]) {
+		it(`preserves required metrics within ${width} columns`, () => {
+			const lines = render([row()], width);
+			const text = stripVTControlCharacters(lines.join("\n"));
+
+			assert.match(text, /ctx 12\.4k \(62% · ⇊2\)/);
+			assert.match(text, /tps 42\.3/);
+			assert.match(text, /model openai-codex\/gpt-5\.5/);
+			assert.match(text, /think high/);
+			for (const line of lines) assert.ok(visibleWidth(line) <= width, `${visibleWidth(line)} > ${width}: ${line}`);
+		});
+	}
+
+	it("renders every managed subagent in fleets larger than fourteen", () => {
+		const rows = Array.from({ length: 16 }, (_, index) => row(index + 1));
+		const text = stripVTControlCharacters(render(rows, 80).join("\n"));
+
+		for (const agent of rows) assert.match(text, new RegExp(agent.type));
+		assert.doesNotMatch(text, /\+\d+ more/);
+	});
+});

--- a/extensions/subagents-pi/test/store.test.mjs
+++ b/extensions/subagents-pi/test/store.test.mjs
@@ -107,31 +107,49 @@ describe("SubagentMetricsStore", () => {
 		assert.equal(store.listRows()[0].context, "175 (8% · ⇊2)");
 	});
 
-	it("falls back to cumulative session tokens when the context estimate is unavailable", () => {
-		const records = new Map([
-			[
-				"fallback",
-				{
-					id: "fallback",
-					type: "Explore",
-					description: "Unavailable estimate",
-					status: "running",
-					toolUses: 0,
-					startedAt: Date.now() - 1000,
-					lifetimeUsage: { input: 500, output: 100, cacheWrite: 0 },
-					compactionCount: 0,
-					session: {
-						getSessionStats: () => ({
-							tokens: { input: 200, output: 40, cacheWrite: 0, total: 240 },
-							contextUsage: { tokens: null, contextWindow: 2000, percent: null },
-						}),
-					},
-				},
-			],
-		]);
-		mockRegistry(records);
+	it("shows context as unavailable when tokens are null after compaction", () => {
+		const record = {
+			id: "compacted-null",
+			type: "Explore",
+			description: "Unavailable estimate",
+			status: "running",
+			toolUses: 0,
+			startedAt: Date.now() - 1000,
+			lifetimeUsage: { input: 500, output: 100, cacheWrite: 0 },
+			compactionCount: 2,
+			session: {
+				getSessionStats: () => ({
+					tokens: { input: 200, output: 40, cacheWrite: 0, total: 240 },
+					contextUsage: { tokens: null, contextWindow: 2000, percent: 8 },
+				}),
+			},
+		};
+		mockRegistry(new Map([[record.id, record]]));
 		const store = new SubagentMetricsStore();
-		store.trackId("fallback");
+		store.trackId(record.id);
+
+		assert.equal(store.listRows()[0].context, "— (8% · ⇊2)");
+	});
+
+	it("falls back to cumulative session tokens for older stats without context usage", () => {
+		const record = {
+			id: "legacy",
+			type: "Explore",
+			description: "Older session stats",
+			status: "running",
+			toolUses: 0,
+			startedAt: Date.now() - 1000,
+			lifetimeUsage: { input: 500, output: 100, cacheWrite: 0 },
+			compactionCount: 0,
+			session: {
+				getSessionStats: () => ({
+					tokens: { input: 200, output: 40, cacheWrite: 0, total: 240 },
+				}),
+			},
+		};
+		mockRegistry(new Map([[record.id, record]]));
+		const store = new SubagentMetricsStore();
+		store.trackId(record.id);
 
 		assert.equal(store.listRows()[0].context, "240");
 	});
@@ -159,11 +177,11 @@ describe("SubagentMetricsStore", () => {
 		assert.equal(store.listRows()[0].model, "—");
 	});
 
-	it("hides old finished agents but shows them again when resumed", () => {
+	it("keeps finished agents visible until the registry removes them", () => {
 		const record = {
-			id: "resumed",
+			id: "finished",
 			type: "general-purpose",
-			description: "Resume later",
+			description: "Finished agent",
 			status: "completed",
 			toolUses: 1,
 			startedAt: Date.now() - 60_000,
@@ -177,11 +195,11 @@ describe("SubagentMetricsStore", () => {
 		store.trackId(record.id);
 
 		store.pruneMissing();
-		assert.equal(store.listRows().length, 0);
-
-		record.status = "running";
-		record.startedAt = Date.now();
 		assert.equal(store.listRows()[0].id, record.id);
+
+		records.delete(record.id);
+		store.pruneMissing();
+		assert.equal(store.listRows().length, 0);
 	});
 
 	it("reset clears tracked ids", () => {

--- a/extensions/subagents-pi/test/store.test.mjs
+++ b/extensions/subagents-pi/test/store.test.mjs
@@ -62,7 +62,7 @@ describe("SubagentMetricsStore", () => {
 						thinkingLevel: "high",
 						getSessionStats: () => ({
 							tokens: { input: 100, output: 20, cacheRead: 5, cacheWrite: 0, total: 125 },
-							contextUsage: { percent: 12 },
+							contextUsage: { tokens: 110, contextWindow: 1000, percent: 12 },
 						}),
 					},
 				},
@@ -78,7 +78,7 @@ describe("SubagentMetricsStore", () => {
 		assert.notEqual(row.model, row.type);
 	});
 
-	it("uses current session tokens instead of larger lifetime usage", () => {
+	it("uses the current context estimate instead of cumulative session tokens", () => {
 		const records = new Map([
 			[
 				"compacted",
@@ -94,7 +94,7 @@ describe("SubagentMetricsStore", () => {
 					session: {
 						getSessionStats: () => ({
 							tokens: { input: 200, output: 40, cacheRead: 10, cacheWrite: 0, total: 250 },
-							contextUsage: { percent: 8 },
+							contextUsage: { tokens: 175, contextWindow: 2000, percent: 8 },
 						}),
 					},
 				},
@@ -104,7 +104,36 @@ describe("SubagentMetricsStore", () => {
 		const store = new SubagentMetricsStore();
 		store.trackId("compacted");
 
-		assert.equal(store.listRows()[0].context, "250 (8% · ⇊2)");
+		assert.equal(store.listRows()[0].context, "175 (8% · ⇊2)");
+	});
+
+	it("falls back to cumulative session tokens when the context estimate is unavailable", () => {
+		const records = new Map([
+			[
+				"fallback",
+				{
+					id: "fallback",
+					type: "Explore",
+					description: "Unavailable estimate",
+					status: "running",
+					toolUses: 0,
+					startedAt: Date.now() - 1000,
+					lifetimeUsage: { input: 500, output: 100, cacheWrite: 0 },
+					compactionCount: 0,
+					session: {
+						getSessionStats: () => ({
+							tokens: { input: 200, output: 40, cacheWrite: 0, total: 240 },
+							contextUsage: { tokens: null, contextWindow: 2000, percent: null },
+						}),
+					},
+				},
+			],
+		]);
+		mockRegistry(records);
+		const store = new SubagentMetricsStore();
+		store.trackId("fallback");
+
+		assert.equal(store.listRows()[0].context, "240");
 	});
 
 	it("does not substitute the agent type for an unknown model", () => {
@@ -128,6 +157,31 @@ describe("SubagentMetricsStore", () => {
 		store.trackId("unknown");
 
 		assert.equal(store.listRows()[0].model, "—");
+	});
+
+	it("hides old finished agents but shows them again when resumed", () => {
+		const record = {
+			id: "resumed",
+			type: "general-purpose",
+			description: "Resume later",
+			status: "completed",
+			toolUses: 1,
+			startedAt: Date.now() - 60_000,
+			completedAt: Date.now() - 31_000,
+			lifetimeUsage: { input: 100, output: 20, cacheWrite: 0 },
+			compactionCount: 0,
+		};
+		const records = new Map([[record.id, record]]);
+		mockRegistry(records);
+		const store = new SubagentMetricsStore();
+		store.trackId(record.id);
+
+		store.pruneMissing();
+		assert.equal(store.listRows().length, 0);
+
+		record.status = "running";
+		record.startedAt = Date.now();
+		assert.equal(store.listRows()[0].id, record.id);
 	});
 
 	it("reset clears tracked ids", () => {

--- a/extensions/subagents-pi/test/store.test.mjs
+++ b/extensions/subagents-pi/test/store.test.mjs
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+import { SubagentMetricsStore } from "../dist/store.js";
+
+const MANAGER_KEY = Symbol.for("pi-subagents:manager");
+
+function mockRegistry(records) {
+	globalThis[MANAGER_KEY] = {
+		getRecord: (id) => records.get(id),
+		hasRunning: () => [...records.values()].some((r) => r.status === "running"),
+	};
+}
+
+afterEach(() => {
+	delete globalThis[MANAGER_KEY];
+});
+
+describe("SubagentMetricsStore", () => {
+	it("lists rows for tracked agents", () => {
+		const records = new Map([
+			[
+				"a1",
+				{
+					id: "a1",
+					type: "Explore",
+					description: "Find auth",
+					status: "running",
+					toolUses: 2,
+					startedAt: Date.now() - 5000,
+					lifetimeUsage: { input: 1, output: 100, cacheWrite: 0 },
+					compactionCount: 0,
+					invocation: { modelName: "haiku", thinking: "high" },
+				},
+			],
+		]);
+		mockRegistry(records);
+		const store = new SubagentMetricsStore();
+		store.markCompanionReady();
+		store.trackId("a1");
+		const rows = store.listRows();
+		assert.equal(rows.length, 1);
+		assert.equal(rows[0].model, "haiku");
+		assert.equal(rows[0].thinking, "high");
+		assert.equal(rows[0].context, "101");
+	});
+
+	it("reset clears tracked ids", () => {
+		mockRegistry(new Map());
+		const store = new SubagentMetricsStore();
+		store.trackId("x");
+		store.reset();
+		assert.equal(store.visibleCount(), 0);
+	});
+});

--- a/extensions/subagents-pi/test/store.test.mjs
+++ b/extensions/subagents-pi/test/store.test.mjs
@@ -44,6 +44,92 @@ describe("SubagentMetricsStore", () => {
 		assert.equal(rows[0].context, "101");
 	});
 
+	it("uses runtime model and thinking for invocation-less inherited sessions", () => {
+		const records = new Map([
+			[
+				"inherited",
+				{
+					id: "inherited",
+					type: "general-purpose",
+					description: "Use inherited defaults",
+					status: "running",
+					toolUses: 0,
+					startedAt: Date.now() - 1000,
+					lifetimeUsage: { input: 500, output: 50, cacheWrite: 0 },
+					compactionCount: 0,
+					session: {
+						model: { provider: "openai-codex", id: "gpt-5.5" },
+						thinkingLevel: "high",
+						getSessionStats: () => ({
+							tokens: { input: 100, output: 20, cacheRead: 5, cacheWrite: 0, total: 125 },
+							contextUsage: { percent: 12 },
+						}),
+					},
+				},
+			],
+		]);
+		mockRegistry(records);
+		const store = new SubagentMetricsStore();
+		store.trackId("inherited");
+
+		const [row] = store.listRows();
+		assert.equal(row.model, "openai-codex/gpt-5.5");
+		assert.equal(row.thinking, "high");
+		assert.notEqual(row.model, row.type);
+	});
+
+	it("uses current session tokens instead of larger lifetime usage", () => {
+		const records = new Map([
+			[
+				"compacted",
+				{
+					id: "compacted",
+					type: "Explore",
+					description: "Compacted session",
+					status: "running",
+					toolUses: 1,
+					startedAt: Date.now() - 1000,
+					lifetimeUsage: { input: 20_000, output: 5_000, cacheWrite: 1_000 },
+					compactionCount: 2,
+					session: {
+						getSessionStats: () => ({
+							tokens: { input: 200, output: 40, cacheRead: 10, cacheWrite: 0, total: 250 },
+							contextUsage: { percent: 8 },
+						}),
+					},
+				},
+			],
+		]);
+		mockRegistry(records);
+		const store = new SubagentMetricsStore();
+		store.trackId("compacted");
+
+		assert.equal(store.listRows()[0].context, "250 (8% · ⇊2)");
+	});
+
+	it("does not substitute the agent type for an unknown model", () => {
+		const records = new Map([
+			[
+				"unknown",
+				{
+					id: "unknown",
+					type: "general-purpose",
+					description: "Unknown model",
+					status: "queued",
+					toolUses: 0,
+					startedAt: Date.now(),
+					lifetimeUsage: { input: 0, output: 0, cacheWrite: 0 },
+					compactionCount: 0,
+				},
+			],
+		]);
+		mockRegistry(records);
+		const store = new SubagentMetricsStore();
+		store.trackId("unknown");
+
+		assert.equal(store.listRows()[0].model, "—");
+	});
+
 	it("reset clears tracked ids", () => {
 		mockRegistry(new Map());
 		const store = new SubagentMetricsStore();

--- a/extensions/subagents-pi/tsconfig.json
+++ b/extensions/subagents-pi/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
Closes #29

## Summary

Adds **subagents-pi**, a Pi extension that shows a below-editor fleet panel for subagents managed by `@tintinweb/pi-subagents`. Each row displays context usage, output TPS, model, and thinking level.

## Approach

**Balanced subagents-pi with shared metrics and rich panel** — integrate with the pi-subagents event bus and global agent registry rather than reimplementing orchestration.

## Decision Record

- **Root cause:** No dedicated subagent metrics extension existed in this repo; statusline-pi only covers the main session.
- **Options considered:** Option 1 — Minimal metrics panel; Option 2 — Balanced subagents-pi; Option 3 — Comprehensive native manager
- **Options rejected:** Option 1 — insufficient visualization; Option 3 — XL scope duplicates pi-subagents
- **Selected option:** Option 2 — Balanced subagents-pi with shared metrics and rich panel
- **Residual risk:** Fleet list tracks agents from lifecycle events after load; requires `@tintinweb/pi-subagents` for spawn/registry. Per-agent TPS is an output-token average, not live stream TPS.

Analyzed at: `feat/29-subagent-management-extension @ ba2a462` (2026-07-14)

## Changes

| File | Change |
|------|--------|
| `extensions/subagents-pi/` | New pi-package extension (widget, store, formatters, tests) |
| `README.md` | Feature blurb + not-on-npm note |
| `docs/DEVELOPMENT.md` | Included Extensions section |
| `docs/CHANGELOG.md` | Unreleased entry |

## Test Results

- Unit tests: 7 passed (`extensions/subagents-pi`)
- Integration tests: skipped (no repo runner)
- E2e tests: skipped
- Build: passed (`npm run build` in subagents-pi)
- QA cycles: 1

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Users can install and enable a dedicated Pi extension for managing subagents | pass | `extensions/subagents-pi/package.json` `pi.extensions`; `/subagents-pi` toggle |
| Extension provides a view containing every managed subagent | pass | `setWidget` below-editor fleet list in `src/index.ts` |
| Every displayed subagent includes context length, TPS, model, and thinking level | pass | `AgentMetricsRow` + `render.ts` per-row metrics |