### PR TITLE
fix(opencode-pi): register API handler for opencode-cli-runner (#38)

### DIFF
--- a/extensions/opencode-pi/src/index.test.ts
+++ b/extensions/opencode-pi/src/index.test.ts
@@ -11,6 +11,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import {
+  clearApiProviders,
+  getApiProvider,
+} from "@earendil-works/pi-ai";
 import type {
   Api,
   AssistantMessageEvent,
@@ -972,6 +976,31 @@ test("extension registration preserves discovered model capabilities", async () 
     ]);
   } finally {
     restoreEnv("OPENCODE_PI_MODELS", previousModels);
+  }
+});
+
+test("extension registration resolves the API handler for inference", async () => {
+  const previousModels = process.env.OPENCODE_PI_MODELS;
+  delete process.env.OPENCODE_PI_MODELS;
+
+  try {
+    await withFakeOpenCode(
+      `process.stdout.write("opencode/one-free\\n");`,
+      () =>
+        opencodePiExtension({
+          registerProvider() {},
+          on() {},
+          registerCommand() {},
+        } as unknown as ExtensionAPI),
+    );
+
+    const apiProvider = getApiProvider("opencode-cli-runner");
+    assert.notEqual(apiProvider, undefined);
+    assert.equal(typeof apiProvider?.streamSimple, "function");
+    assert.equal(typeof apiProvider?.stream, "function");
+  } finally {
+    restoreEnv("OPENCODE_PI_MODELS", previousModels);
+    clearApiProviders();
   }
 });
 

--- a/extensions/opencode-pi/src/index.ts
+++ b/extensions/opencode-pi/src/index.ts
@@ -7,6 +7,7 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import {
   calculateCost,
   createAssistantMessageEventStream,
+  registerApiProvider,
   type Api,
   type AssistantMessage,
   type AssistantMessageEventStream,
@@ -365,6 +366,7 @@ async function refreshModels(
   } catch {
     // registerProvider may reject if already registered; the models array is already updated.
   }
+  registerApiHandler();
 
   const newModels = models.filter((model) => !previousModels.has(model.id));
 
@@ -1349,6 +1351,18 @@ function statusLines(): string[] {
   return lines;
 }
 
+function registerApiHandler(): void {
+  registerApiProvider(
+    {
+      api: API_ID,
+      stream: (model, context, options) =>
+        streamOpenCode(model, context, options),
+      streamSimple: streamOpenCode,
+    },
+    PROVIDER_ID,
+  );
+}
+
 export default async function opencodePiExtension(pi: ExtensionAPI) {
   const { models, time } = await discoverModels();
   registeredModels = models;
@@ -1362,6 +1376,7 @@ export default async function opencodePiExtension(pi: ExtensionAPI) {
     models: registeredModels.map(providerModel),
     streamSimple: streamOpenCode,
   });
+  registerApiHandler();
 
   pi.on("session_start", async (_event: any, ctx: any) => {
     ctx.ui.notify(


### PR DESCRIPTION
## Summary

Closes #38

Inference through the `opencode-pi` extension failed with `No API provider registered for api: opencode-cli-runner`. The extension only called `pi.registerProvider(...)`, which on some Pi versions (including 0.83.0) does not populate the pi-ai API registry that the compatibility layer's `resolveApiProvider(api)` consults.

## Approach

Explicitly register the API handler with `registerApiProvider()` from `@earendil-works/pi-ai` — the same call Pi's own model registry makes when it sees `config.streamSimple` (`model-registry.js:681`). The registration is idempotent (registry is a Map keyed by API id), so it is safe to re-run on `/opencode-pi update` model refreshes.

## Decision Record

- **Selected option:** Explicit `registerApiProvider()` alongside both `pi.registerProvider()` call sites (initial registration and `refreshModels`)
- **Options rejected:**
  - *Rely on `pi.registerProvider` side effect only* — rejected: it is version-dependent and is exactly what fails on Pi 0.83.0
  - *Rename/alias the API to a known built-in id* — rejected: would change user-visible `API_ID` and break existing configs
- **Complexity:** low · **Risk:** low

## Changes

| File | Change |
|------|--------|
| `extensions/opencode-pi/src/index.ts` | Import `registerApiProvider`; add `registerApiHandler()`; call it at initial registration and in `refreshModels` |
| `extensions/opencode-pi/src/index.test.ts` | Regression test asserting `getApiProvider("opencode-cli-runner")` resolves after extension registration |

## Test Results

- `npm run build` — clean
- `node --test dist/index.test.js` — 42 pass, 0 fail (includes new regression test)

## Acceptance Criteria Verification

| Criterion | Status |
|-----------|--------|
| API handler registered for `opencode-cli-runner` so `resolveApiProvider` resolves it | ✅ verified by regression test |
| Registration survives model refresh (`/opencode-pi update`) | ✅ `refreshModels` re-calls `registerApiHandler()` |
| No behavior change for Pi versions that already auto-registered | ✅ Map.set overwrite, same stream functions |

<!-- gitissue:qa v1 cycles=1 clean=true head=499dafd -->