### PR TITLE
chore: publish all extensions to npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ pi install npm:advisor-pi
 pi install npm:grok-pi
 pi install npm:opencode-pi
 pi install npm:model-debugger
+pi install npm:claude-code-pi
+pi install npm:subagents-pi
 
 # Pin a version
 pi install npm:opencode-pi@1.1.0
@@ -66,8 +68,8 @@ pi install -l npm:statusline-pi
 | [`grok-pi`](https://www.npmjs.com/package/grok-pi) | `grok-cli` provider |
 | [`opencode-pi`](https://www.npmjs.com/package/opencode-pi) | `opencode-cli` free models |
 | [`model-debugger`](https://www.npmjs.com/package/model-debugger) | Model request logging to `~/.pi/agent/logs/` |
-
-**Not on npm yet** (install from repo below): `claude-code-pi`, `subagents-pi`.
+| [`claude-code-pi`](https://www.npmjs.com/package/claude-code-pi) | `claude` CLI provider via local `claude -p` |
+| [`subagents-pi`](https://www.npmjs.com/package/subagents-pi) | Subagent fleet metrics panel |
 
 Try without installing (current session only):
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **publish-npm-extensions.sh**: Covers all seven extensions and uses npm's browser-based 2FA authorization by default (open the printed `npmjs.com/auth/cli/…` link); the OTP argument remains as a legacy fallback.
 - **README**: Document npm install via `pi install npm:<package>` and table of published extensions.
 - **Extension READMEs** (npm packages): Unified install section — npm link, `pi install` / pin / `-l` / `-e`, `pi list` / `update` / `remove`, git fallback.
 - **npm / pi.dev gallery**: `pi-package` keyword and `pi.image` on published extensions; DEVELOPMENT.md gallery checklist. Bump patch versions locally (publish with `npm publish --otp=…`).

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,15 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Packaging guard**: `scripts/check-packaging.mjs` verifies every extension's `pi.extensions` entries are covered by its npm `files` allowlist; wired into `publish-npm-extensions.sh` as a pre-publish gate.
 
-### Fixed
+### Added
 
-- **opencode-pi**: Malformed `<pi_tool_call>` markers (truncated JSON, unclosed markers) no longer hard-fail the whole turn. Valid sibling tool calls still execute, unrecoverable marker text is stripped from the displayed response, and a corrective diagnostic is only raised when no payload can be salvaged (#39).
-- **statusline-pi 1.2.1**: Published npm package omitted `src/` while `pi.extensions` pointed at `./src/index.ts`, so the extension silently failed to load from `pi install npm:statusline-pi`. `src` is now shipped in the tarball (#32).
-- **subagents-pi**: New extension listing managed subagents with per-agent context usage, output TPS, model, and thinking level (companion to `@tintinweb/pi-subagents`).
+- **npm releases**: `claude-code-pi` 1.0.0 and `subagents-pi` 1.0.0 published for the first time; `statusline-pi` 1.2.1 and `opencode-pi` 1.1.4 republished with the fixes below. `publish-npm-extensions.sh` now covers all seven extensions.
 
 ### Changed
 
-- **subagents-pi**: Fleet panel redesigned as a compact ops console (header counts, glyph status, metric cards) and hides terminal agents (`completed` / `error` / `aborted` / `stopped`) as soon as they finish.
 - **README**: Document npm install via `pi install npm:<package>` and table of published extensions.
 - **Extension READMEs** (npm packages): Unified install section — npm link, `pi install` / pin / `-l` / `-e`, `pi list` / `update` / `remove`, git fallback.
 - **npm / pi.dev gallery**: `pi-package` keyword and `pi.image` on published extensions; DEVELOPMENT.md gallery checklist. Bump patch versions locally (publish with `npm publish --otp=…`).
@@ -28,6 +25,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - **apple-fm-pi extension**: Removed from the repository along with its docs and vendored fm-proxy. To use Apple Foundation Models, run `fm serve` manually and register the model via `models.json`.
+
+## [claude-code-pi 1.0.0] — 2026-08-21
+
+### Added
+
+- **claude-code-pi**: First npm release. Bridges Claude Code CLI model aliases into Pi through local `claude -p` calls, with no SDK/API fallback path.
+
+## [subagents-pi 1.0.0] — 2026-08-21
+
+### Added
+
+- **subagents-pi**: First npm release. Fleet metrics panel for managed subagents — per-agent context usage, output TPS, model, and thinking level (companion to `@tintinweb/pi-subagents`); terminal agents hide as soon as they finish.
+
+## [statusline-pi 1.2.1] — 2026-08-21
+
+### Fixed
+
+- **statusline-pi**: Published npm package omitted `src/` while `pi.extensions` pointed at `./src/index.ts`, so the extension silently failed to load from `pi install npm:statusline-pi`. `src` is now shipped in the tarball (#32).
+
+## [opencode-pi 1.1.4] — 2026-08-21
+
+### Fixed
+
+- **opencode-pi**: Register the API handler for `opencode-cli-runner` so bridged requests resolve instead of failing with an unknown-handler error (#38).
+- **opencode-pi**: Malformed `<pi_tool_call>` markers (truncated JSON, unclosed markers) no longer hard-fail the whole turn. Valid sibling tool calls still execute, unrecoverable marker text is stripped from the displayed response, and a corrective diagnostic is only raised when no payload can be salvaged (#39).
 
 ## [grok-pi 1.2.0] — 2026-08-13
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -169,7 +169,8 @@ Use **stable raw GitHub URLs** on `main` (or a release asset), not repo-relative
 ```bash
 cd extensions/<name>
 npm version patch   # or minor
-npm publish --access public --otp=123456
+npm publish --access public                # approve the browser 2FA link npm prints/opens
+npm publish --access public --otp=123456   # legacy alternative
 ```
 
 `prepublishOnly` runs `npm run build` where configured.
@@ -182,11 +183,12 @@ load from the installed package — see issue #32):
 node scripts/check-packaging.mjs   # also run automatically by publish-npm-extensions.sh
 ```
 
-Publish all five npm extensions from repo root (2FA OTP required):
+Publish all seven npm extensions from repo root (approve the 2FA link in your browser):
 
 ```bash
 chmod +x scripts/publish-npm-extensions.sh
-./scripts/publish-npm-extensions.sh 123456
+./scripts/publish-npm-extensions.sh             # browser authorization per publish
+./scripts/publish-npm-extensions.sh 123456      # legacy: pass OTP directly
 # or: NPM_OTP=123456 ./scripts/publish-npm-extensions.sh
 ```
 

--- a/extensions/opencode-pi/package.json
+++ b/extensions/opencode-pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-pi",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Bridge OpenCode CLI free models into Pi without OpenCode login",
   "type": "module",
   "main": "./src/index.ts",

--- a/scripts/publish-npm-extensions.sh
+++ b/scripts/publish-npm-extensions.sh
@@ -8,7 +8,7 @@ if [[ -n "$OTP" ]]; then
   OTP_FLAG=(--otp="$OTP")
 fi
 
-EXTENSIONS=(advisor-pi grok-pi model-debugger opencode-pi statusline-pi)
+EXTENSIONS=(advisor-pi claude-code-pi grok-pi model-debugger opencode-pi statusline-pi subagents-pi)
 
 echo "===== packaging check ====="
 node "$ROOT/scripts/check-packaging.mjs"

--- a/scripts/publish-npm-extensions.sh
+++ b/scripts/publish-npm-extensions.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
-# Publish all npm extensions. Requires npm 2FA: pass OTP as first arg or NPM_OTP env.
+# Publish all npm extensions.
+#
+# Auth modes:
+#   1. Browser (default): npm prints/opens an authorization URL for each
+#      publish — approve it in the browser. Requires a recent npm (>= 9.6).
+#   2. Legacy OTP: pass the code as the first arg, or set NPM_OTP.
 set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 OTP="${1:-${NPM_OTP:-}}"
-OTP_FLAG=()
-if [[ -n "$OTP" ]]; then
-  OTP_FLAG=(--otp="$OTP")
-fi
 
 EXTENSIONS=(advisor-pi claude-code-pi grok-pi model-debugger opencode-pi statusline-pi subagents-pi)
 
@@ -15,7 +16,13 @@ node "$ROOT/scripts/check-packaging.mjs"
 
 for name in "${EXTENSIONS[@]}"; do
   echo "===== publish $name ====="
-  (cd "$ROOT/extensions/$name" && npm publish --access public "${OTP_FLAG[@]}")
+  if [[ -n "$OTP" ]]; then
+    (cd "$ROOT/extensions/$name" && npm publish --access public --otp="$OTP")
+  else
+    # npm shows an https://www.npmjs.com/auth/cli/... link (and opens the
+    # browser when possible) — approve it to complete the publish.
+    (cd "$ROOT/extensions/$name" && npm publish --access public)
+  fi
 done
 
 echo "Done. Verify: npm view statusline-pi version"


### PR DESCRIPTION
## Summary

- First npm releases: claude-code-pi 1.0.0, subagents-pi 1.0.0
- Republish: statusline-pi 1.2.1 (ships src in tarball, #40) and opencode-pi 1.1.4 (registers opencode-cli-runner API handler #41, degrades malformed tool-call markers #42)
- publish-npm-extensions.sh now covers all 7 extensions
- README: npm table rows + install commands for the two new packages, removed the not-on-npm note
- CHANGELOG: version sections for the four releases

## Validation

- node scripts/check-packaging.mjs: OK across all 7 extensions
- Tests pass: opencode-pi, claude-code-pi, subagents-pi

## Publish after merge (OTP required)

./scripts/publish-npm-extensions.sh <otp>