### PR TITLE
feat(claude-code-pi): thinking levels, 1M context window, image input

### DIFF
--- a/extensions/claude-code-pi/README.md
+++ b/extensions/claude-code-pi/README.md
@@ -81,6 +81,7 @@ Commands:
 | `CLAUDE_CODE_PI_BIN` | Override the Claude Code executable path. Defaults to `claude`. |
 | `CLAUDE_CODE_PI_MODELS` | Comma- or space-separated model aliases to register. Defaults to `sonnet,opus,fable`. |
 | `CLAUDE_CODE_PI_TIMEOUT_MS` | Per-turn `claude -p` timeout in milliseconds. Defaults to 300000. |
+| `CLAUDE_CODE_PI_CONTEXT_WINDOW` | Override the advertised context window in tokens. Defaults to 1000000 (current Claude aliases serve 1M-token context windows). |
 
 Example:
 
@@ -88,13 +89,29 @@ Example:
 CLAUDE_CODE_PI_MODELS="sonnet,opus,claude-fable-5" pi
 ```
 
+## Thinking levels
+
+Pi thinking levels map to Claude Code's `--effort` flag:
+
+| Pi thinking level | Passed to Claude Code |
+|-------------------|-----------------------|
+| `off` / unset     | no `--effort` flag    |
+| `minimal`, `low`  | `--effort low`        |
+| `medium`          | `--effort medium`     |
+| `high`            | `--effort high`       |
+| `xhigh`           | `--effort xhigh`      |
+
+## Images
+
+Models advertise image input. When a turn contains images, the extension switches to the stream-json transport (`--input-format stream-json --output-format stream-json --verbose`) and sends images as base64 content blocks over stdin. Text-only turns keep the plain-text transport.
+
 ## How it works
 
 For each Pi model turn, the extension:
 
 1. Serializes Pi's system prompt, conversation transcript, and available tool schemas into one text prompt.
-2. Spawns the local Claude Code CLI with `claude -p --model <selected> --no-session-persistence --tools "" --output-format text`.
-3. Writes the serialized prompt to Claude Code over stdin.
+2. Spawns the local Claude Code CLI with `claude -p --model <selected> --no-session-persistence --tools "" --output-format text`, plus `--effort <level>` when a thinking level is set.
+3. Writes the serialized prompt (or a stream-json user message with base64 image blocks) to Claude Code over stdin.
 4. Converts Claude Code stdout into a Pi assistant text message, or converts `<pi_tool_call>{...}</pi_tool_call>` markers into native Pi tool calls.
 5. Emits a clear assistant error if the CLI is missing, exits non-zero, is aborted, or times out.
 
@@ -104,5 +121,4 @@ The extension disables Claude Code's own tools with `--tools ""`. Pi tool schema
 
 - This is slower than native HTTP providers because a `claude -p` process starts for each model turn.
 - Tool calling is prompt-bridged with `<pi_tool_call>{...}</pi_tool_call>` markers, so it is less reliable than native provider tool calling but still keeps execution in Pi.
-- Image input is serialized as an omitted-image placeholder and the registered models are text-only.
-- Availability checks use `claude --version`; real model calls may still fail if local Claude Code auth or account access is not configured.
+- Image input requires the stream-json transport and is supported for base64 image blocks; availability checks use `claude --version`, so real model calls may still fail if local Claude Code auth or account access is not configured.

--- a/extensions/claude-code-pi/src/index.ts
+++ b/extensions/claude-code-pi/src/index.ts
@@ -10,6 +10,7 @@ import {
   type ImageContent,
   type Message,
   type Model,
+  type ModelThinkingLevel,
   type SimpleStreamOptions,
   type TextContent,
   type Tool,
@@ -18,7 +19,7 @@ import {
 
 export const PROVIDER_ID = "claude-code-cli";
 const API_ID = "claude-code-cli-runner";
-const DEFAULT_CONTEXT_WINDOW = 200_000;
+const DEFAULT_CONTEXT_WINDOW = 1_000_000;
 const DEFAULT_MAX_TOKENS = 16_384;
 const STATUS_TIMEOUT_MS = 4_000;
 const REQUEST_TIMEOUT_MS = 5 * 60_000;
@@ -69,6 +70,12 @@ function requestTimeoutMs(): number {
   return REQUEST_TIMEOUT_MS;
 }
 
+function contextWindowOverride(): number | undefined {
+  const configured = Number(process.env.CLAUDE_CODE_PI_CONTEXT_WINDOW);
+  if (Number.isFinite(configured) && configured > 0) return Math.floor(configured);
+  return undefined;
+}
+
 function dedupe(values: string[]): string[] {
   return [...new Set(values)];
 }
@@ -81,22 +88,40 @@ export function configuredModels(raw: string | undefined): ClaudeCodeModelInfo[]
 
   const ids = configured && configured.length > 0 ? dedupe(configured) : DEFAULT_MODELS.map((model) => model.id);
   const defaults = new Map(DEFAULT_MODELS.map((model) => [model.id, model]));
+  const contextWindow = contextWindowOverride();
 
   return ids.map((id) => {
     const known = defaults.get(id);
-    if (known) return known;
+    if (known && !contextWindow) return known;
     return {
       id,
-      name: `Claude Code ${id}`,
-      contextWindow: DEFAULT_CONTEXT_WINDOW,
-      maxTokens: DEFAULT_MAX_TOKENS,
+      name: known?.name ?? `Claude Code ${id}`,
+      contextWindow: contextWindow ?? known?.contextWindow ?? DEFAULT_CONTEXT_WINDOW,
+      maxTokens: known?.maxTokens ?? DEFAULT_MAX_TOKENS,
       reasoning: true,
     };
   });
 }
 
-export function buildClaudeArgs(modelId: string): string[] {
-  return [
+const EFFORT_BY_LEVEL: Record<Exclude<ModelThinkingLevel, "off">, string> = {
+  minimal: "low",
+  low: "low",
+  medium: "medium",
+  high: "high",
+  xhigh: "xhigh",
+};
+
+export function effortArgs(level: ModelThinkingLevel | undefined): string[] {
+  if (!level || level === "off") return [];
+  return ["--effort", EFFORT_BY_LEVEL[level] ?? "high"];
+}
+
+export function buildClaudeArgs(
+  modelId: string,
+  reasoning?: ModelThinkingLevel,
+  useStreamJson = false,
+): string[] {
+  const args = [
     "-p",
     "--model",
     modelId,
@@ -105,9 +130,14 @@ export function buildClaudeArgs(modelId: string): string[] {
     "dontAsk",
     "--tools",
     "",
-    "--output-format",
-    "text",
   ];
+  args.push(...effortArgs(reasoning));
+  if (useStreamJson) {
+    args.push("--input-format", "stream-json", "--output-format", "stream-json", "--verbose");
+  } else {
+    args.push("--output-format", "text");
+  }
+  return args;
 }
 
 function emptyUsage(): AssistantMessage["usage"] {
@@ -185,6 +215,45 @@ function serializeTools(tools?: Tool[]): string {
       parameters: tool.parameters,
     })),
   );
+}
+
+function contextImages(context: Context): ImageContent[] {
+  return context.messages.flatMap((message) =>
+    message.role === "user" && Array.isArray(message.content)
+      ? message.content.filter((item): item is ImageContent => item.type === "image")
+      : [],
+  );
+}
+
+export function buildStreamJsonInput(images: ImageContent[], prompt: string): string {
+  const content: Array<Record<string, unknown>> = images.map((image) => ({
+    type: "image",
+    source: { type: "base64", media_type: image.mimeType, data: image.data },
+  }));
+  content.push({ type: "text", text: prompt });
+  return `${JSON.stringify({ type: "user", message: { role: "user", content } })}\n`;
+}
+
+export function parseStreamJsonOutput(stdout: string): string {
+  const texts: string[] = [];
+  let result = "";
+  for (const line of stdout.split("\n")) {
+    if (!line.trim()) continue;
+    let event: any;
+    try {
+      event = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (event?.type === "assistant") {
+      for (const block of event.message?.content ?? []) {
+        if (block?.type === "text" && typeof block.text === "string" && block.text) texts.push(block.text);
+      }
+    } else if (event?.type === "result" && typeof event.result === "string") {
+      result = event.result;
+    }
+  }
+  return result || texts.join("\n");
 }
 
 export function buildPrompt(context: Pick<Context, "systemPrompt" | "messages" | "tools">): string {
@@ -353,6 +422,8 @@ function streamClaudeCode(
     };
 
     const prompt = buildPrompt(context);
+    const images = contextImages(context);
+    const useStreamJson = images.length > 0;
     let stderr = "";
     let stdout = "";
     let settled = false;
@@ -361,7 +432,7 @@ function streamClaudeCode(
 
     try {
       stream.push({ type: "start", partial: output });
-      const child = spawn(claudeBin(), buildClaudeArgs(model.id), {
+      const child = spawn(claudeBin(), buildClaudeArgs(model.id, options?.reasoning, useStreamJson), {
         stdio: ["pipe", "pipe", "pipe"],
         env: { ...process.env },
       });
@@ -374,7 +445,7 @@ function streamClaudeCode(
       }, timeout);
       options?.signal?.addEventListener("abort", abort, { once: true });
 
-      child.stdin!.end(prompt);
+      child.stdin!.end(useStreamJson ? buildStreamJsonInput(images, prompt) : prompt);
       child.stdout!.setEncoding("utf8");
       child.stderr!.setEncoding("utf8");
       child.stdout!.on("data", (chunk: string) => {
@@ -397,7 +468,8 @@ function streamClaudeCode(
       if (code !== 0) throw new Error(stderr.trim() || `claude -p exited with code ${code}`);
 
       setEstimatedUsage(model, output, prompt, stdout);
-      const toolCalls = parseToolCalls(stdout);
+      const responseText = useStreamJson ? parseStreamJsonOutput(stdout) : stdout;
+      const toolCalls = parseToolCalls(responseText);
       if (toolCalls.length > 0) {
         output.stopReason = "toolUse";
         for (const call of toolCalls) {
@@ -419,12 +491,12 @@ function streamClaudeCode(
       }
 
       const contentIndex = output.content.length;
-      output.content.push({ type: "text", text: stdout });
+      output.content.push({ type: "text", text: responseText });
       stream.push({ type: "text_start", contentIndex, partial: output });
-      if (stdout) {
-        stream.push({ type: "text_delta", contentIndex, delta: stdout, partial: output });
+      if (responseText) {
+        stream.push({ type: "text_delta", contentIndex, delta: responseText, partial: output });
       }
-      stream.push({ type: "text_end", contentIndex, content: stdout, partial: output });
+      stream.push({ type: "text_end", contentIndex, content: responseText, partial: output });
       stream.push({ type: "done", reason: "stop", message: output });
       stream.end();
     } catch (error) {
@@ -444,7 +516,7 @@ function providerModels() {
     id: model.id,
     name: `${model.name} (Claude Code CLI)`,
     reasoning: model.reasoning,
-    input: ["text"] as ("text" | "image")[],
+    input: ["text", "image"] as ("text" | "image")[],
     contextWindow: model.contextWindow,
     maxTokens: model.maxTokens,
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
@@ -469,6 +541,8 @@ function statusLines(status?: CliStatus): string[] {
     "Transport: strictly local `claude -p` per model turn",
     "Fallbacks: none (no Anthropic SDK, HTTP API, or built-in Claude provider)",
     'Own Claude Code tools: disabled via --tools ""',
+    "Thinking: --effort mapped from Pi thinking levels (minimal→low … xhigh)",
+    "Images: sent as base64 blocks via --input-format stream-json",
     `Registered models: ${registeredModels.length}`,
   ];
 
@@ -535,6 +609,9 @@ export default function claudeCodePiExtension(pi: ExtensionAPI) {
         ctx.ui.notify("Usage: /claude-code-pi [status|models|test|help]", "info");
         ctx.ui.notify("Set CLAUDE_CODE_PI_BIN to override the claude executable.", "info");
         ctx.ui.notify("Set CLAUDE_CODE_PI_MODELS for comma-separated Claude Code model aliases.", "info");
+        ctx.ui.notify("Set CLAUDE_CODE_PI_CONTEXT_WINDOW to override the advertised context window (default 1000000).", "info");
+        ctx.ui.notify("Thinking levels map to `claude -p --effort` (minimal/low→low, medium, high, xhigh).", "info");
+        ctx.ui.notify("Image inputs are sent as base64 blocks via --input-format stream-json.", "info");
         ctx.ui.notify("All provider calls spawn local `claude -p`; there is no API fallback.", "info");
         return;
       }

--- a/extensions/claude-code-pi/test/helpers.test.mjs
+++ b/extensions/claude-code-pi/test/helpers.test.mjs
@@ -3,7 +3,10 @@ import assert from "node:assert/strict";
 import {
   buildClaudeArgs,
   buildPrompt,
+  buildStreamJsonInput,
   configuredModels,
+  effortArgs,
+  parseStreamJsonOutput,
   PROVIDER_ID,
 } from "../dist/index.js";
 
@@ -39,6 +42,55 @@ describe("claude-code-pi helpers", () => {
       "--output-format",
       "text",
     ]);
+  });
+
+  it("maps Pi thinking levels to claude --effort flags", () => {
+    assert.deepEqual(effortArgs(undefined), []);
+    assert.deepEqual(effortArgs("off"), []);
+    assert.deepEqual(effortArgs("minimal"), ["--effort", "low"]);
+    assert.deepEqual(effortArgs("low"), ["--effort", "low"]);
+    assert.deepEqual(effortArgs("medium"), ["--effort", "medium"]);
+    assert.deepEqual(effortArgs("high"), ["--effort", "high"]);
+    assert.deepEqual(effortArgs("xhigh"), ["--effort", "xhigh"]);
+    assert.ok(buildClaudeArgs("sonnet", "high").includes("--effort"));
+  });
+
+  it("switches to stream-json transport when images are present", () => {
+    const args = buildClaudeArgs("sonnet", "medium", true);
+    assert.ok(args.includes("--input-format"));
+    assert.ok(args.includes("stream-json"));
+    assert.ok(args.includes("--verbose"));
+    assert.ok(!args.includes("text"));
+  });
+
+  it("advertises a 1M context window with env override support", () => {
+    const models = configuredModels(undefined);
+    assert.equal(models[0].contextWindow, 1_000_000);
+  });
+
+  it("wraps images and prompt into a stream-json user message", () => {
+    const input = buildStreamJsonInput(
+      [{ type: "image", mimeType: "image/png", data: "aGk=" }],
+      "Describe this.",
+    );
+    const parsed = JSON.parse(input);
+    assert.equal(parsed.type, "user");
+    assert.equal(parsed.message.role, "user");
+    assert.equal(parsed.message.content[0].type, "image");
+    assert.equal(parsed.message.content[0].source.media_type, "image/png");
+    assert.equal(parsed.message.content[0].source.data, "aGk=");
+    assert.equal(parsed.message.content[1].text, "Describe this.");
+  });
+
+  it("extracts text from stream-json output events", () => {
+    const stdout = [
+      JSON.stringify({ type: "system", subtype: "init" }),
+      JSON.stringify({ type: "assistant", message: { content: [{ type: "text", text: "Red" }] } }),
+      JSON.stringify({ type: "result", result: "Red" }),
+      "not json",
+    ].join("\n");
+    assert.equal(parseStreamJsonOutput(stdout), "Red");
+    assert.equal(parseStreamJsonOutput(""), "");
   });
 
   it("serializes Pi context and documents the strict transport boundary", () => {


### PR DESCRIPTION
Closes #47

## Summary
- Enable thinking level support: Pi thinking levels map to `claude -p --effort` (minimal/low→low, medium, high, xhigh; off/unset omits the flag)
- Fix outdated context window: default bumped from 200K to 1M tokens (current Claude aliases serve 1M context), with new `CLAUDE_CODE_PI_CONTEXT_WINDOW` env override
- Enable image input: models now advertise `["text", "image"]`; turns containing images switch to the stream-json transport (`--input-format stream-json --output-format stream-json --verbose`) and send base64 image blocks over stdin

## Verification
- Live-tested `claude -p --effort xhigh` on CLI 2.1.238 (returns OK)
- Live-tested stream-json image transport with a base64 PNG (model correctly identified the color)
- Context window sizes confirmed against current Anthropic docs (Opus/Sonnet/Fable current generations: 1M tokens)
- `npm test`: 9/9 passing; `npm run build` clean