### PR TITLE
fix(opencode-pi): preserve model capabilities and tool calls

### DIFF
--- a/extensions/opencode-pi/README.md
+++ b/extensions/opencode-pi/README.md
@@ -92,7 +92,7 @@ This queries `opencode models opencode --verbose`, parses each model's capabilit
 | Environment variable | Description                                                                                         |
 | -------------------- | --------------------------------------------------------------------------------------------------- |
 | `OPENCODE_PI_BIN`    | Override the OpenCode executable path. Defaults to `opencode`.                                      |
-| `OPENCODE_PI_MODELS` | Comma- or space-separated model list to register. Values without `/` are prefixed with `opencode/`; matching verbose metadata is used when available. |
+| `OPENCODE_PI_MODELS` | Comma- or space-separated model list to register. Values without `/` are prefixed with `opencode/`. Registers immediately with conservative fallback metadata (skipping verbose discovery so startup never pays a discovery timeout); run `/opencode-pi update` to enrich these models with real capabilities from verbose discovery. |
 
 Example:
 
@@ -120,6 +120,6 @@ This keeps file access and edits under Pi's normal tool pipeline. Temporary imag
 
 - This is a CLI bridge, not a native provider API. It is slower than direct HTTP providers because it starts `opencode run` for each model turn.
 - Tool calling is prompt-bridged. Marker parsing is deliberately strict for safety, but native tool-call providers can still be more reliable.
-- Image and reasoning support are advertised per model only when verbose discovery reports those capabilities. If discovery fails, configured/default IDs use conservative text-only, non-reasoning fallback metadata.
+- Image and reasoning support are advertised per model only when verbose discovery reports those capabilities. Models configured via `OPENCODE_PI_MODELS` start on conservative text-only, non-reasoning fallback metadata (no discovery call at startup) until `/opencode-pi update` runs discovery to enrich them; default (unconfigured) IDs fall back the same way if discovery fails.
 - Reasoning levels are exposed only for variants reported by OpenCode; models without variants do not claim selectable thinking levels.
 - If OpenCode ever attempts to use its own tools, the extension fails the turn instead of hiding it.

--- a/extensions/opencode-pi/README.md
+++ b/extensions/opencode-pi/README.md
@@ -22,7 +22,7 @@ It is intended for the free OpenCode models that work without `opencode auth log
 
 ```bash
 opencode --version
-opencode models opencode
+opencode models opencode --verbose
 ```
 
 No OpenCode login is required for the bundled free OpenCode models.
@@ -85,14 +85,14 @@ OpenCode changes its free model roster frequently. Refresh the registered models
 /opencode-pi update
 ```
 
-This queries `opencode models opencode`, updates the provider's model list, and shows how many new models were added. The status command also displays the timestamp of the last discovery.
+This queries `opencode models opencode --verbose`, parses each model's capabilities and limits, updates the provider's model list, and shows how many new models were added. Pi receives the discovered display name, reasoning and image capabilities, context window, and output limit. The status command also displays the timestamp of the last discovery.
 
 ## Configuration
 
 | Environment variable | Description                                                                                         |
 | -------------------- | --------------------------------------------------------------------------------------------------- |
 | `OPENCODE_PI_BIN`    | Override the OpenCode executable path. Defaults to `opencode`.                                      |
-| `OPENCODE_PI_MODELS` | Comma- or space-separated model list to register. Values without `/` are prefixed with `opencode/`. |
+| `OPENCODE_PI_MODELS` | Comma- or space-separated model list to register. Values without `/` are prefixed with `opencode/`; matching verbose metadata is used when available. |
 
 Example:
 
@@ -104,17 +104,22 @@ OPENCODE_PI_MODELS="opencode/deepseek-v4-flash-free,opencode/mimo-v2.5-free" pi
 
 For each Pi model call, the extension:
 
-1. Creates a temporary OpenCode project with a locked-down `pi-model` agent.
-2. Denies OpenCode's own tools (`bash`, `edit`, `read`, web tools, subagents, etc.).
-3. Sends Pi's current prompt/context to `opencode run --format json` over stdin.
-4. Streams the final OpenCode text back into Pi.
-5. Converts `<pi_tool_call>{...}</pi_tool_call>` markers into real Pi tool calls, so Pi executes tools rather than OpenCode.
+1. Discovers model metadata from the ID/JSON pairs printed by `opencode models opencode --verbose`.
+2. Creates a temporary OpenCode project with a locked-down `pi-model` agent.
+3. Denies OpenCode's own tools (`bash`, `edit`, `read`, web tools, subagents, etc.).
+4. Sends Pi's current prompt/context to `opencode run --format json` over stdin.
+5. Writes user and tool-result images to temporary files and adds one `--file` argument per image when the selected model advertises image input.
+6. Enables `--thinking` for reasoning models, maps supported Pi reasoning levels to discovered OpenCode variants, and converts reasoning JSON events into Pi thinking blocks.
+7. Converts marker-only `<pi_tool_call>{...}</pi_tool_call>` responses into real Pi tool calls, so Pi executes tools rather than OpenCode.
 
-This keeps file access and edits under Pi's normal tool pipeline.
+Tool markers are treated as control syntax only when the complete non-whitespace response consists of marker blocks. Plain JSON, quoted examples, mixed prose, malformed arguments, and tool names absent from the current Pi context are never executed. Tool-call IDs are retained in the serialized transcript so later results can be matched correctly.
+
+This keeps file access and edits under Pi's normal tool pipeline. Temporary image and agent files are removed after each turn.
 
 ## Notes and limitations
 
 - This is a CLI bridge, not a native provider API. It is slower than direct HTTP providers because it starts `opencode run` for each model turn.
-- Tool calling is prompt-bridged. It works for common cases, but native tool-call providers will be more reliable.
-- Image input is not registered; these models are exposed as text-only in Pi.
+- Tool calling is prompt-bridged. Marker parsing is deliberately strict for safety, but native tool-call providers can still be more reliable.
+- Image and reasoning support are advertised per model only when verbose discovery reports those capabilities. If discovery fails, configured/default IDs use conservative text-only, non-reasoning fallback metadata.
+- Reasoning levels are exposed only for variants reported by OpenCode; models without variants do not claim selectable thinking levels.
 - If OpenCode ever attempts to use its own tools, the extension fails the turn instead of hiding it.

--- a/extensions/opencode-pi/package-lock.json
+++ b/extensions/opencode-pi/package-lock.json
@@ -11,6 +11,9 @@
       "devDependencies": {
         "typescript": "^5.6.0"
       },
+      "engines": {
+        "node": ">=18"
+      },
       "peerDependencies": {
         "@earendil-works/pi-ai": "^0.75.4",
         "@earendil-works/pi-coding-agent": "^0.75.4"

--- a/extensions/opencode-pi/package.json
+++ b/extensions/opencode-pi/package.json
@@ -10,6 +10,7 @@
   ],
   "scripts": {
     "build": "tsc",
+    "test": "npm run build && node --test dist/index.test.js",
     "prepublishOnly": "npm run build"
   },
   "pi": {
@@ -27,6 +28,9 @@
   ],
   "author": "pi-extensions contributors",
   "license": "MIT",
+  "engines": {
+    "node": ">=18"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/luongnv89/pi-extensions.git"

--- a/extensions/opencode-pi/src/index.test.ts
+++ b/extensions/opencode-pi/src/index.test.ts
@@ -214,3 +214,11 @@ test("parseToolCalls rejects tool names absent from the current context", () => 
   const response = `<pi_tool_call>{"name":"bash","arguments":{"command":"pwd"}}</pi_tool_call>`;
   assert.deepEqual(parseToolCalls(response, new Set(["read"])), []);
 });
+
+test("parseToolCalls ignores marker-like text embedded inside JSON string arguments", () => {
+  const response = `<pi_tool_call>{"name":"bash","arguments":{"command":"echo '</pi_tool_call>'"}}</pi_tool_call>`;
+
+  assert.deepEqual(parseToolCalls(response, new Set(["bash"])), [
+    { name: "bash", arguments: { command: "echo '</pi_tool_call>'" } },
+  ]);
+});

--- a/extensions/opencode-pi/src/index.test.ts
+++ b/extensions/opencode-pi/src/index.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import type { Message } from "@earendil-works/pi-ai";
 import {
   imageContentsForModel,
+  isToolCallMarkerResponse,
   parseToolCalls,
   parseVerboseModels,
   reasoningCliArgs,
@@ -221,4 +222,18 @@ test("parseToolCalls ignores marker-like text embedded inside JSON string argume
   assert.deepEqual(parseToolCalls(response, new Set(["bash"])), [
     { name: "bash", arguments: { command: "echo '</pi_tool_call>'" } },
   ]);
+});
+
+test("isToolCallMarkerResponse detects a marker followed by trailing prose", () => {
+  const response = `<pi_tool_call>{"name":"bash","arguments":{"command":"pwd"}}</pi_tool_call> thanks!`;
+  assert.equal(isToolCallMarkerResponse(response), true);
+});
+
+test("isToolCallMarkerResponse detects leading prose followed by a marker", () => {
+  const response = `Sure, one moment: <pi_tool_call>{"name":"bash","arguments":{"command":"pwd"}}</pi_tool_call>`;
+  assert.equal(isToolCallMarkerResponse(response), true);
+});
+
+test("isToolCallMarkerResponse is false for plain text with no marker syntax", () => {
+  assert.equal(isToolCallMarkerResponse("Sure, here is the answer."), false);
 });

