### PR TITLE
fix(statusline-pi): ship src in npm package files (#32)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Packaging guard**: `scripts/check-packaging.mjs` verifies every extension's `pi.extensions` entries are covered by its npm `files` allowlist; wired into `publish-npm-extensions.sh` as a pre-publish gate.
+
+### Fixed
+
+- **statusline-pi 1.2.1**: Published npm package omitted `src/` while `pi.extensions` pointed at `./src/index.ts`, so the extension silently failed to load from `pi install npm:statusline-pi`. `src` is now shipped in the tarball (#32).
+
+### Added
+
 - **subagents-pi**: New extension listing managed subagents with per-agent context usage, output TPS, model, and thinking level (companion to `@tintinweb/pi-subagents`).
 
 ### Changed

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,9 +14,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **statusline-pi 1.2.1**: Published npm package omitted `src/` while `pi.extensions` pointed at `./src/index.ts`, so the extension silently failed to load from `pi install npm:statusline-pi`. `src` is now shipped in the tarball (#32).
-
-### Added
-
 - **subagents-pi**: New extension listing managed subagents with per-agent context usage, output TPS, model, and thinking level (companion to `@tintinweb/pi-subagents`).
 
 ### Changed

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -174,6 +174,14 @@ npm publish --access public --otp=123456
 
 `prepublishOnly` runs `npm run build` where configured.
 
+Before publishing, verify every extension's `pi.extensions` entries are actually
+shipped by its `files` allowlist (a mismatch makes the extension silently fail to
+load from the installed package — see issue #32):
+
+```bash
+node scripts/check-packaging.mjs   # also run automatically by publish-npm-extensions.sh
+```
+
 Publish all five npm extensions from repo root (2FA OTP required):
 
 ```bash

--- a/extensions/statusline-pi/package.json
+++ b/extensions/statusline-pi/package.json
@@ -1,12 +1,13 @@
 {
   "name": "statusline-pi",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Compact project statusline footer for Pi with directory, branch changes, context remaining, response speed, model, and PR number",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist",
+    "src",
     "README.md"
   ],
   "exports": {

--- a/extensions/statusline-pi/test/packaging.test.mjs
+++ b/extensions/statusline-pi/test/packaging.test.mjs
@@ -1,0 +1,40 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const pkg = JSON.parse(
+	readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+);
+const guardScript = fileURLToPath(
+	new URL("../../../scripts/check-packaging.mjs", import.meta.url),
+);
+
+function isCoveredByFiles(entry, files) {
+	const rel = entry.replace(/^\.\//, "");
+	let covered = false;
+	for (const raw of files) {
+		const exclude = raw.startsWith("!");
+		const pattern = raw.replace(/^\.\//, "").replace(/\/$/, "");
+		if (pattern === rel || rel.startsWith(`${pattern}/`)) covered = !exclude;
+	}
+	return covered;
+}
+
+describe("npm packaging consistency (#32)", () => {
+	it("ships every pi.extensions entry listed in files", () => {
+		const entries = pkg.pi?.extensions ?? [];
+		assert.ok(entries.length > 0, "pi.extensions must not be empty");
+		for (const entry of entries) {
+			assert.ok(
+				isCoveredByFiles(entry, pkg.files ?? []),
+				`${entry} is not covered by "files" ${JSON.stringify(pkg.files)}; the published tarball would miss it`,
+			);
+		}
+	});
+
+	it("passes the repo-wide packaging guard for all extensions", () => {
+		execFileSync(process.execPath, [guardScript], { stdio: "pipe" });
+	});
+});

--- a/scripts/check-packaging.mjs
+++ b/scripts/check-packaging.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+// Packaging consistency guard: every `pi.extensions` entry must be shipped by
+// the npm package, i.e. covered by the `files` allowlist in package.json.
+//
+// Semantics mirrored from npm:
+// - no `files` field => everything is published => pass
+// - directory entries cover everything under them
+// - entries prefixed with `!` are exclusions and override earlier matches
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const root = resolve(new URL("..", import.meta.url).pathname);
+const extensionsDir = join(root, "extensions");
+
+function collectViolations(pkgDir) {
+	const pkgPath = join(pkgDir, "package.json");
+	const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+	const entries = pkg.pi?.extensions ?? [];
+	if (entries.length === 0) return [];
+
+	const rawFiles = pkg.files;
+	if (!Array.isArray(rawFiles)) return []; // no allowlist: npm ships everything
+
+	// Last matching entry wins (npm applies rules in order).
+	const rules = rawFiles.map((f) => ({
+		pattern: f.replace(/^\.\//, "").replace(/\/$/, ""),
+		exclude: f.startsWith("!"),
+	}));
+
+	const violations = [];
+	for (const entry of entries) {
+		const rel = entry.replace(/^\.\//, "");
+		let covered = false;
+		for (const { pattern, exclude } of rules) {
+			const matches =
+				pattern === rel || rel.startsWith(pattern ? `${pattern}/` : "\u0000");
+			if (matches) covered = !exclude;
+		}
+		if (!covered) violations.push(entry);
+	}
+	return violations;
+}
+
+const failures = [];
+for (const name of readdirSync(extensionsDir).sort()) {
+	const dir = join(extensionsDir, name);
+	if (!statSync(dir).isDirectory()) continue;
+	for (const entry of collectViolations(dir)) {
+		failures.push({ pkg: name, entry });
+	}
+}
+
+if (failures.length > 0) {
+	console.error("Packaging check FAILED — pi.extensions entries not shipped:");
+	for (const { pkg, entry } of failures) {
+		console.error(`  extensions/${pkg}: ${entry} is not covered by "files"`);
+	}
+	console.error(
+		"\nFix: add the missing paths to \"files\" in the package.json, or point pi.extensions at shipped files.",
+	);
+	process.exit(1);
+}
+
+console.log("Packaging check OK: all pi.extensions entries are shipped.");

--- a/scripts/publish-npm-extensions.sh
+++ b/scripts/publish-npm-extensions.sh
@@ -10,6 +10,9 @@ fi
 
 EXTENSIONS=(advisor-pi grok-pi model-debugger opencode-pi statusline-pi)
 
+echo "===== packaging check ====="
+node "$ROOT/scripts/check-packaging.mjs"
+
 for name in "${EXTENSIONS[@]}"; do
   echo "===== publish $name ====="
   (cd "$ROOT/extensions/$name" && npm publish --access public "${OTP_FLAG[@]}")


### PR DESCRIPTION
Closes #32

## Summary

The published `statusline-pi` npm package declared `pi.extensions: ["./src/index.ts"]` while its `files` allowlist shipped only `dist` and `README.md`, so the entry file was absent from the tarball and Pi's extension loader silently failed to load the extension after `pi install npm:statusline-pi`. This ships `src/` in the tarball, bumps to 1.2.1, and adds a repo-wide packaging guard so this bug class cannot recur.

## Approach

Option 3 — Comprehensive fix + packaging guard: apply the minimal manifest fix (add `src` to `files`, matching advisor-pi / claude-code-pi / subagents-pi convention), plus a dependency-free guard script asserting every extension's `pi.extensions` entries are covered by its `files` allowlist, wired into the publish pipeline and covered by a node:test regression suite.

## Decision Record

- **Root cause:** `extensions/statusline-pi/package.json` set `"pi": {"extensions": ["./src/index.ts"]}` but `"files": ["dist", "README.md"]` excluded `src/` from the published tarball; Pi's loader resolves `pi.extensions` relative to the package dir, finds no entry (and no root `index.ts`/`index.js` fallback), and silently skips the extension. The mismatch persisted across publishes 1.1.3 (949ce58) and 1.2.0 (5c2ab77).
- **Options considered:** Option 1 — Minimal fix: add `src` to files allowlist; Option 2 — Point `pi.extensions` at `./dist/index.js`; Option 3 — Fix + packaging consistency guard across all extensions
- **Options rejected:** Option 1 — correct but leaves the bug class unguarded (user opted for broader scope); Option 2 — works but breaks the repo-wide convention of loading TS source via `pi.extensions`, inconsistent with sibling extensions
- **Selected option:** Option 3 — Comprehensive: fix + packaging guard
- **Residual risk:** the guard checks allowlist coverage, not on-disk existence of referenced files, and does not model npm's implicit always-included files (package.json/README/LICENSE/main) — acceptable since all current `pi.extensions` entries are source paths outside those rules
- **Reproduction:** standalone repro script asserting statusline-pi's `pi.extensions` coverage confirmed red pre-fix (`RED: pi.extensions entries not shipped in files: [ './src/index.ts' ]`) → regression test `extensions/statusline-pi/test/packaging.test.mjs` now green

Analyzed at: `fix/32-statusline-pi-1-1-3-published-package @ 49129c4` (2026-08-21)

## Changes

| File | Change |
|------|--------|
| `extensions/statusline-pi/package.json` | Add `src` to `files`; version 1.2.0 → 1.2.1 |
| `scripts/check-packaging.mjs` | New dependency-free guard: every `pi.extensions` entry must be covered by the package's `files` allowlist (npm dir/exclusion semantics); non-zero exit + violation report |
| `scripts/publish-npm-extensions.sh` | Run the packaging guard before the publish loop |
| `extensions/statusline-pi/test/packaging.test.mjs` | Regression tests: manifest self-check + repo-wide guard invocation |
| `docs/DEVELOPMENT.md` | Document the packaging check |
| `docs/CHANGELOG.md` | Unreleased entries for the guard and the statusline-pi fix |

## Test Results

- Unit tests: 18 passed (`npm run test` in extensions/statusline-pi, incl. 2 new packaging tests)
- Integration tests: packaging guard wired as pre-publish gate in publish script
- E2e tests: 0 (no e2e framework)
- Build: passed (`tsc`)
- QA cycles: 1 (review PASS, 0 blocking issues)

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Published package's `pi.extensions` points at a file actually shipped in the tarball | pass | `files` now includes `src`; `node scripts/check-packaging.mjs` exits 0 across all extensions |
| Fresh `npm pack` of the fixed version contains the entry file referenced by `pi.extensions` | pass | Verified red: standalone coverage repro → fixed → `npm pack --dry-run` lists `src/index.ts`; regression test `extensions/statusline-pi/test/packaging.test.mjs` |
| Extension loads successfully after a clean `pi install npm:statusline-pi` | unverified | Requires publishing 1.2.1 to npm and a live install; verify after release via `scripts/publish-npm-extensions.sh` |

<!-- gitissue:qa v1 head=49129c45f7048d465d90c28f032e028ac9a2e665 profile=full cycles=1 review=clean ui=none -->