--- a/extensions/opencode-pi/src/index.test.ts
+++ b/extensions/opencode-pi/src/index.test.ts
@@ -49,6 +49,22 @@ function abortAfterFirstCheck(): AbortSignal {
   } as unknown as AbortSignal;
 }
 
+// Same idea as abortAfterFirstCheck, but reports not-aborted for the first
+// two reads (the pre-spawn check and the recheck after createTempAgentDir)
+// and aborted from the third read onward, so it deterministically lands the
+// abort in the async gap right after writeImageFiles instead.
+function abortAfterSecondCheck(): AbortSignal {
+  let calls = 0;
+  return {
+    get aborted() {
+      calls += 1;
+      return calls > 2;
+    },
+    addEventListener() {},
+    removeEventListener() {},
+  } as unknown as AbortSignal;
+}
+
 // process.env values are coerced to strings, so `process.env.X = undefined`
 // sets it to the literal string "undefined" instead of clearing it. Restore
 // via delete when the original value was unset.
@@ -66,6 +82,20 @@ function writeFakeOpencodeBinary(sentinelPath: string): string {
 const fs = require("node:fs");
 fs.writeFileSync(${JSON.stringify(sentinelPath)}, "ran");
 process.stdout.write(JSON.stringify({ type: "text", part: { text: "ok" } }) + "\\n");
+`,
+    "utf8",
+  );
+  chmodSync(binPath, 0o755);
+  return binPath;
+}
+
+function writeReasoningOnlyOpencodeBinary(): string {
+  const dir = mkdtempSync(join(tmpdir(), "opencode-pi-fake-bin-"));
+  const binPath = join(dir, "opencode-fake.js");
+  writeFileSync(
+    binPath,
+    `#!/usr/bin/env node
+process.stdout.write(JSON.stringify({ type: "reasoning", part: { text: "thinking it through" } }) + "\\n");
 `,
     "utf8",
   );
@@ -346,6 +376,49 @@ test("streamOpenCode spawns opencode and returns its output when not aborted", a
   } finally {
     restoreEnv("OPENCODE_PI_BIN", previousBin);
     rmSync(sentinelDir, { recursive: true, force: true });
+  }
+});
+
+test("streamOpenCode never spawns opencode when the signal aborts after image file setup", async () => {
+  const sentinelDir = mkdtempSync(join(tmpdir(), "opencode-pi-sentinel-"));
+  const sentinelPath = join(sentinelDir, "ran.marker");
+  const binPath = writeFakeOpencodeBinary(sentinelPath);
+  const previousBin = process.env.OPENCODE_PI_BIN;
+  process.env.OPENCODE_PI_BIN = binPath;
+
+  try {
+    const message = await streamOpenCode(fakeModel(), fakeContext(), {
+      signal: abortAfterSecondCheck(),
+    }).result();
+
+    assert.equal(message.stopReason, "aborted");
+    assert.equal(existsSync(sentinelPath), false);
+  } finally {
+    restoreEnv("OPENCODE_PI_BIN", previousBin);
+    rmSync(sentinelDir, { recursive: true, force: true });
+  }
+});
+
+test("streamOpenCode succeeds when opencode emits reasoning-only output with no text or tool calls", async () => {
+  const previousBin = process.env.OPENCODE_PI_BIN;
+  const binPath = writeReasoningOnlyOpencodeBinary();
+  process.env.OPENCODE_PI_BIN = binPath;
+
+  try {
+    const message = await streamOpenCode(fakeModel(), fakeContext()).result();
+
+    assert.equal(message.stopReason, "stop");
+    assert.equal(message.errorMessage, undefined);
+    const thinkingBlock = message.content.find(
+      (block) => block.type === "thinking",
+    );
+    assert.equal(thinkingBlock?.thinking, "thinking it through");
+    assert.equal(
+      message.content.some((block) => block.type === "text"),
+      false,
+    );
+  } finally {
+    restoreEnv("OPENCODE_PI_BIN", previousBin);
   }
 });
 

--- a/extensions/opencode-pi/src/index.test.ts
+++ b/extensions/opencode-pi/src/index.test.ts
@@ -1,0 +1,216 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { Message } from "@earendil-works/pi-ai";
+import {
+  imageContentsForModel,
+  parseToolCalls,
+  parseVerboseModels,
+  reasoningCliArgs,
+} from "./index.js";
+
+test("parseVerboseModels normalizes capabilities, limits, and variants", () => {
+  const output = `opencode/vision-reasoner-free
+{
+  "id": "vision-reasoner-free",
+  "name": "Vision Reasoner",
+  "cost": { "input": 99, "output": 99 },
+  "limit": { "context": 200000, "output": 32000 },
+  "capabilities": {
+    "reasoning": true,
+    "input": { "text": true, "image": true }
+  },
+  "variants": {
+    "none": { "reasoningEffort": "none" },
+    "low": { "reasoningEffort": "low" },
+    "high": { "reasoningEffort": "high" },
+    "max": { "reasoningEffort": "max" }
+  }
+}
+opencode/text-free
+{
+  "id": "text-free",
+  "name": "Text {Free}",
+  "limit": { "context": 64000, "output": 4096 },
+  "capabilities": {
+    "reasoning": false,
+    "input": { "text": true, "image": false }
+  },
+  "variants": {}
+}
+`;
+
+  assert.deepEqual(parseVerboseModels(output), [
+    {
+      id: "opencode/vision-reasoner-free",
+      name: "Vision Reasoner",
+      reasoning: true,
+      image: true,
+      contextWindow: 200000,
+      maxTokens: 32000,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      thinkingLevelMap: {
+        off: "none",
+        minimal: null,
+        low: "low",
+        medium: null,
+        high: "high",
+        xhigh: "max",
+      },
+    },
+    {
+      id: "opencode/text-free",
+      name: "Text {Free}",
+      reasoning: false,
+      image: false,
+      contextWindow: 64000,
+      maxTokens: 4096,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    },
+  ]);
+});
+
+test("parseVerboseModels maps an OpenCode off variant to Pi off", () => {
+  const output = `opencode/reasoner-free
+{
+  "capabilities": { "reasoning": true },
+  "variants": { "off": {}, "medium": {} }
+}
+`;
+
+  assert.deepEqual(parseVerboseModels(output)[0]?.thinkingLevelMap, {
+    off: "off",
+    minimal: null,
+    low: null,
+    medium: "medium",
+    high: null,
+    xhigh: null,
+  });
+});
+
+test("reasoningCliArgs respects off, selected levels, and provider defaults", () => {
+  const map = { off: "none", low: "low" } as const;
+
+  assert.deepEqual(reasoningCliArgs("off", map), []);
+  assert.deepEqual(reasoningCliArgs("low", map), [
+    "--thinking",
+    "--variant",
+    "low",
+  ]);
+  assert.deepEqual(reasoningCliArgs(undefined, map), []);
+  assert.deepEqual(reasoningCliArgs("high", map), ["--thinking"]);
+});
+
+test("imageContentsForModel omits historical images for text-only models", () => {
+  const historicalImage = {
+    type: "image" as const,
+    mimeType: "image/png",
+    data: "AAAA",
+  };
+  const messages: Message[] = [
+    {
+      role: "user",
+      content: [historicalImage],
+      timestamp: 1,
+    },
+    {
+      role: "user",
+      content: "Continue without re-sending the old image",
+      timestamp: 2,
+    },
+  ];
+
+  assert.deepEqual(imageContentsForModel(messages, false), []);
+  assert.deepEqual(imageContentsForModel(messages, true), [historicalImage]);
+});
+
+test("parseVerboseModels skips malformed metadata and uses safe defaults", () => {
+  const output = `opencode/broken-free
+{not json}
+opencode/custom-free
+{
+  "capabilities": { "reasoning": true, "input": {} },
+  "variants": {}
+}
+`;
+
+  assert.deepEqual(parseVerboseModels(output), [
+    {
+      id: "opencode/custom-free",
+      name: "OpenCode custom-free",
+      reasoning: true,
+      image: false,
+      contextWindow: 128000,
+      maxTokens: 16384,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      thinkingLevelMap: {
+        minimal: null,
+        low: null,
+        medium: null,
+        high: null,
+        xhigh: null,
+      },
+    },
+  ]);
+});
+
+test("parseToolCalls accepts complete marker-only responses", () => {
+  const response = `
+<pi_tool_call>{"name":"read","arguments":{"path":"README.md"}}</pi_tool_call>
+<pi_tool_call>{"name":"bash","arguments":{"command":"pwd"}}</pi_tool_call>
+`;
+
+  assert.deepEqual(parseToolCalls(response, new Set(["read", "bash"])), [
+    { name: "read", arguments: { path: "README.md" } },
+    { name: "bash", arguments: { command: "pwd" } },
+  ]);
+});
+
+test("parseToolCalls rejects all calls when any marker payload is malformed", () => {
+  const response = `
+<pi_tool_call>{"name":"read","arguments":{"path":"README.md"}}</pi_tool_call>
+<pi_tool_call>{not json}</pi_tool_call>
+`;
+
+  assert.deepEqual(parseToolCalls(response, new Set(["read"])), []);
+});
+
+test("parseToolCalls rejects all calls when any candidate has invalid arguments", () => {
+  const response = `<pi_tool_call>[
+    {"name":"read","arguments":{"path":"README.md"}},
+    {"name":"read","arguments":[]}
+  ]</pi_tool_call>`;
+
+  assert.deepEqual(parseToolCalls(response, new Set(["read"])), []);
+});
+
+test("parseToolCalls supports nested function calls and JSON-string arguments", () => {
+  const response = `<pi_tool_call>{"tool_calls":[{"type":"function","function":{"name":"read","arguments":"{\\"path\\":\\"src/index.ts\\"}"}}]}</pi_tool_call>`;
+
+  assert.deepEqual(parseToolCalls(response, new Set(["read"])), [
+    { name: "read", arguments: { path: "src/index.ts" } },
+  ]);
+});
+
+test("parseToolCalls never treats plain JSON or mixed prose as control syntax", () => {
+  assert.deepEqual(
+    parseToolCalls('{"name":"bash","arguments":{"command":"pwd"}}'),
+    [],
+  );
+  assert.deepEqual(
+    parseToolCalls(
+      'Example: <pi_tool_call>{"name":"bash","arguments":{"command":"pwd"}}</pi_tool_call>',
+    ),
+    [],
+  );
+  assert.deepEqual(
+    parseToolCalls(
+      '"<pi_tool_call>{\\"name\\":\\"bash\\",\\"arguments\\":{}}</pi_tool_call>"',
+    ),
+    [],
+  );
+});
+
+test("parseToolCalls rejects tool names absent from the current context", () => {
+  const response = `<pi_tool_call>{"name":"bash","arguments":{"command":"pwd"}}</pi_tool_call>`;
+  assert.deepEqual(parseToolCalls(response, new Set(["read"])), []);
+});

--- a/extensions/opencode-pi/src/index.test.ts
+++ b/extensions/opencode-pi/src/index.test.ts
@@ -1,13 +1,77 @@
 import assert from "node:assert/strict";
+import { chmodSync, existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
-import type { Message } from "@earendil-works/pi-ai";
+import type { Api, Context, Message, Model } from "@earendil-works/pi-ai";
 import {
+  discoverModels,
   imageContentsForModel,
   isToolCallMarkerResponse,
   parseToolCalls,
   parseVerboseModels,
   reasoningCliArgs,
+  streamOpenCode,
 } from "./index.js";
+
+function fakeModel(): Model<Api> {
+  return {
+    id: "opencode/fake-free",
+    name: "Fake",
+    api: "opencode-cli-runner",
+    provider: "opencode-cli",
+    baseUrl: "",
+    reasoning: false,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 128_000,
+    maxTokens: 16_384,
+  };
+}
+
+function fakeContext(): Context {
+  return { messages: [] };
+}
+
+// A fake AbortSignal that reports not-aborted on its first read (mirroring the
+// pre-spawn check at the top of streamOpenCode) and aborted on every read
+// after that, so it deterministically simulates an abort landing in the
+// async gap right after the first check without racing real timers.
+function abortAfterFirstCheck(): AbortSignal {
+  let calls = 0;
+  return {
+    get aborted() {
+      calls += 1;
+      return calls > 1;
+    },
+    addEventListener() {},
+    removeEventListener() {},
+  } as unknown as AbortSignal;
+}
+
+// process.env values are coerced to strings, so `process.env.X = undefined`
+// sets it to the literal string "undefined" instead of clearing it. Restore
+// via delete when the original value was unset.
+function restoreEnv(key: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[key];
+  else process.env[key] = value;
+}
+
+function writeFakeOpencodeBinary(sentinelPath: string): string {
+  const dir = mkdtempSync(join(tmpdir(), "opencode-pi-fake-bin-"));
+  const binPath = join(dir, "opencode-fake.js");
+  writeFileSync(
+    binPath,
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+fs.writeFileSync(${JSON.stringify(sentinelPath)}, "ran");
+process.stdout.write(JSON.stringify({ type: "text", part: { text: "ok" } }) + "\\n");
+`,
+    "utf8",
+  );
+  chmodSync(binPath, 0o755);
+  return binPath;
+}
 
 test("parseVerboseModels normalizes capabilities, limits, and variants", () => {
   const output = `opencode/vision-reasoner-free
@@ -236,4 +300,149 @@ test("isToolCallMarkerResponse detects leading prose followed by a marker", () =
 
 test("isToolCallMarkerResponse is false for plain text with no marker syntax", () => {
   assert.equal(isToolCallMarkerResponse("Sure, here is the answer."), false);
+});
+
+test("isToolCallMarkerResponse is false for a lone closing marker with no opening marker", () => {
+  const response =
+    "The bridge closes tool calls with a literal `</pi_tool_call>` tag.";
+  assert.equal(isToolCallMarkerResponse(response), false);
+});
+
+test("streamOpenCode never spawns opencode when the signal aborts before the child is launched", async () => {
+  const sentinelDir = mkdtempSync(join(tmpdir(), "opencode-pi-sentinel-"));
+  const sentinelPath = join(sentinelDir, "ran.marker");
+  const binPath = writeFakeOpencodeBinary(sentinelPath);
+  const previousBin = process.env.OPENCODE_PI_BIN;
+  process.env.OPENCODE_PI_BIN = binPath;
+
+  try {
+    const message = await streamOpenCode(fakeModel(), fakeContext(), {
+      signal: abortAfterFirstCheck(),
+    }).result();
+
+    assert.equal(message.stopReason, "aborted");
+    assert.equal(existsSync(sentinelPath), false);
+  } finally {
+    restoreEnv("OPENCODE_PI_BIN", previousBin);
+    rmSync(sentinelDir, { recursive: true, force: true });
+  }
+});
+
+test("streamOpenCode spawns opencode and returns its output when not aborted", async () => {
+  const sentinelDir = mkdtempSync(join(tmpdir(), "opencode-pi-sentinel-"));
+  const sentinelPath = join(sentinelDir, "ran.marker");
+  const binPath = writeFakeOpencodeBinary(sentinelPath);
+  const previousBin = process.env.OPENCODE_PI_BIN;
+  process.env.OPENCODE_PI_BIN = binPath;
+
+  try {
+    const message = await streamOpenCode(
+      fakeModel(),
+      fakeContext(),
+    ).result();
+
+    assert.equal(existsSync(sentinelPath), true);
+    assert.equal(message.stopReason, "stop");
+  } finally {
+    restoreEnv("OPENCODE_PI_BIN", previousBin);
+    rmSync(sentinelDir, { recursive: true, force: true });
+  }
+});
+
+test("discoverModels bypasses opencode discovery when OPENCODE_PI_MODELS is set", async () => {
+  const sentinelDir = mkdtempSync(join(tmpdir(), "opencode-pi-sentinel-"));
+  const sentinelPath = join(sentinelDir, "ran.marker");
+  const binPath = writeFakeOpencodeBinary(sentinelPath);
+  const previousBin = process.env.OPENCODE_PI_BIN;
+  const previousModels = process.env.OPENCODE_PI_MODELS;
+  process.env.OPENCODE_PI_BIN = binPath;
+  process.env.OPENCODE_PI_MODELS = "custom-model-a, opencode/custom-model-b";
+
+  try {
+    const { models, error } = await discoverModels();
+
+    assert.equal(existsSync(sentinelPath), false);
+    assert.equal(error, undefined);
+    assert.deepEqual(
+      models.map((model) => model.id),
+      ["opencode/custom-model-a", "opencode/custom-model-b"],
+    );
+  } finally {
+    restoreEnv("OPENCODE_PI_BIN", previousBin);
+    restoreEnv("OPENCODE_PI_MODELS", previousModels);
+    rmSync(sentinelDir, { recursive: true, force: true });
+  }
+});
+
+test("discoverModels runs opencode discovery and filters to free models when OPENCODE_PI_MODELS is unset", async () => {
+  const previousModels = process.env.OPENCODE_PI_MODELS;
+  const previousBin = process.env.OPENCODE_PI_BIN;
+  delete process.env.OPENCODE_PI_MODELS;
+  const dir = mkdtempSync(join(tmpdir(), "opencode-pi-fake-bin-"));
+  const binPath = join(dir, "opencode-fake.js");
+  writeFileSync(
+    binPath,
+    `#!/usr/bin/env node
+process.stdout.write([
+  "opencode/one-free",
+  JSON.stringify({ capabilities: { reasoning: true, input: { image: true } } }),
+  "opencode/two-paid",
+  JSON.stringify({ capabilities: {} }),
+].join("\\n"));
+`,
+    "utf8",
+  );
+  chmodSync(binPath, 0o755);
+  process.env.OPENCODE_PI_BIN = binPath;
+
+  try {
+    const { models, error } = await discoverModels();
+
+    assert.equal(error, undefined);
+    assert.deepEqual(
+      models.map((model) => model.id),
+      ["opencode/one-free"],
+    );
+  } finally {
+    restoreEnv("OPENCODE_PI_BIN", previousBin);
+    restoreEnv("OPENCODE_PI_MODELS", previousModels);
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("discoverModels with forceDiscovery still enriches configured models from opencode metadata", async () => {
+  const previousModels = process.env.OPENCODE_PI_MODELS;
+  const previousBin = process.env.OPENCODE_PI_BIN;
+  process.env.OPENCODE_PI_MODELS = "custom-reasoner-free";
+  const dir = mkdtempSync(join(tmpdir(), "opencode-pi-fake-bin-"));
+  const binPath = join(dir, "opencode-fake.js");
+  writeFileSync(
+    binPath,
+    `#!/usr/bin/env node
+process.stdout.write([
+  "opencode/custom-reasoner-free",
+  JSON.stringify({
+    capabilities: { reasoning: true, input: { image: true } },
+    variants: { off: {}, high: {} },
+  }),
+].join("\\n"));
+`,
+    "utf8",
+  );
+  chmodSync(binPath, 0o755);
+  process.env.OPENCODE_PI_BIN = binPath;
+
+  try {
+    const { models, error } = await discoverModels({ forceDiscovery: true });
+
+    assert.equal(error, undefined);
+    assert.equal(models.length, 1);
+    assert.equal(models[0]?.id, "opencode/custom-reasoner-free");
+    assert.equal(models[0]?.reasoning, true);
+    assert.equal(models[0]?.image, true);
+  } finally {
+    restoreEnv("OPENCODE_PI_BIN", previousBin);
+    restoreEnv("OPENCODE_PI_MODELS", previousModels);
+    rmSync(dir, { recursive: true, force: true });
+  }
 });

--- a/extensions/opencode-pi/src/index.ts
+++ b/extensions/opencode-pi/src/index.ts
@@ -269,12 +269,30 @@ function runCapture(
   });
 }
 
-async function discoverModels(): Promise<{
+export async function discoverModels(opts?: {
+  forceDiscovery?: boolean;
+}): Promise<{
   models: OpenCodeModelInfo[];
   time: number;
   error: string | undefined;
 }> {
   const configured = configuredModels();
+  // An explicit OPENCODE_PI_MODELS list already tells us exactly which
+  // models to register, so the fast (non-forced) path skips spawning
+  // opencode entirely rather than making explicitly configured users pay a
+  // discovery timeout on every startup when the binary is missing or slow.
+  // `forceDiscovery` (used by the user-initiated /opencode-pi update
+  // command) still runs discovery so configured models can be enriched with
+  // real capability metadata (reasoning/image/limits) on request.
+  if (configured?.length && !opts?.forceDiscovery) {
+    lastDiscoveryError = undefined;
+    return {
+      models: dedupe(configured).map(fallbackModel),
+      time: Date.now(),
+      error: undefined,
+    };
+  }
+
   try {
     const result = await runCapture(["models", "opencode", "--verbose"]);
     if (result.code !== 0) {
@@ -316,7 +334,9 @@ async function refreshModels(
   ctx: { ui: { notify: (msg: string, level?: string) => void } },
 ): Promise<void> {
   const previousModels = new Set(registeredModels.map((model) => model.id));
-  const { models, time, error } = await discoverModels();
+  const { models, time, error } = await discoverModels({
+    forceDiscovery: true,
+  });
   registeredModels = models;
   lastDiscoveryTime = time;
 
@@ -544,9 +564,14 @@ const MARKER_CLOSE = "</pi_tool_call>";
 // is. A one-sided check let malformed leading prose silently leak raw
 // marker text into the visible chat response while malformed trailing prose
 // hard-failed the turn.
+//
+// Requires the opening marker specifically: a response can only be
+// *attempting* a tool call if it emits the open tag. A lone closing marker
+// (e.g. prose that merely quotes or discusses `</pi_tool_call>`) is not a
+// plausible tool-call attempt and must not hard-fail the turn.
 export function isToolCallMarkerResponse(text: string): boolean {
   const trimmed = text.trim();
-  return trimmed.includes(MARKER_OPEN) || trimmed.includes(MARKER_CLOSE);
+  return trimmed.includes(MARKER_OPEN);
 }
 
 // A closing marker inside a JSON string (e.g. tool arguments that happen to
@@ -736,7 +761,7 @@ You are the OpenCode side of a Pi Coding Agent bridge. OpenCode tools are disabl
   return dir;
 }
 
-function streamOpenCode(
+export function streamOpenCode(
   model: Model<Api>,
   context: Context,
   options?: SimpleStreamOptions,
@@ -772,11 +797,13 @@ function streamOpenCode(
       if (options?.signal?.aborted) throw new Error("Request was aborted");
 
       tempDir = await createTempAgentDir();
+      if (options?.signal?.aborted) throw new Error("Request was aborted");
       const images = imageContentsForModel(
         context.messages,
         model.input.includes("image"),
       );
       const imagePaths = await writeImageFiles(images, tempDir);
+      if (options?.signal?.aborted) throw new Error("Request was aborted");
       const args = [
         "run",
         "--pure",

--- a/extensions/opencode-pi/src/index.ts
+++ b/extensions/opencode-pi/src/index.ts
@@ -539,20 +539,52 @@ function isToolCallMarkerResponse(text: string): boolean {
   return /^<\/?pi_tool_call(?:>|$)/.test(text.trim());
 }
 
+const MARKER_OPEN = "<pi_tool_call>";
+const MARKER_CLOSE = "</pi_tool_call>";
+
+// A closing marker inside a JSON string (e.g. tool arguments that happen to
+// contain the literal text "</pi_tool_call>") must not be treated as the
+// real boundary, so this walks the JSON string-escaping state rather than
+// matching the close tag with a plain regex.
+function findMarkerClose(text: string, from: number): number {
+  let inString = false;
+  let escaped = false;
+  for (let i = from; i < text.length; i++) {
+    const char = text[i];
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (char === "\\") escaped = true;
+      else if (char === '"') inString = false;
+      continue;
+    }
+    if (char === '"') {
+      inString = true;
+      continue;
+    }
+    if (text.startsWith(MARKER_CLOSE, i)) return i;
+  }
+  return -1;
+}
+
 function toolCallMarkerBodies(text: string): string[] | undefined {
   const trimmed = text.trim();
-  const tagRegex = /<pi_tool_call>([\s\S]*?)<\/pi_tool_call>/g;
-  const matches = [...trimmed.matchAll(tagRegex)];
-  if (matches.length === 0) return undefined;
-
+  const bodies: string[] = [];
   let cursor = 0;
-  for (const match of matches) {
-    const index = match.index ?? 0;
-    if (trimmed.slice(cursor, index).trim()) return undefined;
-    cursor = index + match[0].length;
+  while (cursor < trimmed.length) {
+    const openIndex = trimmed.indexOf(MARKER_OPEN, cursor);
+    if (openIndex === -1) break;
+    if (trimmed.slice(cursor, openIndex).trim()) return undefined;
+
+    const bodyStart = openIndex + MARKER_OPEN.length;
+    const closeIndex = findMarkerClose(trimmed, bodyStart);
+    if (closeIndex === -1) return undefined;
+
+    bodies.push(trimmed.slice(bodyStart, closeIndex));
+    cursor = closeIndex + MARKER_CLOSE.length;
   }
+  if (bodies.length === 0) return undefined;
   if (trimmed.slice(cursor).trim()) return undefined;
-  return matches.map((match) => match[1] ?? "");
+  return bodies;
 }
 
 export function parseToolCalls(

--- a/extensions/opencode-pi/src/index.ts
+++ b/extensions/opencode-pi/src/index.ts
@@ -14,8 +14,10 @@ import {
   type ImageContent,
   type Message,
   type Model,
+  type ModelThinkingLevel,
   type SimpleStreamOptions,
   type TextContent,
+  type ThinkingLevelMap,
   type Tool,
   type ToolCall,
 } from "@earendil-works/pi-ai";
@@ -34,8 +36,33 @@ const DEFAULT_FREE_MODELS = [
   "opencode/nemotron-3-super-free",
   "opencode/big-pickle",
 ];
+const ZERO_COST = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 } as const;
+const THINKING_LEVELS = [
+  "off",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+] as const satisfies readonly ModelThinkingLevel[];
 
-let registeredModels: string[] = [];
+export type OpenCodeModelInfo = {
+  id: string;
+  name: string;
+  reasoning: boolean;
+  image: boolean;
+  contextWindow: number;
+  maxTokens: number;
+  cost: typeof ZERO_COST;
+  thinkingLevelMap?: ThinkingLevelMap;
+};
+
+export type ParsedToolCall = {
+  name: string;
+  arguments: Record<string, unknown>;
+};
+
+let registeredModels: OpenCodeModelInfo[] = [];
 let lastDiscoveryTime: number | undefined;
 let lastDiscoveryError: string | undefined;
 
@@ -74,6 +101,131 @@ function looksFree(model: string): boolean {
 
 function dedupe(values: string[]): string[] {
   return [...new Set(values)];
+}
+
+function fallbackModel(id: string): OpenCodeModelInfo {
+  return {
+    id,
+    name: modelDisplayName(id),
+    reasoning: false,
+    image: false,
+    contextWindow: contextWindowFor(id),
+    maxTokens: maxTokensFor(id),
+    cost: ZERO_COST,
+  };
+}
+
+function positiveNumber(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? value
+    : fallback;
+}
+
+function thinkingLevelMap(variants: unknown): ThinkingLevelMap {
+  const map: ThinkingLevelMap = {};
+  const names =
+    typeof variants === "object" && variants !== null && !Array.isArray(variants)
+      ? new Set(Object.keys(variants))
+      : new Set<string>();
+
+  for (const level of THINKING_LEVELS) {
+    if (level === "off") {
+      if (names.has("off")) map.off = "off";
+      else if (names.has("none")) map.off = "none";
+      continue;
+    }
+    map[level] = names.has(level) ? level : null;
+  }
+  if (!names.has("xhigh") && names.has("max")) map.xhigh = "max";
+  return map;
+}
+
+export function reasoningCliArgs(
+  requestedReasoning: ModelThinkingLevel | undefined,
+  map?: ThinkingLevelMap,
+): string[] {
+  if (!requestedReasoning || requestedReasoning === "off") return [];
+
+  const args = ["--thinking"];
+  const variant = map?.[requestedReasoning];
+  if (typeof variant === "string" && variant.trim()) {
+    args.push("--variant", variant);
+  }
+  return args;
+}
+
+function findJsonObjectEnd(text: string, start: number): number | undefined {
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let index = start; index < text.length; index += 1) {
+    const character = text[index];
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (character === "\\") escaped = true;
+      else if (character === '"') inString = false;
+      continue;
+    }
+    if (character === '"') inString = true;
+    else if (character === "{") depth += 1;
+    else if (character === "}") {
+      depth -= 1;
+      if (depth === 0) return index + 1;
+    }
+  }
+  return undefined;
+}
+
+/** Parse the `model-id` + pretty-printed JSON pairs from OpenCode verbose discovery. */
+export function parseVerboseModels(output: string): OpenCodeModelInfo[] {
+  const records = new Map<string, OpenCodeModelInfo>();
+  const idPattern = /^opencode\/[^\s]+\s*$/gm;
+  for (const match of output.matchAll(idPattern)) {
+    const id = match[0].trim();
+    const metadataStart = (match.index ?? 0) + match[0].length;
+    const objectStart = output.indexOf("{", metadataStart);
+    if (objectStart < 0) continue;
+
+    const nextId = output.slice(metadataStart).search(/^opencode\/[^\s]+\s*$/m);
+    if (nextId >= 0 && objectStart >= metadataStart + nextId) continue;
+    const objectEnd = findJsonObjectEnd(output, objectStart);
+    if (objectEnd === undefined) continue;
+
+    let metadata: unknown;
+    try {
+      metadata = JSON.parse(output.slice(objectStart, objectEnd));
+    } catch {
+      continue;
+    }
+    if (typeof metadata !== "object" || metadata === null) continue;
+
+    const value = metadata as {
+      name?: unknown;
+      limit?: { context?: unknown; output?: unknown };
+      capabilities?: { reasoning?: unknown; input?: { image?: unknown } };
+      variants?: unknown;
+    };
+    const reasoning = value.capabilities?.reasoning === true;
+    records.set(id, {
+      id,
+      name:
+        typeof value.name === "string" && value.name.trim()
+          ? value.name.trim()
+          : modelDisplayName(id),
+      reasoning,
+      image: value.capabilities?.input?.image === true,
+      contextWindow: positiveNumber(
+        value.limit?.context,
+        contextWindowFor(id),
+      ),
+      maxTokens: positiveNumber(value.limit?.output, maxTokensFor(id)),
+      cost: ZERO_COST,
+      ...(reasoning
+        ? { thinkingLevelMap: thinkingLevelMap(value.variants) }
+        : {}),
+    });
+  }
+  return [...records.values()];
 }
 
 function runCapture(
@@ -118,39 +270,41 @@ function runCapture(
 }
 
 async function discoverModels(): Promise<{
-  models: string[];
+  models: OpenCodeModelInfo[];
   time: number;
   error: string | undefined;
 }> {
   const configured = configuredModels();
-  if (configured?.length) {
-    lastDiscoveryError = undefined;
-    return { models: dedupe(configured), time: Date.now(), error: undefined };
-  }
-
   try {
-    const result = await runCapture(["models", "opencode"]);
+    const result = await runCapture(["models", "opencode", "--verbose"]);
     if (result.code !== 0) {
       throw new Error(
         result.stderr.trim() ||
           `opencode models exited with code ${result.code}`,
       );
     }
-    const discovered = result.stdout
-      .split(/\r?\n/)
-      .map((line) => line.trim())
-      .filter((line) => line.startsWith("opencode/"))
-      .filter(looksFree);
+
+    const metadata = parseVerboseModels(result.stdout);
+    if (metadata.length === 0) {
+      throw new Error("opencode verbose model discovery returned no metadata");
+    }
+    const byId = new Map(metadata.map((model) => [model.id, model]));
+    const selected = configured?.length
+      ? dedupe(configured).map((id) => byId.get(id) ?? fallbackModel(id))
+      : metadata.filter((model) => looksFree(model.id));
+    if (selected.length === 0) {
+      throw new Error("opencode verbose model discovery returned no free models");
+    }
+
     lastDiscoveryError = undefined;
-    return {
-      models: dedupe(discovered.length > 0 ? discovered : DEFAULT_FREE_MODELS),
-      time: Date.now(),
-      error: undefined,
-    };
+    return { models: selected, time: Date.now(), error: undefined };
   } catch (error) {
     lastDiscoveryError = error instanceof Error ? error.message : String(error);
+    const fallbackIds = configured?.length
+      ? dedupe(configured)
+      : DEFAULT_FREE_MODELS;
     return {
-      models: DEFAULT_FREE_MODELS,
+      models: fallbackIds.map(fallbackModel),
       time: Date.now(),
       error: lastDiscoveryError,
     };
@@ -161,7 +315,7 @@ async function refreshModels(
   pi: ExtensionAPI,
   ctx: { ui: { notify: (msg: string, level?: string) => void } },
 ): Promise<void> {
-  const previousModels = new Set(registeredModels);
+  const previousModels = new Set(registeredModels.map((model) => model.id));
   const { models, time, error } = await discoverModels();
   registeredModels = models;
   lastDiscoveryTime = time;
@@ -172,15 +326,7 @@ async function refreshModels(
     baseUrl: "cli:opencode",
     apiKey: "opencode-cli-no-api-key",
     api: API_ID,
-    models: models.map((model) => ({
-      id: model,
-      name: `${modelDisplayName(model)} (OpenCode CLI)`,
-      reasoning: false,
-      input: ["text"] as const,
-      contextWindow: contextWindowFor(model),
-      maxTokens: maxTokensFor(model),
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-    })),
+    models: models.map(providerModel),
     streamSimple: streamOpenCode,
   };
 
@@ -190,11 +336,14 @@ async function refreshModels(
     // registerProvider may reject if already registered; the models array is already updated.
   }
 
-  const newModels = models.filter((m) => !previousModels.has(m));
+  const newModels = models.filter((model) => !previousModels.has(model.id));
 
   let msg = `opencode-pi: refreshed ${models.length} model(s).`;
   if (newModels.length > 0) {
-    msg += ` ${newModels.length} new: ${newModels.slice(0, 5).join(", ")}${newModels.length > 5 ? ", ..." : ""}`;
+    msg += ` ${newModels.length} new: ${newModels
+      .slice(0, 5)
+      .map((model) => model.id)
+      .join(", ")}${newModels.length > 5 ? ", ..." : ""}`;
   }
   if (error) msg += ` Discovery issue: ${error}`;
   ctx.ui.notify(msg, "info");
@@ -235,9 +384,71 @@ function contentToText(
   return content
     .map((item) => {
       if (item.type === "text") return item.text;
-      return `[image omitted: ${item.mimeType}, ${item.data.length} base64 chars]`;
+      return `[image in conversation: ${item.mimeType}, ${item.data.length} base64 chars]`;
     })
     .join("\n");
+}
+
+export function imageContentsForModel(
+  messages: Message[],
+  supportsImages: boolean,
+): ImageContent[] {
+  if (!supportsImages) return [];
+
+  const images: ImageContent[] = [];
+  for (const message of messages) {
+    if (message.role !== "user" && message.role !== "toolResult") continue;
+    if (typeof message.content === "string") continue;
+    for (const content of message.content) {
+      if (content.type === "image") images.push(content);
+    }
+  }
+  return images;
+}
+
+function safeImageExtension(mimeType: string): string {
+  const extensions: Record<string, string> = {
+    "image/avif": ".avif",
+    "image/bmp": ".bmp",
+    "image/gif": ".gif",
+    "image/jpeg": ".jpg",
+    "image/png": ".png",
+    "image/webp": ".webp",
+  };
+  return extensions[mimeType.toLowerCase()] ?? ".bin";
+}
+
+async function writeImageFiles(
+  images: ImageContent[],
+  directory: string,
+): Promise<string[]> {
+  const imageDir = join(directory, "pi-images");
+  if (images.length > 0) await mkdir(imageDir, { recursive: true });
+  return Promise.all(
+    images.map(async (image, index) => {
+      if (!image.mimeType.toLowerCase().startsWith("image/")) {
+        throw new Error(`Unsupported image MIME type: ${image.mimeType}`);
+      }
+      const base64 = image.data.replace(/\s/g, "");
+      if (
+        !base64 ||
+        base64.length % 4 === 1 ||
+        !/^[A-Za-z0-9+/]*={0,2}$/.test(base64)
+      ) {
+        throw new Error(`Invalid base64 data for image ${index + 1}`);
+      }
+      const data = Buffer.from(base64, "base64");
+      if (data.length === 0) {
+        throw new Error(`Empty image data for image ${index + 1}`);
+      }
+      const path = join(
+        imageDir,
+        `image-${String(index + 1).padStart(3, "0")}${safeImageExtension(image.mimeType)}`,
+      );
+      await writeFile(path, data);
+      return path;
+    }),
+  );
 }
 
 function safeJson(value: unknown): string {
@@ -265,7 +476,7 @@ function serializeMessage(message: Message): string {
       if (part.type === "text") return part.text;
       if (part.type === "thinking")
         return `<thinking>${part.thinking}</thinking>`;
-      return `<pi_tool_call>${safeJson({ name: part.name, arguments: part.arguments })}</pi_tool_call>`;
+      return `<pi_tool_call>${safeJson({ id: part.id, name: part.name, arguments: part.arguments })}</pi_tool_call>`;
     },
   );
   return `ASSISTANT:\n${parts.join("\n")}`;
@@ -290,15 +501,17 @@ function buildPrompt(context: Context): string {
 You are being used as the model backend for Pi Coding Agent through the OpenCode CLI.
 OpenCode's own tools are disabled. Do not try to use OpenCode tools.
 
-If you need Pi to run a tool, output only one or more tool-call blocks and no prose:
+If you need Pi to run a tool, your entire response must contain only one or more tool-call blocks separated by whitespace:
 <pi_tool_call>{"name":"tool_name","arguments":{}}</pi_tool_call>
 
 Rules for Pi tool calls:
-- Use only tools listed in the "Available Pi tools" section.
-- The JSON inside <pi_tool_call> must be valid JSON with "name" and "arguments" fields.
-- Do not wrap tool calls in Markdown fences.
-- If you can answer without a tool, answer normally in plain text.
-- After Pi returns tool results, continue from the transcript and either answer or request another Pi tool call.`);
+- Use only exact tool names listed in the "Available Pi tools" section.
+- The JSON inside every marker must be valid JSON with a string "name" and an object "arguments".
+- Markers are bridge control syntax. Never quote them, explain them, put them in prose, or wrap them in Markdown fences.
+- Never output a marker as an example. A marker means you are requesting immediate execution.
+- Do not put any text before or after tool-call markers. Mixed prose and markers will not execute.
+- If you can answer without a tool, answer normally in plain text and do not emit any marker.
+- After Pi returns tool results, match them to prior tool-call IDs in the transcript, then either answer or request another Pi tool call.`);
 
   if (context.systemPrompt?.trim()) {
     sections.push(`# Pi system prompt
@@ -322,54 +535,130 @@ ${context.messages.map(serializeMessage).join("\n\n---\n\n")}`);
   return sections.join("\n\n---\n\n");
 }
 
-function parseToolCalls(
-  text: string,
-): Array<{ name: string; arguments: Record<string, any> }> {
+function isToolCallMarkerResponse(text: string): boolean {
+  return /^<\/?pi_tool_call(?:>|$)/.test(text.trim());
+}
+
+function toolCallMarkerBodies(text: string): string[] | undefined {
   const trimmed = text.trim();
   const tagRegex = /<pi_tool_call>([\s\S]*?)<\/pi_tool_call>/g;
   const matches = [...trimmed.matchAll(tagRegex)];
-  if (matches.length > 0) {
-    // Some models prepend a sentence like "Let me check that" before the marker.
-    // Treat any valid marker as the assistant's intended Pi tool call and drop prose
-    // so Pi receives structured tool calls instead of raw marker text.
-    return matches.flatMap((match) => parseToolCallJson(match[1] ?? ""));
+  if (matches.length === 0) return undefined;
+
+  let cursor = 0;
+  for (const match of matches) {
+    const index = match.index ?? 0;
+    if (trimmed.slice(cursor, index).trim()) return undefined;
+    cursor = index + match[0].length;
   }
-  return parseToolCallJson(trimmed);
+  if (trimmed.slice(cursor).trim()) return undefined;
+  return matches.map((match) => match[1] ?? "");
 }
 
-function parseToolCallJson(
-  raw: string,
-): Array<{ name: string; arguments: Record<string, any> }> {
-  let value: any;
+export function parseToolCalls(
+  text: string,
+  allowedToolNames?: ReadonlySet<string>,
+): ParsedToolCall[] {
+  const bodies = toolCallMarkerBodies(text);
+  if (!bodies) return [];
+
+  const parsed: ParsedToolCall[] = [];
+  for (const body of bodies) {
+    const calls = parseToolCallJson(body);
+    if (
+      calls.length === 0 ||
+      calls.some(
+        (call) => allowedToolNames && !allowedToolNames.has(call.name),
+      )
+    ) {
+      return [];
+    }
+    parsed.push(...calls);
+  }
+  return parsed;
+}
+
+function parseArguments(value: unknown): Record<string, unknown> | undefined {
+  let parsed = value;
+  if (typeof parsed === "string") {
+    try {
+      parsed = JSON.parse(parsed);
+    } catch {
+      return undefined;
+    }
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return undefined;
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function parseToolCallJson(raw: string): ParsedToolCall[] {
+  let value: unknown;
   try {
     value = JSON.parse(raw.trim());
   } catch {
     return [];
   }
 
+  const container = value as { tool_calls?: unknown } | null;
   const candidates = Array.isArray(value)
     ? value
-    : Array.isArray(value?.tool_calls)
-      ? value.tool_calls
+    : Array.isArray(container?.tool_calls)
+      ? container.tool_calls
       : [value];
-  const calls: Array<{ name: string; arguments: Record<string, any> }> = [];
-  for (const candidate of candidates) {
-    const name =
-      typeof candidate?.name === "string"
-        ? candidate.name
-        : typeof candidate?.tool === "string"
-          ? candidate.tool
-          : undefined;
-    const args =
-      candidate?.arguments ?? candidate?.args ?? candidate?.input ?? {};
+  if (candidates.length === 0) return [];
+
+  const calls: ParsedToolCall[] = [];
+  for (const rawCandidate of candidates) {
     if (
-      !name ||
-      typeof args !== "object" ||
-      args === null ||
-      Array.isArray(args)
-    )
-      continue;
-    calls.push({ name, arguments: args });
+      typeof rawCandidate !== "object" ||
+      rawCandidate === null ||
+      Array.isArray(rawCandidate)
+    ) {
+      return [];
+    }
+    const candidate = rawCandidate as {
+      name?: unknown;
+      tool?: unknown;
+      arguments?: unknown;
+      args?: unknown;
+      input?: unknown;
+      function?: { name?: unknown; arguments?: unknown };
+    };
+    const nameValue =
+      typeof candidate.name === "string"
+        ? candidate.name
+        : typeof candidate.tool === "string"
+          ? candidate.tool
+          : candidate.function?.name;
+
+    let argumentsValue: unknown;
+    if (Object.hasOwn(candidate, "arguments")) {
+      argumentsValue = candidate.arguments;
+    } else if (Object.hasOwn(candidate, "args")) {
+      argumentsValue = candidate.args;
+    } else if (Object.hasOwn(candidate, "input")) {
+      argumentsValue = candidate.input;
+    } else if (
+      candidate.function &&
+      typeof candidate.function === "object" &&
+      Object.hasOwn(candidate.function, "arguments")
+    ) {
+      argumentsValue = candidate.function.arguments;
+    } else {
+      return [];
+    }
+
+    const args = parseArguments(argumentsValue);
+    if (
+      typeof nameValue !== "string" ||
+      !nameValue.trim() ||
+      !args
+    ) {
+      return [];
+    }
+    calls.push({ name: nameValue, arguments: args });
   }
   return calls;
 }
@@ -381,9 +670,10 @@ async function createTempAgentDir(): Promise<string> {
   await writeFile(
     join(agentsDir, `${AGENT_ID}.md`),
     `---
-description: Text-only Pi bridge agent. OpenCode tools are denied; Pi tool calls are emitted as text markers.
+description: Pi bridge agent. OpenCode tools are denied; Pi tool calls are emitted as text markers.
 mode: primary
 permission:
+  "*": deny
   read: deny
   edit: deny
   glob: deny
@@ -428,14 +718,26 @@ function streamOpenCode(
 
     let tempDir: string | undefined;
     let accumulatedText = "";
+    let accumulatedThinking = "";
     let stderr = "";
     let stdoutRemainder = "";
     let opencodeToolUse: string | undefined;
+    let opencodeError: string | undefined;
+    let finishReason: "stop" | "length" = "stop";
+    let timedOut = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
     const prompt = buildPrompt(context);
 
     try {
       stream.push({ type: "start", partial: output });
+      if (options?.signal?.aborted) throw new Error("Request was aborted");
+
       tempDir = await createTempAgentDir();
+      const images = imageContentsForModel(
+        context.messages,
+        model.input.includes("image"),
+      );
+      const imagePaths = await writeImageFiles(images, tempDir);
       const args = [
         "run",
         "--pure",
@@ -448,6 +750,14 @@ function streamOpenCode(
         "--dir",
         tempDir,
       ];
+      const requestedReasoning = options?.reasoning as
+        | ModelThinkingLevel
+        | undefined;
+      args.push(
+        ...reasoningCliArgs(requestedReasoning, model.thinkingLevelMap),
+      );
+      for (const path of imagePaths) args.push("--file", path);
+
       const child = spawn(opencodeBin(), args, {
         stdio: ["pipe", "pipe", "pipe"],
         env: { ...process.env, OPENCODE_DISABLE_UPDATE_CHECK: "1" },
@@ -455,6 +765,16 @@ function streamOpenCode(
 
       const abort = () => child.kill("SIGTERM");
       options?.signal?.addEventListener("abort", abort, { once: true });
+      if (
+        typeof options?.timeoutMs === "number" &&
+        Number.isFinite(options.timeoutMs) &&
+        options.timeoutMs > 0
+      ) {
+        timer = setTimeout(() => {
+          timedOut = true;
+          child.kill("SIGTERM");
+        }, options.timeoutMs);
+      }
 
       child.stdin!.end(prompt);
       child.stdout!.setEncoding("utf8");
@@ -475,7 +795,19 @@ function streamOpenCode(
           return;
         }
 
-        if (event.type === "step_finish" && event.part?.tokens) {
+        if (
+          event.type === "reasoning" &&
+          typeof event.part?.text === "string"
+        ) {
+          accumulatedThinking += event.part.text;
+          return;
+        }
+
+        if (event.type === "step_finish") {
+          if (/length|max.?tokens/i.test(String(event.part?.reason ?? ""))) {
+            finishReason = "length";
+          }
+          if (!event.part?.tokens) return;
           const tokens = event.part.tokens;
           output.usage.input = Number(tokens.input ?? 0);
           output.usage.output =
@@ -501,7 +833,15 @@ function streamOpenCode(
         }
 
         if (event.type === "error") {
-          stderr = (stderr + `\n${safeJson(event)}`).slice(-STDERR_LIMIT);
+          const message =
+            event.error?.data?.message ??
+            event.error?.message ??
+            event.part?.message;
+          opencodeError =
+            typeof message === "string" && message.trim()
+              ? message.trim()
+              : safeJson(event);
+          stderr = (stderr + `\n${opencodeError}`).slice(-STDERR_LIMIT);
         }
       };
 
@@ -520,22 +860,68 @@ function streamOpenCode(
         child.on("close", resolve);
       });
       options?.signal?.removeEventListener("abort", abort);
+      if (timer) clearTimeout(timer);
       if (stdoutRemainder.trim()) handleLine(stdoutRemainder);
 
       if (options?.signal?.aborted) {
         throw new Error("Request was aborted");
       }
+      if (timedOut) {
+        throw new Error(`opencode timed out after ${options?.timeoutMs}ms`);
+      }
       if (code !== 0) {
         throw new Error(stderr.trim() || `opencode exited with code ${code}`);
       }
+      if (opencodeError) throw new Error(opencodeError);
       if (opencodeToolUse) {
         throw new Error(
           `OpenCode attempted to use its own tool (${opencodeToolUse}). opencode-pi disables OpenCode tools; use Pi tool-call markers only.`,
         );
       }
 
-      const toolCalls = parseToolCalls(accumulatedText);
-      setEstimatedUsage(model, output, prompt, accumulatedText);
+      const allowedToolNames = new Set(
+        context.tools?.map((tool) => tool.name) ?? [],
+      );
+      const markerResponse = isToolCallMarkerResponse(accumulatedText);
+      const toolCalls = parseToolCalls(accumulatedText, allowedToolNames);
+      if (markerResponse && toolCalls.length === 0) {
+        throw new Error(
+          "opencode returned invalid or unavailable Pi tool-call markers",
+        );
+      }
+      if (toolCalls.length === 0 && !accumulatedText.trim()) {
+        throw new Error(
+          stderr.trim() || "opencode returned no assistant text or tool calls",
+        );
+      }
+      setEstimatedUsage(
+        model,
+        output,
+        prompt,
+        accumulatedText + accumulatedThinking,
+      );
+
+      if (accumulatedThinking) {
+        const thinkingIndex = output.content.length;
+        output.content.push({ type: "thinking", thinking: accumulatedThinking });
+        stream.push({
+          type: "thinking_start",
+          contentIndex: thinkingIndex,
+          partial: output,
+        });
+        stream.push({
+          type: "thinking_delta",
+          contentIndex: thinkingIndex,
+          delta: accumulatedThinking,
+          partial: output,
+        });
+        stream.push({
+          type: "thinking_end",
+          contentIndex: thinkingIndex,
+          content: accumulatedThinking,
+          partial: output,
+        });
+      }
 
       if (toolCalls.length > 0) {
         output.stopReason = "toolUse";
@@ -571,6 +957,7 @@ function streamOpenCode(
         return;
       }
 
+      output.stopReason = finishReason;
       const contentIndex = output.content.length;
       output.content.push({ type: "text", text: accumulatedText });
       stream.push({ type: "text_start", contentIndex, partial: output });
@@ -588,15 +975,17 @@ function streamOpenCode(
         content: accumulatedText,
         partial: output,
       });
-      stream.push({ type: "done", reason: "stop", message: output });
+      stream.push({ type: "done", reason: finishReason, message: output });
       stream.end();
     } catch (error) {
+      if (timer) clearTimeout(timer);
       output.stopReason = options?.signal?.aborted ? "aborted" : "error";
       output.errorMessage =
         error instanceof Error ? error.message : String(error);
       stream.push({ type: "error", reason: output.stopReason, error: output });
       stream.end();
     } finally {
+      if (timer) clearTimeout(timer);
       if (tempDir) {
         await rm(tempDir, { recursive: true, force: true }).catch(
           () => undefined,
@@ -606,6 +995,23 @@ function streamOpenCode(
   })();
 
   return stream;
+}
+
+function providerModel(model: OpenCodeModelInfo) {
+  return {
+    id: model.id,
+    name: `${model.name} (OpenCode CLI)`,
+    reasoning: model.reasoning,
+    ...(model.thinkingLevelMap
+      ? { thinkingLevelMap: model.thinkingLevelMap }
+      : {}),
+    input: model.image
+      ? (["text", "image"] as ("text" | "image")[])
+      : (["text"] as ("text" | "image")[]),
+    contextWindow: model.contextWindow,
+    maxTokens: model.maxTokens,
+    cost: model.cost,
+  };
 }
 
 function statusLines(): string[] {
@@ -619,8 +1025,15 @@ function statusLines(): string[] {
   if (lastDiscoveryError)
     lines.push(`Discovery fallback: ${lastDiscoveryError}`);
   lines.push("");
-  for (const model of registeredModels)
-    lines.push(`  - ${PROVIDER_ID}/${model}`);
+  for (const model of registeredModels) {
+    const capabilities = [
+      model.reasoning ? "reasoning" : undefined,
+      model.image ? "image" : undefined,
+    ].filter(Boolean);
+    lines.push(
+      `  - ${PROVIDER_ID}/${model.id}${capabilities.length > 0 ? ` (${capabilities.join(", ")})` : ""}`,
+    );
+  }
   lines.push("");
   lines.push(
     "OpenCode login is not required for the bundled free OpenCode models.",
@@ -644,15 +1057,7 @@ export default async function opencodePiExtension(pi: ExtensionAPI) {
     baseUrl: "cli:opencode",
     apiKey: "opencode-cli-no-api-key",
     api: API_ID,
-    models: registeredModels.map((model) => ({
-      id: model,
-      name: `${modelDisplayName(model)} (OpenCode CLI)`,
-      reasoning: false,
-      input: ["text"],
-      contextWindow: contextWindowFor(model),
-      maxTokens: maxTokensFor(model),
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-    })),
+    models: registeredModels.map(providerModel),
     streamSimple: streamOpenCode,
   });
 
@@ -679,7 +1084,7 @@ export default async function opencodePiExtension(pi: ExtensionAPI) {
       }
       if (sub === "models") {
         for (const model of registeredModels)
-          ctx.ui.notify(`${PROVIDER_ID}/${model}`, "info");
+          ctx.ui.notify(`${PROVIDER_ID}/${model.id}`, "info");
         ctx.ui.notify(
           `Override with OPENCODE_PI_MODELS="opencode/model-a,opencode/model-b"`,
           "info",
@@ -688,11 +1093,11 @@ export default async function opencodePiExtension(pi: ExtensionAPI) {
       }
       if (sub === "test") {
         ctx.ui.notify(
-          `Run: pi -p --provider ${PROVIDER_ID} --model ${registeredModels[0] ?? DEFAULT_FREE_MODELS[0]} "Reply with exactly OK"`,
+          `Run: pi -p --provider ${PROVIDER_ID} --model ${registeredModels[0]?.id ?? DEFAULT_FREE_MODELS[0]} "Reply with exactly OK"`,
           "info",
         );
         ctx.ui.notify(
-          `OpenCode check: ${opencodeBin()} run -m ${registeredModels[0] ?? DEFAULT_FREE_MODELS[0]} --format json "Reply OK"`,
+          `OpenCode check: ${opencodeBin()} run -m ${registeredModels[0]?.id ?? DEFAULT_FREE_MODELS[0]} --format json "Reply OK"`,
           "info",
         );
         return;

--- a/extensions/opencode-pi/src/index.ts
+++ b/extensions/opencode-pi/src/index.ts
@@ -535,12 +535,19 @@ ${context.messages.map(serializeMessage).join("\n\n---\n\n")}`);
   return sections.join("\n\n---\n\n");
 }
 
-function isToolCallMarkerResponse(text: string): boolean {
-  return /^<\/?pi_tool_call(?:>|$)/.test(text.trim());
-}
-
 const MARKER_OPEN = "<pi_tool_call>";
 const MARKER_CLOSE = "</pi_tool_call>";
+
+// Detects marker syntax anywhere in the response, not just at the start, so
+// prose-then-marker and marker-then-prose responses are treated the same
+// way: either both are rejected as malformed tool-call attempts, or neither
+// is. A one-sided check let malformed leading prose silently leak raw
+// marker text into the visible chat response while malformed trailing prose
+// hard-failed the turn.
+export function isToolCallMarkerResponse(text: string): boolean {
+  const trimmed = text.trim();
+  return trimmed.includes(MARKER_OPEN) || trimmed.includes(MARKER_CLOSE);
+}
 
 // A closing marker inside a JSON string (e.g. tool arguments that happen to
 // contain the literal text "</pi_tool_call>") must not be treated as the

--- a/extensions/opencode-pi/src/index.ts
+++ b/extensions/opencode-pi/src/index.ts
@@ -955,7 +955,11 @@ export function streamOpenCode(
           "opencode returned invalid or unavailable Pi tool-call markers",
         );
       }
-      if (toolCalls.length === 0 && !accumulatedText.trim()) {
+      if (
+        toolCalls.length === 0 &&
+        !accumulatedText.trim() &&
+        !accumulatedThinking.trim()
+      ) {
         throw new Error(
           stderr.trim() || "opencode returned no assistant text or tool calls",
         );
@@ -1024,23 +1028,23 @@ export function streamOpenCode(
       }
 
       output.stopReason = finishReason;
-      const contentIndex = output.content.length;
-      output.content.push({ type: "text", text: accumulatedText });
-      stream.push({ type: "text_start", contentIndex, partial: output });
       if (accumulatedText) {
+        const contentIndex = output.content.length;
+        output.content.push({ type: "text", text: accumulatedText });
+        stream.push({ type: "text_start", contentIndex, partial: output });
         stream.push({
           type: "text_delta",
           contentIndex,
           delta: accumulatedText,
           partial: output,
         });
+        stream.push({
+          type: "text_end",
+          contentIndex,
+          content: accumulatedText,
+          partial: output,
+        });
       }
-      stream.push({
-        type: "text_end",
-        contentIndex,
-        content: accumulatedText,
-        partial: output,
-      });
       stream.push({ type: "done", reason: finishReason, message: output });
       stream.end();
     } catch (error) {


### PR DESCRIPTION
Type: chore

## Summary

- discover OpenCode model metadata with `opencode models opencode --verbose` and expose accurate reasoning, image, context, output, and variant capabilities in Pi
- pass image attachments and reasoning settings through the OpenCode CLI bridge
- harden prompt-bridged tool calls with ID preservation, strict marker parsing, tool allowlisting, and all-or-nothing validation
- improve abort, timeout, error, empty-output, usage, and finish-reason handling
- document the updated bridge behavior and add focused regression tests
- tighten tool-call-marker detection to require an opening marker, close the abort cancellation window around temp-dir/image setup, and skip opencode model discovery at startup when `OPENCODE_PI_MODELS` is explicitly configured (while still enriching those models on an explicit `/opencode-pi update`)

## Decision Record

- **Root cause:** No GitHub issue is linked; this PR follows the repo's `chore` traceability exemption. `toolCallMarkerBodies` used a plain regex for marker-close detection, so a literal `</pi_tool_call>` inside a tool call's own JSON string arguments could be mistaken for a real boundary. `isToolCallMarkerResponse` was start-anchored (letting leading prose leak raw markers into chat) and, once broadened to "marker syntax anywhere," over-corrected into hard-failing responses that merely quoted or discussed a lone closing-marker substring with no real tool-call attempt. `streamOpenCode` rechecked `options.signal.aborted` only once, before the async temp-dir/image setup, leaving a cancellation window where an abort could still let the child process spawn and run. `discoverModels` always spawned `opencode models opencode --verbose` even when `OPENCODE_PI_MODELS` was already set, forcing a discovery timeout on every startup for users who had already told it exactly which models to use.
- **Options considered:** Traceability — fabricate a `Closes #N` vs. use the `chore` exemption. Marker-close detection — plain regex vs. JSON string/escape-aware scanning. `isToolCallMarkerResponse` — start-anchored vs. "marker syntax anywhere" vs. requiring the opening marker specifically. Abort window — single pre-setup check vs. rechecking after each async setup step. Discovery — always run verbose discovery vs. skip it by default for configured models with an opt-in `forceDiscovery` for `/opencode-pi update`.
- **Options rejected:** Fabricating a `Closes #N` reference. Keeping the plain-regex marker-close scan (can't distinguish a real boundary from the same literal text embedded in JSON string arguments). Detecting markers "anywhere in the response" (over-hard-fails on a lone closing-marker quote that never attempted a tool call). A single pre-setup abort check (leaves a window before the child spawns). Permanently skipping discovery for configured models (would silently and permanently regress capability enrichment, contradicting this PR's own "preserve model capabilities" goal).
- **Selected option:** Use the `chore` exemption with no fabricated issue link. Make marker-close detection JSON-string-aware. Require the opening marker for `isToolCallMarkerResponse` (marker-then-prose and prose-then-marker both still hard-fail symmetrically; a lone closing marker no longer does). Recheck `options.signal.aborted` after `createTempAgentDir` resolves and again after `writeImageFiles` resolves, before the child is spawned. Give `discoverModels` a `forceDiscovery` option: configured models skip discovery by default at startup, but `/opencode-pi update` passes `forceDiscovery: true` so they still get enriched with real capability metadata on request.
- **Residual risk:** No GitHub issue is linked; traceability relies on the repo's documented `chore` exemption rather than an issue reference. Models registered via `OPENCODE_PI_MODELS` start on conservative fallback capability metadata (no reasoning/image detection) until a user runs `/opencode-pi update`, which performs the enrichment discovery pass.

## Acceptance Criteria Verification

- `cd extensions/opencode-pi && npm test` — 21/21 tests pass (build + `node --test`), including coverage for the JSON-string-aware marker scanner, `isToolCallMarkerResponse`'s marker-then-prose / prose-then-marker symmetry and lone-closing-marker case, the `streamOpenCode` abort-window fix, and both the configured-bypass and `forceDiscovery`-enrichment paths of `discoverModels`.
- `cd extensions/opencode-pi && npm run build` — passes (`tsc`).
- `git diff --check` — no whitespace errors.

## Testing

- `cd extensions/opencode-pi && npm test` (21 tests passed)
- `cd extensions/opencode-pi && npm run build`
- `git diff --check`
