### PR TITLE
feat: add 9router-pi extension with dynamic model discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **9router-pi**: Dynamic `9router` provider discovery from the local OpenAI-compatible `/v1/models` endpoint, with manual refresh and offline fallback support.
+
 ## [0.2.0] — 2026-08-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ More assets live in [`assets/`](assets/) (e.g. `statusline-pi-gpt-5-mini-195toks
 - **claude-code-pi** — Bridge Claude Code CLI model aliases into Pi strictly through local `claude -p` calls, with no SDK/API fallback path.
 - **grok-pi** — Bridge Grok CLI session models (Grok 4.6/4.5, Composer 2.5, Grok Build) into Pi via `grok-cli` and `~/.grok/auth.json`, with Pi thinking levels on reasoning models.
 - **opencode-pi** — Bridge local OpenCode CLI free models into Pi without OpenCode login, with OpenCode tools disabled and Pi tool calls prompt-bridged back into Pi.
+- **9router-pi** — Register the `9router` provider with dynamic discovery from a local OpenAI-compatible `/v1/models` endpoint.
 - **agy-pi** — Bridge `agy` CLI models (Gemini flash/pro variants, Claude Sonnet, GPT OSS) into Pi via an `agy` provider, with auto-discovery from `agy models` output (`extensions/agy-pi/src/index.ts`).
 - **timestamp-pi** — Per-message timestamps with age labels plus a prompt-cache countdown in the footer, stored as session entries so they persist across reloads without reaching the LLM (`extensions/timestamp-pi/src/index.ts`).
 - **subagents-pi** — Fleet metrics panel for managed subagents (context, TPS, model, thinking); works with `@tintinweb/pi-subagents`.
@@ -82,9 +83,9 @@ Try without installing (current session only):
 pi -e npm:advisor-pi
 ```
 
-**Not on npm yet:** `subagents-pi` is packaged for npm but not yet published.
-Install it from a clone (`pi -e ./extensions/subagents-pi`) or via the repo
-installer below.
+**Not on npm yet:** `9router-pi` and `subagents-pi` are packaged for npm but not yet published.
+Install them from a clone (`pi -e ./extensions/9router-pi` or
+`pi -e ./extensions/subagents-pi`) or via the repo installer below.
 
 List and update installed packages:
 
@@ -218,6 +219,18 @@ pi --provider opencode-cli --model opencode/deepseek-v4-flash-free
 
 **Commands:** `/opencode-pi status`, `/opencode-pi models`, `/opencode-pi test`, `/opencode-pi help`
 
+### 9router-pi
+
+`9router-pi` registers the **`9router`** provider and discovers the current model catalog from the local gateway. Use `/9router-pi refresh` after changing enabled models; credentials stay in `~/.pi/agent/models.json`.
+
+Full setup: [extensions/9router-pi/README.md](extensions/9router-pi/README.md)
+
+```bash
+pi -e ./extensions/9router-pi
+```
+
+**Commands:** `/9router-pi status`, `/9router-pi refresh`, `/9router-pi help`
+
 ### advisor-pi
 
 `advisor-pi` registers an `advisor` tool for strategic planning and course correction.
@@ -349,6 +362,7 @@ pi-extensions/
 │   ├── grok-pi/
 │   ├── model-debugger/
 │   ├── opencode-pi/
+│   ├── 9router-pi/
 │   ├── statusline-pi/
 │   ├── subagents-pi/
 │   └── timestamp-pi/

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -7,6 +7,7 @@ Pi Extensions is a collection of side-loadable extensions and themes for Pi Codi
 ```
 pi-extensions/
 ├── extensions/                     # one npm package per extension
+│   ├── 9router-pi/                 # Dynamic 9router model discovery (src/index.ts)
 │   ├── advisor-pi/                 # Advisor tool + /advisor-pi command (src/index.ts)
 │   ├── agy-pi/                     # agy CLI provider bridge (src/index.ts)
 │   ├── claude-code-pi/             # registerProvider + claude -p stream adapter (src/index.ts)
@@ -22,7 +23,7 @@ pi-extensions/
 │   └── opencode.json               # OpenCode-branded theme
 ├── scripts/
 │   ├── check-packaging.mjs         # pi.extensions vs files allowlist guard
-│   └── publish-npm-extensions.sh   # publish all nine npm extensions
+│   └── publish-npm-extensions.sh   # publish all ten npm extensions
 ├── install.sh                      # Interactive/automated installer
 └── package.json                    # npm convenience scripts
 ```
@@ -184,7 +185,7 @@ load from the installed package — see issue #32):
 node scripts/check-packaging.mjs   # also run automatically by publish-npm-extensions.sh
 ```
 
-Publish all nine npm extensions from repo root (approve the 2FA link in your browser):
+Publish all ten npm extensions from repo root (approve the 2FA link in your browser):
 
 ```bash
 chmod +x scripts/publish-npm-extensions.sh
@@ -194,8 +195,8 @@ chmod +x scripts/publish-npm-extensions.sh
 ```
 
 The extension list lives in `EXTENSIONS` at `scripts/publish-npm-extensions.sh:12`;
-all listed extensions except `subagents-pi` are published to npm — the script's
-next run performs `subagents-pi`'s initial publish.
+all listed extensions except `9router-pi` and `subagents-pi` are published to npm —
+the script's next run performs their initial publishes.
 
 ### Gallery `pi.image` URLs (npm metadata)
 

--- a/extensions/9router-pi/README.md
+++ b/extensions/9router-pi/README.md
@@ -1,0 +1,93 @@
+# 9router-pi
+
+Use models exposed by a local **9router** OpenAI-compatible gateway in Pi Coding Agent. The extension discovers the gateway's current model list from `/v1/models`, including model limits, vision support, and reasoning capability.
+
+## What it provides
+
+- Pi provider: `9router`
+- Dynamic discovery at startup
+- `/9router-pi refresh` to fetch the latest catalog without restarting Pi
+- `/9router-pi status` and `/9router-pi help`
+- Static `models.json` entries remain usable when startup discovery is unavailable or `PI_OFFLINE` is set
+
+## Prerequisites
+
+1. A 9router instance running at `http://localhost:20128/v1` (or another configured URL).
+2. Pi API-key configuration for provider `9router`.
+
+The discovery endpoint is currently queried without authentication. The API key is used for model requests through Pi.
+
+## Configuration
+
+Add the provider credentials to `~/.pi/agent/models.json`:
+
+```json
+{
+  "providers": {
+    "9router": {
+      "baseUrl": "http://localhost:20128/v1",
+      "api": "openai-completions",
+      "apiKey": "$NINE_ROUTER_API_KEY"
+    }
+  }
+}
+```
+
+Pi also supports a literal `apiKey`. Do not commit real keys to this repository.
+
+Optional environment variables:
+
+- `NINE_ROUTER_BASE_URL` — overrides the default gateway URL.
+- `NINE_ROUTER_API_KEY` — supplies the request key and overrides the `models.json` key when set.
+
+## Install from this repository
+
+From the repository root:
+
+```bash
+pi -e ./extensions/9router-pi
+```
+
+Or install it persistently:
+
+```bash
+pi install -l ./extensions/9router-pi
+```
+
+Then run `/reload` in Pi (or restart it).
+
+## Usage
+
+List discovered models:
+
+```bash
+pi --list-models 9router
+```
+
+Select a model:
+
+```bash
+pi --provider 9router --model openrouter/stealth/ox-alpha
+```
+
+Refresh after changing the models enabled by 9router:
+
+```text
+/9router-pi refresh
+```
+
+Use `/9router-pi status` to see the discovery count and last error, if any.
+
+## Development
+
+```bash
+cd extensions/9router-pi
+npm install
+npm test
+```
+
+The extension uses Pi's `openai-completions` API adapter and registers models returned by the gateway. The repository intentionally contains no API keys.
+
+## License
+
+MIT — same as [pi-extensions](https://github.com/luongnv89/pi-extensions).

--- a/extensions/9router-pi/README.md
+++ b/extensions/9router-pi/README.md
@@ -37,7 +37,7 @@ Pi also supports a literal `apiKey`. Do not commit real keys to this repository.
 
 Optional environment variables:
 
-- `NINE_ROUTER_BASE_URL` — overrides the default gateway URL.
+- `PI_9ROUTER_BASE_URL` — overrides the `models.json` gateway URL and default.
 - `NINE_ROUTER_API_KEY` — supplies the request key and overrides the `models.json` key when set.
 
 ## Install from this repository

--- a/extensions/9router-pi/package-lock.json
+++ b/extensions/9router-pi/package-lock.json
@@ -1,0 +1,1988 @@
+{
+  "name": "9router-pi",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "9router-pi",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "typescript": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@earendil-works/pi-coding-agent": "^0.84.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent": {
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.84.2.tgz",
+      "integrity": "sha512-l4E+B7hgXKWddRo8bC/eSue2aWZjEgJ9xIpf5p0Og+lq8a2TArCwJ0HCoCPCgaBP/tN4zbYH/wOwvx9pJpeLCA==",
+      "hasShrinkwrap": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@earendil-works/pi-agent-core": "^0.84.2",
+        "@earendil-works/pi-ai": "^0.84.2",
+        "@earendil-works/pi-client": "^0.84.2",
+        "@earendil-works/pi-protocol": "^0.84.2",
+        "@earendil-works/pi-tui": "^0.84.2",
+        "@silvia-odwyer/photon-node": "0.3.4",
+        "chalk": "5.6.2",
+        "cross-spawn": "7.0.6",
+        "diff": "8.0.4",
+        "glob": "13.0.6",
+        "grok-mermaid": "0.2.2",
+        "highlight.js": "10.7.3",
+        "hosted-git-info": "9.0.3",
+        "ignore": "7.0.5",
+        "jiti": "2.7.0",
+        "minimatch": "10.2.5",
+        "proper-lockfile": "4.1.2",
+        "semver": "7.8.0",
+        "typebox": "1.3.7",
+        "undici": "8.9.0",
+        "yaml": "2.9.0"
+      },
+      "bin": {
+        "pi": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      },
+      "optionalDependencies": {
+        "@mariozechner/clipboard": "0.3.9"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@anthropic-ai/sdk": {
+      "version": "0.91.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/client-bedrock-runtime": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
+      "integrity": "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/credential-provider-node": "^3.972.42",
+        "@aws-sdk/eventstream-handler-node": "^3.972.16",
+        "@aws-sdk/middleware-eventstream": "^3.972.12",
+        "@aws-sdk/middleware-websocket": "^3.972.19",
+        "@aws-sdk/token-providers": "3.1048.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/core": {
+      "version": "3.974.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.11.tgz",
+      "integrity": "sha512-QpnINq5FZH6EOaDEkmHdT7eUunbvD27pDNQypaWjFyYz7Zl1q3UCMQErBZxpmfGfI7MvI2TlK8KTkgNpv8b1ug==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/xml-builder": "^3.972.24",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.37.tgz",
+      "integrity": "sha512-/jpPvEh6f7ntmIzf7dNxoNX6Q8vt8UpesCjbW6mFfk4V1NW6bIy9qxcQ6WbA8As5yQhsZOe+xeNd4xHX8kdY2Q==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.39.tgz",
+      "integrity": "sha512-pIgTpisWyWg7X1bUbzSjuUYosYTD0Ghz2M0hkSTmb3a6i3qV3uU+NYJPI/E2XSC0HcsZh5rsLPzeXrkb2DS0Cg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.41.tgz",
+      "integrity": "sha512-u2tyjaxJJzW8UtW4SM1ZcPMDwO6y+kV+llvou+Adts0FAKyzes5jG4izQN+KX3yE8ZROpS5y1LJ//xL2iSf76w==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/credential-provider-env": "^3.972.37",
+        "@aws-sdk/credential-provider-http": "^3.972.39",
+        "@aws-sdk/credential-provider-login": "^3.972.41",
+        "@aws-sdk/credential-provider-process": "^3.972.37",
+        "@aws-sdk/credential-provider-sso": "^3.972.41",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.41",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/credential-provider-imds": "^4.3.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.41.tgz",
+      "integrity": "sha512-0LBitxXiAiaE5nlFPfpNIww/8FRY/I7WIndWsc9GmNFOM7cE1wNpVNQEGEk9Outg5l8xl+3vybxFyUy4l9q/LQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.42.tgz",
+      "integrity": "sha512-D4oon2zbqqsWOJUM99Gm3/ZyJ0IJvTXVN3PyloGb3kQEyI36fjCZheZj422lAgTWWd6TSHgiImLt3RIaLdv3dQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.37",
+        "@aws-sdk/credential-provider-http": "^3.972.39",
+        "@aws-sdk/credential-provider-ini": "^3.972.41",
+        "@aws-sdk/credential-provider-process": "^3.972.37",
+        "@aws-sdk/credential-provider-sso": "^3.972.41",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.41",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/credential-provider-imds": "^4.3.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.37.tgz",
+      "integrity": "sha512-7nVaHBUaWIddASYfVaA9O4D5ZVjewU3sCol9WqZPGfW0nR+0WqE0xHZnD/U2L33PlOB8KNXGKZ6wOES/QijKzg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.41.tgz",
+      "integrity": "sha512-IOWAWEHe5LkjSKkkUUX9ciV6Y1scHTsnfEkdt5yyC4Slrc7AGbkLPrpntjqh18ksJAMOaVhoBsO8p2WyTcY2wQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/token-providers": "3.1048.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.41.tgz",
+      "integrity": "sha512-mbACk9Yypa8nm4iGZLs0PofOXEcTDOUw6wDnsPXNDNSd2WNXs1tSo+6nc/fh0jLYdfVZThhBL98PHW4aXFsG5A==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/eventstream-handler-node": {
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.16.tgz",
+      "integrity": "sha512-yedpPgKftqjU5SlPFHfqWpOw6xSCRieWRG1euWOlXn4WJxt2VX92VprCa2PpSOXjVCAeK6dTjW9eJRXVig9yGA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/middleware-eventstream": {
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.12.tgz",
+      "integrity": "sha512-tHTHHCHNrq6XklQvlzHBDJG4Iuhh7NVPRdtmvP+nHFA+5sxPlIDzlAHHgfoYHGvT3NXP1yVP/L5c3opUn6T3Qg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/middleware-websocket": {
+      "version": "3.972.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.19.tgz",
+      "integrity": "sha512-mkEhOGYozqKQkbFaVrjwr0faiwwZza1v5/jSY6Tucm3bD+uKTazIUH/4Yo6aMnQD2ua2W9cMP6s8mvwTcjtqHw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.9.tgz",
+      "integrity": "sha512-jPR3rnmRI4hWYyzfmTGBr7NblMp8QYYeflHXba1H6+7CGrWVqWKQzaXFQ4qbExqPRsXN3T3L3JxFhr6aouXUGQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.27",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.27.tgz",
+      "integrity": "sha512-0Phbz4t6HI3D3skxvG2uI+VWU034/nSIw1T8d+FPzzQG9EQTrw94o9mOKO2Gv3n3Oc8P7JD7RAUxkoneLWv5Eg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
+      "integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/types": {
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.24.tgz",
+      "integrity": "sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@nodable/entities": "2.1.0",
+        "@smithy/types": "^4.14.1",
+        "fast-xml-parser": "5.7.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.84.2.tgz",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@earendil-works/pi-ai": "^0.84.2",
+        "@earendil-works/pi-telemetry": "^0.84.2",
+        "diff": "8.0.4",
+        "ignore": "7.0.5",
+        "typebox": "1.3.7",
+        "yaml": "2.9.0"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.2.tgz",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@anthropic-ai/sdk": "0.91.1",
+        "@aws-sdk/client-bedrock-runtime": "3.1048.0",
+        "@earendil-works/pi-telemetry": "^0.84.2",
+        "@google/genai": "1.52.0",
+        "@opentelemetry/api": "1.9.0",
+        "@smithy/node-http-handler": "4.7.3",
+        "http-proxy-agent": "7.0.2",
+        "https-proxy-agent": "7.0.6",
+        "openai": "6.40.0",
+        "partial-json": "0.1.7",
+        "typebox": "1.3.7"
+      },
+      "bin": {
+        "pi-ai": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-client": {
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-client/-/pi-client-0.84.2.tgz",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@earendil-works/pi-protocol": "^0.84.2"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-protocol": {
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-protocol/-/pi-protocol-0.84.2.tgz",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "typebox": "1.3.7"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-telemetry": {
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.2.tgz",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.2.tgz",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "get-east-asian-width": "1.6.0",
+        "marked": "18.0.5"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@google/genai": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
+      "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.9.tgz",
+      "integrity": "sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@mariozechner/clipboard-darwin-arm64": "0.3.9",
+        "@mariozechner/clipboard-darwin-universal": "0.3.9",
+        "@mariozechner/clipboard-darwin-x64": "0.3.9",
+        "@mariozechner/clipboard-linux-arm64-gnu": "0.3.9",
+        "@mariozechner/clipboard-linux-arm64-musl": "0.3.9",
+        "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.9",
+        "@mariozechner/clipboard-linux-x64-gnu": "0.3.9",
+        "@mariozechner/clipboard-linux-x64-musl": "0.3.9",
+        "@mariozechner/clipboard-win32-arm64-msvc": "0.3.9",
+        "@mariozechner/clipboard-win32-x64-msvc": "0.3.9"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-arm64": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.9.tgz",
+      "integrity": "sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-universal": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.9.tgz",
+      "integrity": "sha512-BGGR4iA9Z2shAjI65eI5xtyb3LYNlDW9X3gxKxDbqtbnREohsrqznov6zpKoIrsRWpzlYVEdKphS7ksJ0/ndSQ==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-x64": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.9.tgz",
+      "integrity": "sha512-4kURmCbS6nt8uYhtmWpUcJWyPHfmAr5dTpXD1nO3pIfa+TSQ9DbrGOYCKH+aEFW47XhQ4Vp8ZTszie+wfFvDKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-arm64-gnu": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.9.tgz",
+      "integrity": "sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-arm64-musl": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.9.tgz",
+      "integrity": "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-riscv64-gnu": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.9.tgz",
+      "integrity": "sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-x64-gnu": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.9.tgz",
+      "integrity": "sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-x64-musl": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.9.tgz",
+      "integrity": "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-win32-arm64-msvc": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.9.tgz",
+      "integrity": "sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-win32-x64-msvc": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.9.tgz",
+      "integrity": "sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@silvia-odwyer/photon-node": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
+      "integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
+      "license": "Apache-2.0",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/core": {
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.3.tgz",
+      "integrity": "sha512-Ep/7tPamGY8mgESE3LyLKtxJyy6U52WWAqr/3wial47Sj4u3PiIF73AOGI27UyLy9duTkhZbgzodOfLV4TduZg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/credential-provider-imds": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.3.tgz",
+      "integrity": "sha512-I2Bti0DKFo2IJyN28ijCsx51BAumEYR4/1yZ1FXyBygy9MqbnMqCev4JPth/MbpRfBSRAX35hITSnAdJRo1u5w==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/fetch-http-handler": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.3.tgz",
+      "integrity": "sha512-F+DRf8IJazRJgYog2A/yJK7eYVc0rqTlRzO+5ZxjJd4WkZoKz0IJRncf7G6t1pdVT3kryJcwuTFhN1c5m6N47A==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/node-http-handler": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
+      "integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/signature-v4": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.3.tgz",
+      "integrity": "sha512-53+75QuPl6DL+ct6vVEB51FDO5oulXr20TPV46VvJZg76lIlXNWfxi8j+G2V/t0I2qxCBOa3vX/8bmjrpFVo9g==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/types": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
+      "integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-parser": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "peer": true,
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/google-auth-library": {
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/grok-mermaid": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/grok-mermaid/-/grok-mermaid-0.2.2.tgz",
+      "integrity": "sha512-XcJEP5dDC8liHBh52mlLjU18fNvu1ckFsu0QpIG3+APZ270fsj9wxpiA6cOURmbUEuoMVgjbC2+UYgTdCqqgzA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/hosted-git-info": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+      "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "lru-cache": "^11.1.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/lru-cache": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.4.0.tgz",
+      "integrity": "sha512-W+R+kFL4HgVxONq2bhXPi3bGpzGe/yEhVOp233qw9wCRtgncJ15P3bC+e4zZMu4Cq7d+WAJjXGW0uUkifhcatA==",
+      "license": "BlueOak-1.0.0",
+      "peer": true,
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/marked": {
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "peer": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/openai": {
+      "version": "6.40.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.40.0.tgz",
+      "integrity": "sha512-MWtTjd/gQt4jpbji61NTgFWJLoY/PdRJ6wG9/ZDRMYNMlBKrCrSlkLI+KgHP1vR1qT6LKSAyAqIxno6lcK9JiA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/p-retry/node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/partial-json": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
+      "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "peer": true,
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/proper-lockfile/node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/protobufjs": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "license": "ISC",
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/strnum": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/typebox": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.7.tgz",
+      "integrity": "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/undici": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.9.0.tgz",
+      "integrity": "sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/extensions/9router-pi/package-lock.json
+++ b/extensions/9router-pi/package-lock.json
@@ -12,7 +12,7 @@
         "typescript": "^5.6.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22.19.0"
       },
       "peerDependencies": {
         "@earendil-works/pi-coding-agent": "^0.84.2"

--- a/extensions/9router-pi/package.json
+++ b/extensions/9router-pi/package.json
@@ -30,7 +30,7 @@
   "author": "pi-extensions contributors",
   "license": "MIT",
   "engines": {
-    "node": ">=18"
+    "node": ">=22.19.0"
   },
   "repository": {
     "type": "git",

--- a/extensions/9router-pi/package.json
+++ b/extensions/9router-pi/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "9router-pi",
+  "version": "0.1.0",
+  "description": "Dynamic 9router model discovery for Pi Coding Agent",
+  "type": "module",
+  "main": "./src/index.ts",
+  "files": [
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "test": "npm run build && node --test dist/index.test.js",
+    "prepublishOnly": "npm run build"
+  },
+  "pi": {
+    "extensions": [
+      "./src/index.ts"
+    ]
+  },
+  "keywords": [
+    "pi-package",
+    "pi",
+    "pi-coding-agent",
+    "pi-extension",
+    "9router",
+    "custom-provider",
+    "model-discovery"
+  ],
+  "author": "pi-extensions contributors",
+  "license": "MIT",
+  "engines": {
+    "node": ">=18"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/luongnv89/pi-extensions.git"
+  },
+  "bugs": {
+    "url": "https://github.com/luongnv89/pi-extensions/issues"
+  },
+  "homepage": "https://github.com/luongnv89/pi-extensions/tree/main/extensions/9router-pi",
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": "^0.84.2"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/extensions/9router-pi/src/index.test.ts
+++ b/extensions/9router-pi/src/index.test.ts
@@ -1,10 +1,66 @@
 import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import test from "node:test";
-import { normalizeBaseUrl, normalizeModels } from "./index.js";
+import nineRouterPi, { normalizeBaseUrl, normalizeModels } from "./index.js";
 
 test("normalizeBaseUrl trims configuration and trailing slashes", () => {
 	assert.equal(normalizeBaseUrl(" http://localhost:20128/v1/// "), "http://localhost:20128/v1");
 	assert.equal(normalizeBaseUrl(""), "http://localhost:20128/v1");
+});
+
+test("registration inherits the models.json API key when no environment key is set", async () => {
+	const agentDir = await mkdtemp(join(tmpdir(), "9router-pi-test-"));
+	const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+	const originalApiKey = process.env.NINE_ROUTER_API_KEY;
+	const originalOffline = process.env.PI_OFFLINE;
+	const originalFetch = globalThis.fetch;
+	let providerConfig: Parameters<ExtensionAPI["registerProvider"]>[1] | undefined;
+
+	try {
+		await writeFile(
+			join(agentDir, "models.json"),
+			`{
+				// Keep comments and trailing commas compatible with models.json.
+				"providers": {
+					"9router": {
+						"apiKey": "$TEST_9ROUTER_KEY",
+					},
+				},
+			}`,
+		);
+		process.env.PI_CODING_AGENT_DIR = agentDir;
+		delete process.env.NINE_ROUTER_API_KEY;
+		delete process.env.PI_OFFLINE;
+		globalThis.fetch = async () =>
+			new Response(JSON.stringify({ data: [{ id: "discovered-model" }] }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+
+		const pi = {
+			registerCommand() {},
+			registerProvider(_providerId: string, config: Parameters<ExtensionAPI["registerProvider"]>[1]) {
+				if (!config.apiKey) throw new Error("dynamic provider registration requires an API key");
+				providerConfig = config;
+			},
+		} as unknown as ExtensionAPI;
+
+		await nineRouterPi(pi);
+		assert.equal(providerConfig?.apiKey, "$TEST_9ROUTER_KEY");
+		assert.equal(providerConfig?.models?.[0]?.id, "discovered-model");
+	} finally {
+		if (originalAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = originalAgentDir;
+		if (originalApiKey === undefined) delete process.env.NINE_ROUTER_API_KEY;
+		else process.env.NINE_ROUTER_API_KEY = originalApiKey;
+		if (originalOffline === undefined) delete process.env.PI_OFFLINE;
+		else process.env.PI_OFFLINE = originalOffline;
+		globalThis.fetch = originalFetch;
+		await rm(agentDir, { recursive: true, force: true });
+	}
 });
 
 test("normalizeModels maps capabilities and removes invalid duplicates", () => {

--- a/extensions/9router-pi/src/index.test.ts
+++ b/extensions/9router-pi/src/index.test.ts
@@ -385,6 +385,95 @@ test("fallback preserves model-specific base URLs without a provider override", 
 		await nineRouterPi(pi);
 		assert.ok(providerConfig);
 		assert.equal("baseUrl" in providerConfig, false);
+		assert.ok(providerConfig.refreshModels);
+
+		const cached = await providerConfig.refreshModels({
+			allowNetwork: false,
+			publish: async () => true,
+			signal: new AbortController().signal,
+		});
+		assert.equal(cached[0]?.id, "configured-model");
+		assert.equal(cached[0]?.baseUrl, "http://model.example/v1");
+
+		const abortedController = new AbortController();
+		abortedController.abort();
+		const aborted = await providerConfig.refreshModels({
+			allowNetwork: true,
+			publish: async () => true,
+			signal: abortedController.signal,
+		});
+		assert.equal(aborted[0]?.id, "configured-model");
+		assert.equal(aborted[0]?.baseUrl, "http://model.example/v1");
+	} finally {
+		if (originalAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = originalAgentDir;
+		if (originalApiKey === undefined) delete process.env.NINE_ROUTER_API_KEY;
+		else process.env.NINE_ROUTER_API_KEY = originalApiKey;
+		if (originalBaseUrl === undefined) delete process.env.PI_9ROUTER_BASE_URL;
+		else process.env.PI_9ROUTER_BASE_URL = originalBaseUrl;
+		if (originalOffline === undefined) delete process.env.PI_OFFLINE;
+		else process.env.PI_OFFLINE = originalOffline;
+		globalThis.fetch = originalFetch;
+		await rm(agentDir, { recursive: true, force: true });
+	}
+});
+
+test("fallback discovery gives refreshed models an explicit URL without overriding static model URLs", async () => {
+	const agentDir = await mkdtemp(join(tmpdir(), "9router-pi-test-"));
+	const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+	const originalApiKey = process.env.NINE_ROUTER_API_KEY;
+	const originalBaseUrl = process.env.PI_9ROUTER_BASE_URL;
+	const originalOffline = process.env.PI_OFFLINE;
+	const originalFetch = globalThis.fetch;
+	const requestedUrls: string[] = [];
+	let providerConfig: Parameters<ExtensionAPI["registerProvider"]>[1] | undefined;
+
+	try {
+		await writeFile(
+			join(agentDir, "models.json"),
+			JSON.stringify({
+				providers: {
+					"9router": {
+						apiKey: "config-key",
+						models: [{ id: "configured-model", baseUrl: "http://model.example/v1" }],
+					},
+				},
+			}),
+		);
+		process.env.PI_CODING_AGENT_DIR = agentDir;
+		delete process.env.NINE_ROUTER_API_KEY;
+		delete process.env.PI_9ROUTER_BASE_URL;
+		delete process.env.PI_OFFLINE;
+		globalThis.fetch = async (input) => {
+			requestedUrls.push(String(input));
+			if (requestedUrls.length === 1) return new Response("unavailable", { status: 503 });
+			return new Response(
+				JSON.stringify({ data: [{ id: "configured-model" }, { id: "new-model" }] }),
+				{ status: 200 },
+			);
+		};
+
+		const pi = {
+			registerCommand() {},
+			registerProvider(_providerId: string, config: Parameters<ExtensionAPI["registerProvider"]>[1]) {
+				providerConfig = config;
+			},
+		} as unknown as ExtensionAPI;
+
+		await nineRouterPi(pi);
+		assert.ok(providerConfig?.refreshModels);
+		const refreshed = await providerConfig.refreshModels({
+			allowNetwork: true,
+			publish: async () => true,
+			signal: new AbortController().signal,
+		});
+
+		assert.deepEqual(requestedUrls, [
+			"http://localhost:20128/v1/models",
+			"http://localhost:20128/v1/models",
+		]);
+		assert.equal(refreshed[0]?.baseUrl, "http://model.example/v1");
+		assert.equal(refreshed[1]?.baseUrl, "http://localhost:20128/v1");
 	} finally {
 		if (originalAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
 		else process.env.PI_CODING_AGENT_DIR = originalAgentDir;

--- a/extensions/9router-pi/src/index.test.ts
+++ b/extensions/9router-pi/src/index.test.ts
@@ -169,3 +169,155 @@ test("normalizeModels maps capabilities and removes invalid duplicates", () => {
 	assert.equal(models[1].contextWindow, 128000);
 	assert.equal(models[1].maxTokens, 16384);
 });
+
+test("models.json quoted values keep comma-delimiter sequences intact", async () => {
+	const agentDir = await mkdtemp(join(tmpdir(), "9router-pi-test-"));
+	const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+	const originalApiKey = process.env.NINE_ROUTER_API_KEY;
+	const originalBaseUrl = process.env.PI_9ROUTER_BASE_URL;
+	const originalOffline = process.env.PI_OFFLINE;
+	const originalFetch = globalThis.fetch;
+	let providerConfig: Parameters<ExtensionAPI["registerProvider"]>[1] | undefined;
+
+	try {
+		await writeFile(
+			join(agentDir, "models.json"),
+			`{
+				"providers": {
+					"9router": {
+						"baseUrl": "http://config.example/v1, ]",
+						"apiKey": "test-key, }",
+					},
+				},
+			}`,
+		);
+		process.env.PI_CODING_AGENT_DIR = agentDir;
+		delete process.env.NINE_ROUTER_API_KEY;
+		delete process.env.PI_9ROUTER_BASE_URL;
+		delete process.env.PI_OFFLINE;
+		globalThis.fetch = async () =>
+			new Response(JSON.stringify({ data: [{ id: "quoted-value-model" }] }), { status: 200 });
+
+		const pi = {
+			registerCommand() {},
+			registerProvider(_providerId: string, config: Parameters<ExtensionAPI["registerProvider"]>[1]) {
+				providerConfig = config;
+			},
+		} as unknown as ExtensionAPI;
+
+		await nineRouterPi(pi);
+		assert.equal(providerConfig?.baseUrl, "http://config.example/v1, ]");
+		assert.equal(providerConfig?.apiKey, "test-key, }");
+	} finally {
+		if (originalAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = originalAgentDir;
+		if (originalApiKey === undefined) delete process.env.NINE_ROUTER_API_KEY;
+		else process.env.NINE_ROUTER_API_KEY = originalApiKey;
+		if (originalBaseUrl === undefined) delete process.env.PI_9ROUTER_BASE_URL;
+		else process.env.PI_9ROUTER_BASE_URL = originalBaseUrl;
+		if (originalOffline === undefined) delete process.env.PI_OFFLINE;
+		else process.env.PI_OFFLINE = originalOffline;
+		globalThis.fetch = originalFetch;
+		await rm(agentDir, { recursive: true, force: true });
+	}
+});
+
+test("offline startup registers an environment override overlay without models", async () => {
+	const agentDir = await mkdtemp(join(tmpdir(), "9router-pi-test-"));
+	const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+	const originalApiKey = process.env.NINE_ROUTER_API_KEY;
+	const originalBaseUrl = process.env.PI_9ROUTER_BASE_URL;
+	const originalOffline = process.env.PI_OFFLINE;
+	const originalFetch = globalThis.fetch;
+	let providerConfig: Parameters<ExtensionAPI["registerProvider"]>[1] | undefined;
+	let fetchCalls = 0;
+
+	try {
+		await writeFile(
+			join(agentDir, "models.json"),
+			JSON.stringify({ providers: { "9router": { baseUrl: "http://config.example/v1", apiKey: "config-key" } } }),
+		);
+		process.env.PI_CODING_AGENT_DIR = agentDir;
+		process.env.PI_9ROUTER_BASE_URL = " http://environment.example/v1/// ";
+		process.env.NINE_ROUTER_API_KEY = "environment-key";
+		process.env.PI_OFFLINE = "1";
+		globalThis.fetch = async () => {
+			fetchCalls += 1;
+			throw new Error("offline discovery should not run");
+		};
+
+		const pi = {
+			registerCommand() {},
+			registerProvider(_providerId: string, config: Parameters<ExtensionAPI["registerProvider"]>[1]) {
+				providerConfig = config;
+			},
+		} as unknown as ExtensionAPI;
+
+		await nineRouterPi(pi);
+		assert.equal(fetchCalls, 0);
+		assert.equal(providerConfig?.baseUrl, "http://environment.example/v1");
+		assert.equal(providerConfig?.apiKey, "environment-key");
+		assert.equal("models" in (providerConfig ?? {}), false);
+	} finally {
+		if (originalAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = originalAgentDir;
+		if (originalApiKey === undefined) delete process.env.NINE_ROUTER_API_KEY;
+		else process.env.NINE_ROUTER_API_KEY = originalApiKey;
+		if (originalBaseUrl === undefined) delete process.env.PI_9ROUTER_BASE_URL;
+		else process.env.PI_9ROUTER_BASE_URL = originalBaseUrl;
+		if (originalOffline === undefined) delete process.env.PI_OFFLINE;
+		else process.env.PI_OFFLINE = originalOffline;
+		globalThis.fetch = originalFetch;
+		await rm(agentDir, { recursive: true, force: true });
+	}
+});
+
+test("startup discovery failure registers an environment override overlay without models", async () => {
+	const agentDir = await mkdtemp(join(tmpdir(), "9router-pi-test-"));
+	const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+	const originalApiKey = process.env.NINE_ROUTER_API_KEY;
+	const originalBaseUrl = process.env.PI_9ROUTER_BASE_URL;
+	const originalOffline = process.env.PI_OFFLINE;
+	const originalFetch = globalThis.fetch;
+	const requestedUrls: string[] = [];
+	let providerConfig: Parameters<ExtensionAPI["registerProvider"]>[1] | undefined;
+
+	try {
+		await writeFile(
+			join(agentDir, "models.json"),
+			JSON.stringify({ providers: { "9router": { baseUrl: "http://config.example/v1", apiKey: "config-key" } } }),
+		);
+		process.env.PI_CODING_AGENT_DIR = agentDir;
+		process.env.PI_9ROUTER_BASE_URL = "http://environment.example/v1";
+		process.env.NINE_ROUTER_API_KEY = "environment-key";
+		delete process.env.PI_OFFLINE;
+		globalThis.fetch = async (input) => {
+			requestedUrls.push(String(input));
+			return new Response("unavailable", { status: 503 });
+		};
+
+		const pi = {
+			registerCommand() {},
+			registerProvider(_providerId: string, config: Parameters<ExtensionAPI["registerProvider"]>[1]) {
+				providerConfig = config;
+			},
+		} as unknown as ExtensionAPI;
+
+		await nineRouterPi(pi);
+		assert.deepEqual(requestedUrls, ["http://environment.example/v1/models"]);
+		assert.equal(providerConfig?.baseUrl, "http://environment.example/v1");
+		assert.equal(providerConfig?.apiKey, "environment-key");
+		assert.equal("models" in (providerConfig ?? {}), false);
+	} finally {
+		if (originalAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = originalAgentDir;
+		if (originalApiKey === undefined) delete process.env.NINE_ROUTER_API_KEY;
+		else process.env.NINE_ROUTER_API_KEY = originalApiKey;
+		if (originalBaseUrl === undefined) delete process.env.PI_9ROUTER_BASE_URL;
+		else process.env.PI_9ROUTER_BASE_URL = originalBaseUrl;
+		if (originalOffline === undefined) delete process.env.PI_OFFLINE;
+		else process.env.PI_OFFLINE = originalOffline;
+		globalThis.fetch = originalFetch;
+		await rm(agentDir, { recursive: true, force: true });
+	}
+});

--- a/extensions/9router-pi/src/index.test.ts
+++ b/extensions/9router-pi/src/index.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { normalizeBaseUrl, normalizeModels } from "./index.js";
+
+test("normalizeBaseUrl trims configuration and trailing slashes", () => {
+	assert.equal(normalizeBaseUrl(" http://localhost:20128/v1/// "), "http://localhost:20128/v1");
+	assert.equal(normalizeBaseUrl(""), "http://localhost:20128/v1");
+});
+
+test("normalizeModels maps capabilities and removes invalid duplicates", () => {
+	const models = normalizeModels({
+		data: [
+			{
+				id: "alpha",
+				context_length: 256000,
+				max_completion_tokens: 8192,
+				capabilities: {
+					vision: true,
+					reasoning: true,
+					thinkingFormat: "zai",
+					thinkingCanDisable: false,
+				},
+			},
+			{ id: "alpha", capabilities: { reasoning: false } },
+			{ id: "  beta  " },
+			{ id: "" },
+			{ id: null },
+		],
+	});
+
+	assert.equal(models.length, 2);
+	assert.deepEqual(models[0], {
+		id: "alpha",
+		name: "alpha",
+		reasoning: true,
+		thinkingLevelMap: { off: null },
+		input: ["text", "image"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 256000,
+		maxTokens: 8192,
+		compat: { thinkingFormat: "zai" },
+	});
+	assert.equal(models[1].id, "beta");
+	assert.equal(models[1].contextWindow, 128000);
+	assert.equal(models[1].maxTokens, 16384);
+});

--- a/extensions/9router-pi/src/index.test.ts
+++ b/extensions/9router-pi/src/index.test.ts
@@ -272,6 +272,133 @@ test("offline startup registers an environment override overlay without models",
 	}
 });
 
+test("startup fallback refresh retries discovery through the command", async () => {
+	const agentDir = await mkdtemp(join(tmpdir(), "9router-pi-test-"));
+	const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+	const originalApiKey = process.env.NINE_ROUTER_API_KEY;
+	const originalBaseUrl = process.env.PI_9ROUTER_BASE_URL;
+	const originalOffline = process.env.PI_OFFLINE;
+	const originalFetch = globalThis.fetch;
+	const requestedUrls: string[] = [];
+	let providerConfig: Parameters<ExtensionAPI["registerProvider"]>[1] | undefined;
+	type CommandHandler = Parameters<ExtensionAPI["registerCommand"]>[1]["handler"];
+	let commandHandler: CommandHandler | undefined;
+
+	try {
+		await writeFile(
+			join(agentDir, "models.json"),
+			JSON.stringify({ providers: { "9router": { apiKey: "config-key" } } }),
+		);
+		process.env.PI_CODING_AGENT_DIR = agentDir;
+		process.env.PI_9ROUTER_BASE_URL = "http://environment.example/v1";
+		delete process.env.PI_OFFLINE;
+		globalThis.fetch = async (input) => {
+			requestedUrls.push(String(input));
+			if (requestedUrls.length === 1) return new Response("unavailable", { status: 503 });
+			return new Response(JSON.stringify({ data: [{ id: "retried-model" }] }), { status: 200 });
+		};
+
+		const pi = {
+			registerCommand(_name: string, config: { handler: CommandHandler }) {
+				commandHandler = config.handler;
+			},
+			registerProvider(_providerId: string, config: Parameters<ExtensionAPI["registerProvider"]>[1]) {
+				providerConfig = config;
+			},
+		} as unknown as ExtensionAPI;
+
+		await nineRouterPi(pi);
+		const fallbackConfig = providerConfig;
+		const refresh = fallbackConfig?.refreshModels;
+		assert.ok(refresh);
+		assert.ok(commandHandler);
+		const ctx = {
+			modelRegistry: {
+				refresh: async () => {
+					const models = await refresh({
+						allowNetwork: true,
+						publish: async () => true,
+						signal: new AbortController().signal,
+					});
+					assert.equal(models?.[0]?.id, "retried-model");
+					return { aborted: false, errors: new Map() };
+				},
+			},
+			ui: { notify() {} },
+		} as unknown as Parameters<CommandHandler>[1];
+
+		await commandHandler("refresh", ctx);
+		assert.deepEqual(requestedUrls, [
+			"http://environment.example/v1/models",
+			"http://environment.example/v1/models",
+		]);
+	} finally {
+		if (originalAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = originalAgentDir;
+		if (originalApiKey === undefined) delete process.env.NINE_ROUTER_API_KEY;
+		else process.env.NINE_ROUTER_API_KEY = originalApiKey;
+		if (originalBaseUrl === undefined) delete process.env.PI_9ROUTER_BASE_URL;
+		else process.env.PI_9ROUTER_BASE_URL = originalBaseUrl;
+		if (originalOffline === undefined) delete process.env.PI_OFFLINE;
+		else process.env.PI_OFFLINE = originalOffline;
+		globalThis.fetch = originalFetch;
+		await rm(agentDir, { recursive: true, force: true });
+	}
+});
+
+test("fallback preserves model-specific base URLs without a provider override", async () => {
+	const agentDir = await mkdtemp(join(tmpdir(), "9router-pi-test-"));
+	const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+	const originalApiKey = process.env.NINE_ROUTER_API_KEY;
+	const originalBaseUrl = process.env.PI_9ROUTER_BASE_URL;
+	const originalOffline = process.env.PI_OFFLINE;
+	const originalFetch = globalThis.fetch;
+	let providerConfig: Parameters<ExtensionAPI["registerProvider"]>[1] | undefined;
+
+	try {
+		await writeFile(
+			join(agentDir, "models.json"),
+			JSON.stringify({
+				providers: {
+					"9router": {
+						apiKey: "config-key",
+						models: [{ id: "configured-model", baseUrl: "http://model.example/v1" }],
+					},
+				},
+			}),
+		);
+		process.env.PI_CODING_AGENT_DIR = agentDir;
+		delete process.env.NINE_ROUTER_API_KEY;
+		delete process.env.PI_9ROUTER_BASE_URL;
+		process.env.PI_OFFLINE = "1";
+		globalThis.fetch = async () => {
+			throw new Error("offline discovery should not run");
+		};
+
+		const pi = {
+			registerCommand() {},
+			registerProvider(_providerId: string, config: Parameters<ExtensionAPI["registerProvider"]>[1]) {
+				providerConfig = config;
+			},
+		} as unknown as ExtensionAPI;
+
+		await nineRouterPi(pi);
+		assert.ok(providerConfig);
+		assert.equal("baseUrl" in providerConfig, false);
+	} finally {
+		if (originalAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = originalAgentDir;
+		if (originalApiKey === undefined) delete process.env.NINE_ROUTER_API_KEY;
+		else process.env.NINE_ROUTER_API_KEY = originalApiKey;
+		if (originalBaseUrl === undefined) delete process.env.PI_9ROUTER_BASE_URL;
+		else process.env.PI_9ROUTER_BASE_URL = originalBaseUrl;
+		if (originalOffline === undefined) delete process.env.PI_OFFLINE;
+		else process.env.PI_OFFLINE = originalOffline;
+		globalThis.fetch = originalFetch;
+		await rm(agentDir, { recursive: true, force: true });
+	}
+});
+
 test("startup discovery failure registers an environment override overlay without models", async () => {
 	const agentDir = await mkdtemp(join(tmpdir(), "9router-pi-test-"));
 	const originalAgentDir = process.env.PI_CODING_AGENT_DIR;

--- a/extensions/9router-pi/src/index.test.ts
+++ b/extensions/9router-pi/src/index.test.ts
@@ -15,8 +15,10 @@ test("registration inherits the models.json API key when no environment key is s
 	const agentDir = await mkdtemp(join(tmpdir(), "9router-pi-test-"));
 	const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
 	const originalApiKey = process.env.NINE_ROUTER_API_KEY;
+	const originalBaseUrl = process.env.PI_9ROUTER_BASE_URL;
 	const originalOffline = process.env.PI_OFFLINE;
 	const originalFetch = globalThis.fetch;
+	const requestedUrls: string[] = [];
 	let providerConfig: Parameters<ExtensionAPI["registerProvider"]>[1] | undefined;
 
 	try {
@@ -26,6 +28,7 @@ test("registration inherits the models.json API key when no environment key is s
 				// Keep comments and trailing commas compatible with models.json.
 				"providers": {
 					"9router": {
+						"baseUrl": "http://config.example/v1",
 						"apiKey": "$TEST_9ROUTER_KEY",
 					},
 				},
@@ -33,12 +36,15 @@ test("registration inherits the models.json API key when no environment key is s
 		);
 		process.env.PI_CODING_AGENT_DIR = agentDir;
 		delete process.env.NINE_ROUTER_API_KEY;
+		delete process.env.PI_9ROUTER_BASE_URL;
 		delete process.env.PI_OFFLINE;
-		globalThis.fetch = async () =>
-			new Response(JSON.stringify({ data: [{ id: "discovered-model" }] }), {
+		globalThis.fetch = async (input) => {
+			requestedUrls.push(String(input));
+			return new Response(JSON.stringify({ data: [{ id: "discovered-model" }] }), {
 				status: 200,
 				headers: { "content-type": "application/json" },
 			});
+		};
 
 		const pi = {
 			registerCommand() {},
@@ -50,12 +56,75 @@ test("registration inherits the models.json API key when no environment key is s
 
 		await nineRouterPi(pi);
 		assert.equal(providerConfig?.apiKey, "$TEST_9ROUTER_KEY");
+		assert.equal(providerConfig?.baseUrl, "http://config.example/v1");
+		assert.deepEqual(requestedUrls, ["http://config.example/v1/models"]);
 		assert.equal(providerConfig?.models?.[0]?.id, "discovered-model");
 	} finally {
 		if (originalAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
 		else process.env.PI_CODING_AGENT_DIR = originalAgentDir;
 		if (originalApiKey === undefined) delete process.env.NINE_ROUTER_API_KEY;
 		else process.env.NINE_ROUTER_API_KEY = originalApiKey;
+		if (originalBaseUrl === undefined) delete process.env.PI_9ROUTER_BASE_URL;
+		else process.env.PI_9ROUTER_BASE_URL = originalBaseUrl;
+		if (originalOffline === undefined) delete process.env.PI_OFFLINE;
+		else process.env.PI_OFFLINE = originalOffline;
+		globalThis.fetch = originalFetch;
+		await rm(agentDir, { recursive: true, force: true });
+	}
+});
+
+test("environment base URL overrides models.json for discovery and refresh", async () => {
+	const agentDir = await mkdtemp(join(tmpdir(), "9router-pi-test-"));
+	const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+	const originalBaseUrl = process.env.PI_9ROUTER_BASE_URL;
+	const originalOffline = process.env.PI_OFFLINE;
+	const originalFetch = globalThis.fetch;
+	const requestedUrls: string[] = [];
+	let providerConfig: Parameters<ExtensionAPI["registerProvider"]>[1] | undefined;
+
+	try {
+		await writeFile(
+			join(agentDir, "models.json"),
+			JSON.stringify({ providers: { "9router": { baseUrl: "http://config.example/v1" } } }),
+		);
+		process.env.PI_CODING_AGENT_DIR = agentDir;
+		process.env.PI_9ROUTER_BASE_URL = " http://environment.example/v1/// ";
+		delete process.env.PI_OFFLINE;
+		globalThis.fetch = async (input) => {
+			requestedUrls.push(String(input));
+			const id = requestedUrls.length === 1 ? "startup-model" : "refreshed-model";
+			return new Response(JSON.stringify({ data: [{ id }] }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		};
+
+		const pi = {
+			registerCommand() {},
+			registerProvider(_providerId: string, config: Parameters<ExtensionAPI["registerProvider"]>[1]) {
+				providerConfig = config;
+			},
+		} as unknown as ExtensionAPI;
+
+		await nineRouterPi(pi);
+		assert.equal(providerConfig?.baseUrl, "http://environment.example/v1");
+		assert.deepEqual(requestedUrls, ["http://environment.example/v1/models"]);
+		assert.ok(providerConfig?.refreshModels);
+		const refreshed = await providerConfig.refreshModels({
+			allowNetwork: true,
+			publish: async () => true,
+			signal: new AbortController().signal,
+		});
+		assert.equal(refreshed[0]?.id, "refreshed-model");
+		assert.deepEqual(requestedUrls, [
+			"http://environment.example/v1/models",
+			"http://environment.example/v1/models",
+		]);
+	} finally {
+		if (originalAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = originalAgentDir;
+		if (originalBaseUrl === undefined) delete process.env.PI_9ROUTER_BASE_URL;
+		else process.env.PI_9ROUTER_BASE_URL = originalBaseUrl;
 		if (originalOffline === undefined) delete process.env.PI_OFFLINE;
 		else process.env.PI_OFFLINE = originalOffline;
 		globalThis.fetch = originalFetch;

--- a/extensions/9router-pi/src/index.test.ts
+++ b/extensions/9router-pi/src/index.test.ts
@@ -537,3 +537,203 @@ test("startup discovery failure registers an environment override overlay withou
 		await rm(agentDir, { recursive: true, force: true });
 	}
 });
+
+test("fallback reconstruction preserves metadata and merges provider compat defaults", async () => {
+	const agentDir = await mkdtemp(join(tmpdir(), "9router-pi-test-"));
+	const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+	const originalBaseUrl = process.env.PI_9ROUTER_BASE_URL;
+	const originalOffline = process.env.PI_OFFLINE;
+	const originalFetch = globalThis.fetch;
+	let providerConfig: Parameters<ExtensionAPI["registerProvider"]>[1] | undefined;
+	const storedModel = {
+		id: "stored-model",
+		name: "Stored model",
+		reasoning: false,
+		input: ["text"],
+		cost: {
+			input: 1,
+			output: 2,
+			cacheRead: 3,
+			cacheWrite: 4,
+			tiers: [{ input: 0, output: 0, cacheRead: 0, cacheWrite: 0, inputTokensAbove: 1000 }],
+		},
+		contextWindow: 8192,
+		maxTokens: 1024,
+		samplingParams: { temperature: 0.2 },
+		headers: { "x-model": "stored" },
+		compat: { supportsDeveloperRole: false },
+		futureMetadata: { preserved: true },
+	};
+
+	try {
+		await writeFile(
+			join(agentDir, "models.json"),
+			JSON.stringify({
+				providers: {
+					"9router": {
+						compat: { supportsDeveloperRole: true, supportsUsageInStreaming: false },
+					},
+				},
+			}),
+		);
+		process.env.PI_CODING_AGENT_DIR = agentDir;
+		delete process.env.PI_9ROUTER_BASE_URL;
+		process.env.PI_OFFLINE = "1";
+		globalThis.fetch = async () => {
+			throw new Error("offline discovery should not run");
+		};
+
+		const pi = {
+			registerCommand() {},
+			registerProvider(_providerId: string, config: Parameters<ExtensionAPI["registerProvider"]>[1]) {
+				providerConfig = config;
+			},
+		} as unknown as ExtensionAPI;
+
+		await nineRouterPi(pi);
+		assert.ok(providerConfig?.refreshModels);
+		const result = await providerConfig.refreshModels({
+			allowNetwork: false,
+			stored: { models: [storedModel] } as never,
+			publish: async ({ update }) => {
+				update?.();
+				return true;
+			},
+			signal: new AbortController().signal,
+		});
+		assert.deepEqual(result[0], {
+			...storedModel,
+			compat: { supportsDeveloperRole: false, supportsUsageInStreaming: false },
+		});
+		assert.deepEqual(storedModel.compat, { supportsDeveloperRole: false });
+	} finally {
+		if (originalAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = originalAgentDir;
+		if (originalBaseUrl === undefined) delete process.env.PI_9ROUTER_BASE_URL;
+		else process.env.PI_9ROUTER_BASE_URL = originalBaseUrl;
+		if (originalOffline === undefined) delete process.env.PI_OFFLINE;
+		else process.env.PI_OFFLINE = originalOffline;
+		globalThis.fetch = originalFetch;
+		await rm(agentDir, { recursive: true, force: true });
+	}
+});
+
+test("discovered models inherit provider compat without replacing model compat", async () => {
+	const agentDir = await mkdtemp(join(tmpdir(), "9router-pi-test-"));
+	const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+	const originalBaseUrl = process.env.PI_9ROUTER_BASE_URL;
+	const originalOffline = process.env.PI_OFFLINE;
+	const originalFetch = globalThis.fetch;
+	let providerConfig: Parameters<ExtensionAPI["registerProvider"]>[1] | undefined;
+
+	try {
+		await writeFile(
+			join(agentDir, "models.json"),
+			JSON.stringify({ providers: { "9router": { compat: { supportsDeveloperRole: true } } } }),
+		);
+		process.env.PI_CODING_AGENT_DIR = agentDir;
+		process.env.PI_9ROUTER_BASE_URL = "http://compat.example/v1";
+		delete process.env.PI_OFFLINE;
+		globalThis.fetch = async () =>
+			new Response(
+				JSON.stringify({
+					data: [{ id: "discovered-model", capabilities: { thinkingFormat: "zai", reasoning: true } }],
+				}),
+				{ status: 200 },
+			);
+
+		const pi = {
+			registerCommand() {},
+			registerProvider(_providerId: string, config: Parameters<ExtensionAPI["registerProvider"]>[1]) {
+				providerConfig = config;
+			},
+		} as unknown as ExtensionAPI;
+
+		await nineRouterPi(pi);
+		assert.deepEqual(providerConfig?.models?.[0]?.compat, {
+			supportsDeveloperRole: true,
+			thinkingFormat: "zai",
+		});
+	} finally {
+		if (originalAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = originalAgentDir;
+		if (originalBaseUrl === undefined) delete process.env.PI_9ROUTER_BASE_URL;
+		else process.env.PI_9ROUTER_BASE_URL = originalBaseUrl;
+		if (originalOffline === undefined) delete process.env.PI_OFFLINE;
+		else process.env.PI_OFFLINE = originalOffline;
+		globalThis.fetch = originalFetch;
+		await rm(agentDir, { recursive: true, force: true });
+	}
+});
+
+test("superseded refresh cannot overwrite a later cache-only catalog", async () => {
+	const agentDir = await mkdtemp(join(tmpdir(), "9router-pi-test-"));
+	const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+	const originalBaseUrl = process.env.PI_9ROUTER_BASE_URL;
+	const originalOffline = process.env.PI_OFFLINE;
+	const originalFetch = globalThis.fetch;
+	let providerConfig: Parameters<ExtensionAPI["registerProvider"]>[1] | undefined;
+	let resolveFetch: ((response: Response) => void) | undefined;
+	const fetchResponse = new Promise<Response>((resolve) => {
+		resolveFetch = resolve;
+	});
+
+	try {
+		await writeFile(
+			join(agentDir, "models.json"),
+			JSON.stringify({ providers: { "9router": { models: [{ id: "prior-model" }] } } }),
+		);
+		process.env.PI_CODING_AGENT_DIR = agentDir;
+		delete process.env.PI_9ROUTER_BASE_URL;
+		process.env.PI_OFFLINE = "1";
+		globalThis.fetch = async () => fetchResponse;
+
+		const pi = {
+			registerCommand() {},
+			registerProvider(_providerId: string, config: Parameters<ExtensionAPI["registerProvider"]>[1]) {
+				providerConfig = config;
+			},
+		} as unknown as ExtensionAPI;
+		await nineRouterPi(pi);
+		assert.ok(providerConfig?.refreshModels);
+
+		delete process.env.PI_OFFLINE;
+		const lateRefresh = providerConfig.refreshModels({
+			allowNetwork: true,
+			publish: async () => false,
+			signal: new AbortController().signal,
+		});
+		const cached = await providerConfig.refreshModels({
+			allowNetwork: false,
+			stored: { models: [{ id: "cached-model" }] } as never,
+			publish: async ({ update }) => {
+				update?.();
+				return true;
+			},
+			signal: new AbortController().signal,
+		});
+		assert.equal(cached[0]?.id, "cached-model");
+
+		resolveFetch?.(new Response(JSON.stringify({ data: [{ id: "late-model" }] }), { status: 200 }));
+		const rejected = await lateRefresh;
+		assert.equal(rejected[0]?.id, "prior-model");
+
+		const current = await providerConfig.refreshModels({
+			allowNetwork: false,
+			publish: async () => {
+				throw new Error("no publication should be needed for an accepted cache");
+			},
+			signal: new AbortController().signal,
+		});
+		assert.equal(current[0]?.id, "cached-model");
+	} finally {
+		if (originalAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = originalAgentDir;
+		if (originalBaseUrl === undefined) delete process.env.PI_9ROUTER_BASE_URL;
+		else process.env.PI_9ROUTER_BASE_URL = originalBaseUrl;
+		if (originalOffline === undefined) delete process.env.PI_OFFLINE;
+		else process.env.PI_OFFLINE = originalOffline;
+		globalThis.fetch = originalFetch;
+		await rm(agentDir, { recursive: true, force: true });
+	}
+});

--- a/extensions/9router-pi/src/index.ts
+++ b/extensions/9router-pi/src/index.ts
@@ -1,4 +1,4 @@
-import { getAgentDir, type ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { getAgentDir, type ExtensionAPI, type ProviderModelConfig } from "@earendil-works/pi-coding-agent";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
@@ -44,6 +44,7 @@ export type RouterModelsResponse = {
 export type RouterPiModel = {
 	id: string;
 	name: string;
+	baseUrl?: string;
 	reasoning: boolean;
 	thinkingLevelMap?: Partial<Record<PiThinkingLevel, string | null>>;
 	input: ("text" | "image")[];
@@ -180,9 +181,12 @@ function stripJsonComments(input: string): string {
 	return output;
 }
 
+type ModelsJsonModel = Partial<ProviderModelConfig> & { id?: unknown };
+
 type ModelsJsonProvider = {
 	apiKey?: unknown;
 	baseUrl?: unknown;
+	models?: ModelsJsonModel[];
 };
 
 function providerFromModelsJson(): ModelsJsonProvider | undefined {
@@ -200,6 +204,74 @@ function providerFromModelsJson(): ModelsJsonProvider | undefined {
 function apiKeyFromModelsJson(): string | undefined {
 	const value = providerFromModelsJson()?.apiKey;
 	return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function inputFromConfig(value: unknown): ("text" | "image")[] {
+	if (!Array.isArray(value)) return ["text"];
+	const input = value.filter((entry): entry is "text" | "image" => entry === "text" || entry === "image");
+	return input.length > 0 ? input : ["text"];
+}
+
+function nonNegativeNumber(value: unknown, fallback: number): number {
+	return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : fallback;
+}
+
+function costFromConfig(value: unknown): ProviderModelConfig["cost"] {
+	if (!isRecord(value)) return ZERO_COST;
+	return {
+		input: nonNegativeNumber(value.input, 0),
+		output: nonNegativeNumber(value.output, 0),
+		cacheRead: nonNegativeNumber(value.cacheRead, 0),
+		cacheWrite: nonNegativeNumber(value.cacheWrite, 0),
+	};
+}
+
+function modelConfigFromUnknown(value: unknown): ProviderModelConfig | undefined {
+	if (!isRecord(value) || typeof value.id !== "string" || value.id.trim().length === 0) return undefined;
+
+	const id = value.id.trim();
+	const model: ProviderModelConfig = {
+		id,
+		name: typeof value.name === "string" && value.name.trim() ? value.name : id,
+		reasoning: value.reasoning === true,
+		input: inputFromConfig(value.input),
+		cost: costFromConfig(value.cost),
+		contextWindow: positiveNumber(value.contextWindow, 128000),
+		maxTokens: positiveNumber(value.maxTokens, 16384),
+	};
+
+	if (typeof value.api === "string") model.api = value.api as ProviderModelConfig["api"];
+	if (typeof value.baseUrl === "string" && value.baseUrl.trim()) model.baseUrl = value.baseUrl;
+	if (isRecord(value.thinkingLevelMap)) {
+		model.thinkingLevelMap = value.thinkingLevelMap as ProviderModelConfig["thinkingLevelMap"];
+	}
+	if (isRecord(value.headers)) model.headers = value.headers as Record<string, string>;
+	if (isRecord(value.compat)) model.compat = value.compat as ProviderModelConfig["compat"];
+	return model;
+}
+
+function staticModelsFromModelsJson(): ProviderModelConfig[] {
+	return (providerFromModelsJson()?.models ?? [])
+		.map((model) => modelConfigFromUnknown(model))
+		.filter((model): model is ProviderModelConfig => model !== undefined);
+}
+
+function modelsFromStored(stored: { models: readonly unknown[] } | undefined): ProviderModelConfig[] {
+	return (stored?.models ?? [])
+		.map((model) => modelConfigFromUnknown(model))
+		.filter((model): model is ProviderModelConfig => model !== undefined);
+}
+
+function fallbackCatalog(
+	models: ProviderModelConfig[],
+	hasProviderBaseUrlOverride: boolean,
+): ProviderModelConfig[] {
+	if (!hasProviderBaseUrlOverride) return models;
+	return models.map(({ baseUrl: _baseUrl, ...model }) => model);
 }
 
 function baseUrlFromEnvironment(): string | undefined {
@@ -224,14 +296,16 @@ function configuredApiKey(): string | undefined {
 	return apiKeyFromEnvironment() ?? apiKeyFromModelsJson();
 }
 
-let registeredModels: RouterPiModel[] = [];
+let registeredModels: ProviderModelConfig[] = [];
 let registeredBaseUrl = configuredBaseUrl();
+let fallbackCatalogSource: "static" | "stored" | "live" | undefined;
 let providerRegistered = false;
 let lastDiscoveryError: string | undefined;
 
 function registerDynamicProvider(pi: ExtensionAPI, baseUrl: string, initialModels: RouterPiModel[]): void {
 	registeredBaseUrl = baseUrl;
 	registeredModels = initialModels;
+	fallbackCatalogSource = undefined;
 	lastDiscoveryError = undefined;
 
 	const apiKey = configuredApiKey();
@@ -256,7 +330,9 @@ function registerFallbackProvider(pi: ExtensionAPI): void {
 	const configuredBaseUrl = configuredBaseUrlOverride();
 	const discoveryBaseUrl = normalizeBaseUrl(configuredBaseUrl);
 	registeredBaseUrl = discoveryBaseUrl;
-	registeredModels = [];
+	const hasProviderBaseUrlOverride = configuredBaseUrl !== undefined;
+	registeredModels = fallbackCatalog(staticModelsFromModelsJson(), hasProviderBaseUrlOverride);
+	fallbackCatalogSource = "static";
 
 	const apiKey = configuredApiKey();
 	pi.registerProvider(PROVIDER_ID, {
@@ -264,12 +340,41 @@ function registerFallbackProvider(pi: ExtensionAPI): void {
 		...(configuredBaseUrl ? { baseUrl: discoveryBaseUrl } : {}),
 		api: "openai-completions",
 		...(apiKey ? { apiKey } : {}),
-		async refreshModels({ allowNetwork, signal }) {
-			if (!allowNetwork || signal.aborted) return registeredModels;
+		async refreshModels({ allowNetwork, signal, stored }) {
+			const storedModels = fallbackCatalog(modelsFromStored(stored), hasProviderBaseUrlOverride);
+			const previousModels =
+				fallbackCatalogSource !== "static" && registeredModels.length > 0
+					? registeredModels
+					: storedModels.length > 0
+						? storedModels
+						: registeredModels.length > 0
+							? registeredModels
+							: fallbackCatalog(staticModelsFromModelsJson(), hasProviderBaseUrlOverride);
+
+			if (!allowNetwork || signal.aborted) {
+				if (storedModels.length > 0 && fallbackCatalogSource === "static") {
+					registeredModels = storedModels;
+					fallbackCatalogSource = "stored";
+				}
+				return [...previousModels];
+			}
+
 			const refreshed = await discoverModels(discoveryBaseUrl, signal);
-			registeredModels = refreshed;
+			if (signal.aborted) return [...previousModels];
+
+			const staticModels = staticModelsFromModelsJson();
+			const models = hasProviderBaseUrlOverride
+				? refreshed
+				: refreshed.map((model) => {
+						const staticModel = staticModels.find((candidate) => candidate.id === model.id);
+						return staticModel?.baseUrl
+							? { ...model, baseUrl: staticModel.baseUrl }
+							: { ...model, baseUrl: discoveryBaseUrl };
+					});
+			registeredModels = models;
+			fallbackCatalogSource = "live";
 			lastDiscoveryError = undefined;
-			return refreshed;
+			return [...models];
 		},
 	});
 	providerRegistered = true;

--- a/extensions/9router-pi/src/index.ts
+++ b/extensions/9router-pi/src/index.ts
@@ -212,8 +212,12 @@ function baseUrlFromModelsJson(): string | undefined {
 	return typeof value === "string" && value.trim() ? value : undefined;
 }
 
+function configuredBaseUrlOverride(): string | undefined {
+	return baseUrlFromEnvironment() ?? baseUrlFromModelsJson();
+}
+
 function configuredBaseUrl(): string {
-	return normalizeBaseUrl(baseUrlFromEnvironment() ?? baseUrlFromModelsJson());
+	return normalizeBaseUrl(configuredBaseUrlOverride());
 }
 
 function configuredApiKey(): string | undefined {
@@ -249,16 +253,24 @@ function registerDynamicProvider(pi: ExtensionAPI, baseUrl: string, initialModel
 }
 
 function registerFallbackProvider(pi: ExtensionAPI): void {
-	const baseUrl = configuredBaseUrl();
-	registeredBaseUrl = baseUrl;
+	const configuredBaseUrl = configuredBaseUrlOverride();
+	const discoveryBaseUrl = normalizeBaseUrl(configuredBaseUrl);
+	registeredBaseUrl = discoveryBaseUrl;
 	registeredModels = [];
 
 	const apiKey = configuredApiKey();
 	pi.registerProvider(PROVIDER_ID, {
 		name: "9router",
-		baseUrl,
+		...(configuredBaseUrl ? { baseUrl: discoveryBaseUrl } : {}),
 		api: "openai-completions",
 		...(apiKey ? { apiKey } : {}),
+		async refreshModels({ allowNetwork, signal }) {
+			if (!allowNetwork || signal.aborted) return registeredModels;
+			const refreshed = await discoverModels(discoveryBaseUrl, signal);
+			registeredModels = refreshed;
+			lastDiscoveryError = undefined;
+			return refreshed;
+		},
 	});
 	providerRegistered = true;
 }

--- a/extensions/9router-pi/src/index.ts
+++ b/extensions/9router-pi/src/index.ts
@@ -131,7 +131,7 @@ async function fetchPayload(baseUrl: string, signal?: AbortSignal): Promise<Rout
 }
 
 export async function discoverModels(
-	baseUrl = normalizeBaseUrl(process.env.NINE_ROUTER_BASE_URL),
+	baseUrl = configuredBaseUrl(),
 	signal?: AbortSignal,
 ): Promise<RouterPiModel[]> {
 	const models = normalizeModels(await fetchPayload(normalizeBaseUrl(baseUrl), signal));
@@ -152,17 +152,40 @@ function stripJsonComments(input: string): string {
 		.replace(/,\s*([}\]])/gu, "$1");
 }
 
-function apiKeyFromModelsJson(): string | undefined {
+type ModelsJsonProvider = {
+	apiKey?: unknown;
+	baseUrl?: unknown;
+};
+
+function providerFromModelsJson(): ModelsJsonProvider | undefined {
 	try {
 		const modelsPath = join(getAgentDir(), "models.json");
 		const config = JSON.parse(stripJsonComments(readFileSync(modelsPath, "utf8"))) as {
-			providers?: Record<string, { apiKey?: unknown }>;
+			providers?: Record<string, ModelsJsonProvider>;
 		};
-		const value = config.providers?.[PROVIDER_ID]?.apiKey;
-		return typeof value === "string" && value.trim() ? value : undefined;
+		return config.providers?.[PROVIDER_ID];
 	} catch {
 		return undefined;
 	}
+}
+
+function apiKeyFromModelsJson(): string | undefined {
+	const value = providerFromModelsJson()?.apiKey;
+	return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function baseUrlFromEnvironment(): string | undefined {
+	const value = process.env.PI_9ROUTER_BASE_URL?.trim();
+	return value || undefined;
+}
+
+function baseUrlFromModelsJson(): string | undefined {
+	const value = providerFromModelsJson()?.baseUrl;
+	return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function configuredBaseUrl(): string {
+	return normalizeBaseUrl(baseUrlFromEnvironment() ?? baseUrlFromModelsJson());
 }
 
 function configuredApiKey(): string | undefined {
@@ -170,7 +193,7 @@ function configuredApiKey(): string | undefined {
 }
 
 let registeredModels: RouterPiModel[] = [];
-let registeredBaseUrl = normalizeBaseUrl(process.env.NINE_ROUTER_BASE_URL);
+let registeredBaseUrl = configuredBaseUrl();
 let providerRegistered = false;
 let lastDiscoveryError: string | undefined;
 
@@ -198,7 +221,7 @@ function registerDynamicProvider(pi: ExtensionAPI, baseUrl: string, initialModel
 }
 
 async function discoverAndRegister(pi: ExtensionAPI): Promise<RouterPiModel[]> {
-	const baseUrl = normalizeBaseUrl(process.env.NINE_ROUTER_BASE_URL);
+	const baseUrl = configuredBaseUrl();
 	const models = await discoverModels(baseUrl);
 	registerDynamicProvider(pi, baseUrl, models);
 	return models;

--- a/extensions/9router-pi/src/index.ts
+++ b/extensions/9router-pi/src/index.ts
@@ -48,10 +48,10 @@ export type RouterPiModel = {
 	reasoning: boolean;
 	thinkingLevelMap?: Partial<Record<PiThinkingLevel, string | null>>;
 	input: ("text" | "image")[];
-	cost: typeof ZERO_COST;
+	cost: ProviderModelConfig["cost"];
 	contextWindow: number;
 	maxTokens: number;
-	compat?: { thinkingFormat: SupportedThinkingFormat };
+	compat?: ProviderModelConfig["compat"];
 };
 
 function positiveNumber(value: unknown, fallback: number): number {
@@ -186,6 +186,7 @@ type ModelsJsonModel = Partial<ProviderModelConfig> & { id?: unknown };
 type ModelsJsonProvider = {
 	apiKey?: unknown;
 	baseUrl?: unknown;
+	compat?: unknown;
 	models?: ModelsJsonModel[];
 };
 
@@ -221,57 +222,85 @@ function nonNegativeNumber(value: unknown, fallback: number): number {
 }
 
 function costFromConfig(value: unknown): ProviderModelConfig["cost"] {
-	if (!isRecord(value)) return ZERO_COST;
+	if (!isRecord(value)) return { ...ZERO_COST };
+	const cost = structuredClone(value) as Record<string, unknown>;
 	return {
-		input: nonNegativeNumber(value.input, 0),
-		output: nonNegativeNumber(value.output, 0),
-		cacheRead: nonNegativeNumber(value.cacheRead, 0),
-		cacheWrite: nonNegativeNumber(value.cacheWrite, 0),
-	};
+		...cost,
+		input: nonNegativeNumber(cost.input, 0),
+		output: nonNegativeNumber(cost.output, 0),
+		cacheRead: nonNegativeNumber(cost.cacheRead, 0),
+		cacheWrite: nonNegativeNumber(cost.cacheWrite, 0),
+	} as ProviderModelConfig["cost"];
+}
+
+function compatFromConfig(value: unknown): ProviderModelConfig["compat"] | undefined {
+	return isRecord(value) ? (structuredClone(value) as ProviderModelConfig["compat"]) : undefined;
 }
 
 function modelConfigFromUnknown(value: unknown): ProviderModelConfig | undefined {
 	if (!isRecord(value) || typeof value.id !== "string" || value.id.trim().length === 0) return undefined;
 
-	const id = value.id.trim();
-	const model: ProviderModelConfig = {
-		id,
-		name: typeof value.name === "string" && value.name.trim() ? value.name : id,
-		reasoning: value.reasoning === true,
-		input: inputFromConfig(value.input),
-		cost: costFromConfig(value.cost),
-		contextWindow: positiveNumber(value.contextWindow, 128000),
-		maxTokens: positiveNumber(value.maxTokens, 16384),
-	};
+	const model = structuredClone(value) as Record<string, unknown>;
+	const id = (value.id as string).trim();
+	model.id = id;
+	model.name = typeof value.name === "string" && value.name.trim() ? value.name : id;
+	model.reasoning = value.reasoning === true;
+	model.input = inputFromConfig(value.input);
+	model.cost = costFromConfig(value.cost);
+	model.contextWindow = positiveNumber(value.contextWindow, 128000);
+	model.maxTokens = positiveNumber(value.maxTokens, 16384);
+	if (typeof value.api !== "string") delete model.api;
+	if (typeof value.baseUrl !== "string" || !value.baseUrl.trim()) delete model.baseUrl;
+	if (!isRecord(value.thinkingLevelMap)) delete model.thinkingLevelMap;
+	if (!isRecord(value.headers)) delete model.headers;
+	if (!isRecord(value.compat)) delete model.compat;
+	return model as unknown as ProviderModelConfig;
+}
 
-	if (typeof value.api === "string") model.api = value.api as ProviderModelConfig["api"];
-	if (typeof value.baseUrl === "string" && value.baseUrl.trim()) model.baseUrl = value.baseUrl;
-	if (isRecord(value.thinkingLevelMap)) {
-		model.thinkingLevelMap = value.thinkingLevelMap as ProviderModelConfig["thinkingLevelMap"];
-	}
-	if (isRecord(value.headers)) model.headers = value.headers as Record<string, string>;
-	if (isRecord(value.compat)) model.compat = value.compat as ProviderModelConfig["compat"];
-	return model;
+function providerCompatFromModelsJson(): ProviderModelConfig["compat"] | undefined {
+	return compatFromConfig(providerFromModelsJson()?.compat);
+}
+
+function applyProviderCompat(
+	models: readonly ProviderModelConfig[],
+	providerCompat = providerCompatFromModelsJson(),
+): ProviderModelConfig[] {
+	return models.map((model) => {
+		const cloned = structuredClone(model);
+		if (!providerCompat) return cloned;
+		const modelCompat = compatFromConfig(cloned.compat);
+		return {
+			...cloned,
+			compat: { ...providerCompat, ...modelCompat },
+		};
+	});
 }
 
 function staticModelsFromModelsJson(): ProviderModelConfig[] {
-	return (providerFromModelsJson()?.models ?? [])
-		.map((model) => modelConfigFromUnknown(model))
-		.filter((model): model is ProviderModelConfig => model !== undefined);
+	return applyProviderCompat(
+		(providerFromModelsJson()?.models ?? [])
+			.map((model) => modelConfigFromUnknown(model))
+			.filter((model): model is ProviderModelConfig => model !== undefined),
+	);
 }
 
 function modelsFromStored(stored: { models: readonly unknown[] } | undefined): ProviderModelConfig[] {
-	return (stored?.models ?? [])
-		.map((model) => modelConfigFromUnknown(model))
-		.filter((model): model is ProviderModelConfig => model !== undefined);
+	return applyProviderCompat(
+		(stored?.models ?? [])
+			.map((model) => modelConfigFromUnknown(model))
+			.filter((model): model is ProviderModelConfig => model !== undefined),
+	);
 }
 
 function fallbackCatalog(
 	models: ProviderModelConfig[],
 	hasProviderBaseUrlOverride: boolean,
 ): ProviderModelConfig[] {
-	if (!hasProviderBaseUrlOverride) return models;
-	return models.map(({ baseUrl: _baseUrl, ...model }) => model);
+	return models.map((model) => {
+		const cloned = structuredClone(model);
+		if (hasProviderBaseUrlOverride) delete cloned.baseUrl;
+		return cloned;
+	});
 }
 
 function baseUrlFromEnvironment(): string | undefined {
@@ -296,17 +325,34 @@ function configuredApiKey(): string | undefined {
 	return apiKeyFromEnvironment() ?? apiKeyFromModelsJson();
 }
 
-let registeredModels: ProviderModelConfig[] = [];
-let registeredBaseUrl = configuredBaseUrl();
-let fallbackCatalogSource: "static" | "stored" | "live" | undefined;
-let providerRegistered = false;
-let lastDiscoveryError: string | undefined;
+type ExtensionState = {
+	registeredModels: ProviderModelConfig[];
+	registeredBaseUrl: string;
+	fallbackCatalogSource: "static" | "stored" | "live" | undefined;
+	providerRegistered: boolean;
+	lastDiscoveryError: string | undefined;
+};
 
-function registerDynamicProvider(pi: ExtensionAPI, baseUrl: string, initialModels: RouterPiModel[]): void {
-	registeredBaseUrl = baseUrl;
-	registeredModels = initialModels;
-	fallbackCatalogSource = undefined;
-	lastDiscoveryError = undefined;
+function createExtensionState(): ExtensionState {
+	return {
+		registeredModels: [],
+		registeredBaseUrl: configuredBaseUrl(),
+		fallbackCatalogSource: undefined,
+		providerRegistered: false,
+		lastDiscoveryError: undefined,
+	};
+}
+
+function registerDynamicProvider(
+	pi: ExtensionAPI,
+	baseUrl: string,
+	initialModels: RouterPiModel[],
+	state: ExtensionState,
+): void {
+	state.registeredBaseUrl = baseUrl;
+	state.registeredModels = applyProviderCompat(initialModels);
+	state.fallbackCatalogSource = undefined;
+	state.lastDiscoveryError = undefined;
 
 	const apiKey = configuredApiKey();
 	pi.registerProvider(PROVIDER_ID, {
@@ -314,25 +360,32 @@ function registerDynamicProvider(pi: ExtensionAPI, baseUrl: string, initialModel
 		baseUrl,
 		api: "openai-completions",
 		...(apiKey ? { apiKey } : {}),
-		models: registeredModels,
-		async refreshModels({ allowNetwork, signal }) {
-			if (!allowNetwork || signal.aborted) return registeredModels;
+		models: state.registeredModels,
+		async refreshModels({ allowNetwork, signal, publish }) {
+			const previousModels = state.registeredModels;
+			if (!allowNetwork || signal.aborted) return [...previousModels];
 			const refreshed = await discoverModels(baseUrl, signal);
-			registeredModels = refreshed;
-			lastDiscoveryError = undefined;
-			return refreshed;
+			if (signal.aborted) return [...previousModels];
+			const candidate = applyProviderCompat(refreshed);
+			const accepted = await publish({
+				update: () => {
+					state.registeredModels = candidate;
+					state.lastDiscoveryError = undefined;
+				},
+			});
+			return accepted ? [...candidate] : [...previousModels];
 		},
 	});
-	providerRegistered = true;
+	state.providerRegistered = true;
 }
 
-function registerFallbackProvider(pi: ExtensionAPI): void {
+function registerFallbackProvider(pi: ExtensionAPI, state: ExtensionState): void {
 	const configuredBaseUrl = configuredBaseUrlOverride();
 	const discoveryBaseUrl = normalizeBaseUrl(configuredBaseUrl);
-	registeredBaseUrl = discoveryBaseUrl;
+	state.registeredBaseUrl = discoveryBaseUrl;
 	const hasProviderBaseUrlOverride = configuredBaseUrl !== undefined;
-	registeredModels = fallbackCatalog(staticModelsFromModelsJson(), hasProviderBaseUrlOverride);
-	fallbackCatalogSource = "static";
+	state.registeredModels = fallbackCatalog(staticModelsFromModelsJson(), hasProviderBaseUrlOverride);
+	state.fallbackCatalogSource = "static";
 
 	const apiKey = configuredApiKey();
 	pi.registerProvider(PROVIDER_ID, {
@@ -340,21 +393,20 @@ function registerFallbackProvider(pi: ExtensionAPI): void {
 		...(configuredBaseUrl ? { baseUrl: discoveryBaseUrl } : {}),
 		api: "openai-completions",
 		...(apiKey ? { apiKey } : {}),
-		async refreshModels({ allowNetwork, signal, stored }) {
+		async refreshModels({ allowNetwork, signal, stored, publish }) {
 			const storedModels = fallbackCatalog(modelsFromStored(stored), hasProviderBaseUrlOverride);
-			const previousModels =
-				fallbackCatalogSource !== "static" && registeredModels.length > 0
-					? registeredModels
-					: storedModels.length > 0
-						? storedModels
-						: registeredModels.length > 0
-							? registeredModels
-							: fallbackCatalog(staticModelsFromModelsJson(), hasProviderBaseUrlOverride);
+			const previousModels = state.registeredModels;
 
-			if (!allowNetwork || signal.aborted) {
-				if (storedModels.length > 0 && fallbackCatalogSource === "static") {
-					registeredModels = storedModels;
-					fallbackCatalogSource = "stored";
+			if (signal.aborted) return [...previousModels];
+			if (!allowNetwork) {
+				if (storedModels.length > 0 && state.fallbackCatalogSource === "static") {
+					const accepted = await publish({
+						update: () => {
+							state.registeredModels = storedModels;
+							state.fallbackCatalogSource = "stored";
+						},
+					});
+					return accepted ? [...storedModels] : [...previousModels];
 				}
 				return [...previousModels];
 			}
@@ -364,35 +416,41 @@ function registerFallbackProvider(pi: ExtensionAPI): void {
 
 			const staticModels = staticModelsFromModelsJson();
 			const models = hasProviderBaseUrlOverride
-				? refreshed
-				: refreshed.map((model) => {
+				? applyProviderCompat(refreshed)
+				: applyProviderCompat(refreshed).map((model) => {
 						const staticModel = staticModels.find((candidate) => candidate.id === model.id);
 						return staticModel?.baseUrl
-							? { ...model, baseUrl: staticModel.baseUrl }
-							: { ...model, baseUrl: discoveryBaseUrl };
+						? { ...model, baseUrl: staticModel.baseUrl }
+						: { ...model, baseUrl: discoveryBaseUrl };
 					});
-			registeredModels = models;
-			fallbackCatalogSource = "live";
-			lastDiscoveryError = undefined;
-			return [...models];
+			const accepted = await publish({
+				update: () => {
+					state.registeredModels = models;
+					state.fallbackCatalogSource = "live";
+					state.lastDiscoveryError = undefined;
+				},
+			});
+			return accepted ? [...models] : [...previousModels];
 		},
 	});
-	providerRegistered = true;
+	state.providerRegistered = true;
 }
 
-async function discoverAndRegister(pi: ExtensionAPI): Promise<RouterPiModel[]> {
+async function discoverAndRegister(pi: ExtensionAPI, state: ExtensionState): Promise<RouterPiModel[]> {
 	const baseUrl = configuredBaseUrl();
 	const models = await discoverModels(baseUrl);
-	registerDynamicProvider(pi, baseUrl, models);
-	return models;
+	const registeredModels = applyProviderCompat(models);
+	registerDynamicProvider(pi, baseUrl, registeredModels, state);
+	return registeredModels;
 }
 
-function notifyDiscoveryError(error: unknown): void {
-	lastDiscoveryError = error instanceof Error ? error.message : String(error);
-	console.warn(`9router model discovery skipped: ${lastDiscoveryError}`);
+function notifyDiscoveryError(state: ExtensionState, error: unknown): void {
+	state.lastDiscoveryError = error instanceof Error ? error.message : String(error);
+	console.warn(`9router model discovery skipped: ${state.lastDiscoveryError}`);
 }
 
 export default async function nineRouterPi(pi: ExtensionAPI) {
+	const state = createExtensionState();
 	pi.registerCommand("9router-pi", {
 		description: "Show or refresh the dynamic 9router model catalog",
 		handler: async (args, ctx) => {
@@ -405,8 +463,8 @@ export default async function nineRouterPi(pi: ExtensionAPI) {
 				}
 
 				try {
-					if (!providerRegistered) {
-						const models = await discoverAndRegister(pi);
+					if (!state.providerRegistered) {
+						const models = await discoverAndRegister(pi, state);
 						ctx.ui.notify(`9router-pi: registered ${models.length} model(s).`, "info");
 						return;
 					}
@@ -418,22 +476,22 @@ export default async function nineRouterPi(pi: ExtensionAPI) {
 					});
 					const error = result.errors.get(PROVIDER_ID);
 					if (error) {
-						lastDiscoveryError = error.message;
+						state.lastDiscoveryError = error.message;
 						ctx.ui.notify(`9router-pi: refresh failed: ${error.message}`, "error");
 						return;
 					}
-					ctx.ui.notify(`9router-pi: refreshed ${registeredModels.length} model(s).`, "info");
+					ctx.ui.notify(`9router-pi: refreshed ${state.registeredModels.length} model(s).`, "info");
 				} catch (error) {
-					lastDiscoveryError = error instanceof Error ? error.message : String(error);
-					ctx.ui.notify(`9router-pi: refresh failed: ${lastDiscoveryError}`, "error");
+					state.lastDiscoveryError = error instanceof Error ? error.message : String(error);
+					ctx.ui.notify(`9router-pi: refresh failed: ${state.lastDiscoveryError}`, "error");
 				}
 				return;
 			}
 
 			if (command === "status") {
-				const discovery = lastDiscoveryError ? `last error: ${lastDiscoveryError}` : "discovery ready";
+				const discovery = state.lastDiscoveryError ? `last error: ${state.lastDiscoveryError}` : "discovery ready";
 				ctx.ui.notify(
-					`9router-pi: ${registeredModels.length} discovered model(s) at ${registeredBaseUrl}; ${discovery}.`,
+					`9router-pi: ${state.registeredModels.length} discovered model(s) at ${state.registeredBaseUrl}; ${discovery}.`,
 					"info",
 				);
 				return;
@@ -449,16 +507,16 @@ export default async function nineRouterPi(pi: ExtensionAPI) {
 	});
 
 	if (process.env.PI_OFFLINE !== undefined) {
-		registerFallbackProvider(pi);
+		registerFallbackProvider(pi, state);
 		return;
 	}
 
 	try {
-		await discoverAndRegister(pi);
+		await discoverAndRegister(pi, state);
 	} catch (error) {
-		notifyDiscoveryError(error);
+		notifyDiscoveryError(state, error);
 		// A models.json provider configuration remains available as a static
 		// fallback when startup discovery cannot reach the local router.
-		registerFallbackProvider(pi);
+		registerFallbackProvider(pi, state);
 	}
 }

--- a/extensions/9router-pi/src/index.ts
+++ b/extensions/9router-pi/src/index.ts
@@ -1,0 +1,252 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+const PROVIDER_ID = "9router";
+const DEFAULT_BASE_URL = "http://localhost:20128/v1";
+const DISCOVERY_TIMEOUT_MS = 5000;
+const ZERO_COST = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+};
+
+const SUPPORTED_THINKING_FORMATS = [
+	"openai",
+	"openrouter",
+	"deepseek",
+	"together",
+	"zai",
+	"qwen",
+	"qwen-chat-template",
+] as const;
+
+type SupportedThinkingFormat = (typeof SUPPORTED_THINKING_FORMATS)[number];
+type PiThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
+
+type RouterModelInfo = {
+	id?: unknown;
+	context_length?: unknown;
+	max_completion_tokens?: unknown;
+	capabilities?: {
+		vision?: unknown;
+		reasoning?: unknown;
+		thinkingFormat?: unknown;
+		thinkingCanDisable?: unknown;
+	};
+};
+
+export type RouterModelsResponse = {
+	data?: RouterModelInfo[];
+};
+
+export type RouterPiModel = {
+	id: string;
+	name: string;
+	reasoning: boolean;
+	thinkingLevelMap?: Partial<Record<PiThinkingLevel, string | null>>;
+	input: ("text" | "image")[];
+	cost: typeof ZERO_COST;
+	contextWindow: number;
+	maxTokens: number;
+	compat?: { thinkingFormat: SupportedThinkingFormat };
+};
+
+function positiveNumber(value: unknown, fallback: number): number {
+	return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+export function normalizeBaseUrl(value: string | undefined): string {
+	const configured = value?.trim();
+	return (configured || DEFAULT_BASE_URL).replace(/\/+$/u, "");
+}
+
+function thinkingFormatFor(value: unknown): SupportedThinkingFormat | undefined {
+	if (typeof value !== "string") return undefined;
+	return (SUPPORTED_THINKING_FORMATS as readonly string[]).includes(value)
+		? (value as SupportedThinkingFormat)
+		: undefined;
+}
+
+function hasModelId(model: RouterModelInfo): model is RouterModelInfo & { id: string } {
+	return typeof model.id === "string" && model.id.trim().length > 0;
+}
+
+export function normalizeModels(payload: RouterModelsResponse): RouterPiModel[] {
+	const seen = new Set<string>();
+	const models: RouterPiModel[] = [];
+
+	for (const model of payload.data ?? []) {
+		if (!hasModelId(model)) continue;
+		const id = model.id.trim();
+		if (seen.has(id)) continue;
+		seen.add(id);
+
+		const capabilities = model.capabilities;
+		const reasoning = capabilities?.reasoning === true;
+		const thinkingFormat = thinkingFormatFor(capabilities?.thinkingFormat);
+		const thinkingLevelMap =
+			reasoning && capabilities?.thinkingCanDisable === false
+				? { off: null }
+				: undefined;
+
+		models.push({
+			id,
+			name: id,
+			reasoning,
+			...(thinkingLevelMap ? { thinkingLevelMap } : {}),
+			input: capabilities?.vision === true ? ["text", "image"] : ["text"],
+			cost: ZERO_COST,
+			contextWindow: positiveNumber(model.context_length, 128000),
+			maxTokens: positiveNumber(model.max_completion_tokens, 16384),
+			...(thinkingFormat ? { compat: { thinkingFormat } } : {}),
+		});
+	}
+
+	return models;
+}
+
+async function fetchPayload(baseUrl: string, signal?: AbortSignal): Promise<RouterModelsResponse> {
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), DISCOVERY_TIMEOUT_MS);
+	const abortFromParent = () => controller.abort(signal?.reason);
+
+	if (signal?.aborted) {
+		abortFromParent();
+	} else {
+		signal?.addEventListener("abort", abortFromParent, { once: true });
+	}
+
+	try {
+		const response = await fetch(`${baseUrl}/models`, { signal: controller.signal });
+		if (!response.ok) {
+			throw new Error(`9router model discovery failed: HTTP ${response.status}`);
+		}
+		return (await response.json()) as RouterModelsResponse;
+	} finally {
+		clearTimeout(timer);
+		signal?.removeEventListener("abort", abortFromParent);
+	}
+}
+
+export async function discoverModels(
+	baseUrl = normalizeBaseUrl(process.env.NINE_ROUTER_BASE_URL),
+	signal?: AbortSignal,
+): Promise<RouterPiModel[]> {
+	const models = normalizeModels(await fetchPayload(normalizeBaseUrl(baseUrl), signal));
+	if (models.length === 0) {
+		throw new Error("9router model discovery returned no models");
+	}
+	return models;
+}
+
+function apiKeyFromEnvironment(): string | undefined {
+	const value = process.env.NINE_ROUTER_API_KEY?.trim();
+	return value || undefined;
+}
+
+let registeredModels: RouterPiModel[] = [];
+let registeredBaseUrl = normalizeBaseUrl(process.env.NINE_ROUTER_BASE_URL);
+let providerRegistered = false;
+let lastDiscoveryError: string | undefined;
+
+function registerDynamicProvider(pi: ExtensionAPI, baseUrl: string, initialModels: RouterPiModel[]): void {
+	registeredBaseUrl = baseUrl;
+	registeredModels = initialModels;
+	lastDiscoveryError = undefined;
+
+	const apiKey = apiKeyFromEnvironment();
+	pi.registerProvider(PROVIDER_ID, {
+		name: "9router",
+		baseUrl,
+		api: "openai-completions",
+		...(apiKey ? { apiKey } : {}),
+		models: registeredModels,
+		async refreshModels({ allowNetwork, signal }) {
+			if (!allowNetwork || signal.aborted) return registeredModels;
+			const refreshed = await discoverModels(baseUrl, signal);
+			registeredModels = refreshed;
+			lastDiscoveryError = undefined;
+			return refreshed;
+		},
+	});
+	providerRegistered = true;
+}
+
+async function discoverAndRegister(pi: ExtensionAPI): Promise<RouterPiModel[]> {
+	const baseUrl = normalizeBaseUrl(process.env.NINE_ROUTER_BASE_URL);
+	const models = await discoverModels(baseUrl);
+	registerDynamicProvider(pi, baseUrl, models);
+	return models;
+}
+
+function notifyDiscoveryError(error: unknown): void {
+	lastDiscoveryError = error instanceof Error ? error.message : String(error);
+	console.warn(`9router model discovery skipped: ${lastDiscoveryError}`);
+}
+
+export default async function nineRouterPi(pi: ExtensionAPI) {
+	pi.registerCommand("9router-pi", {
+		description: "Show or refresh the dynamic 9router model catalog",
+		handler: async (args, ctx) => {
+			const command = args.trim().toLowerCase() || "status";
+
+			if (command === "refresh") {
+				if (process.env.PI_OFFLINE !== undefined) {
+					ctx.ui.notify("9router-pi: PI_OFFLINE is set; discovery was skipped.", "warning");
+					return;
+				}
+
+				try {
+					if (!providerRegistered) {
+						const models = await discoverAndRegister(pi);
+						ctx.ui.notify(`9router-pi: registered ${models.length} model(s).`, "info");
+						return;
+					}
+
+					const result = await ctx.modelRegistry.refresh({
+						providers: [PROVIDER_ID],
+						allowNetwork: true,
+						force: true,
+					});
+					const error = result.errors.get(PROVIDER_ID);
+					if (error) {
+						lastDiscoveryError = error.message;
+						ctx.ui.notify(`9router-pi: refresh failed: ${error.message}`, "error");
+						return;
+					}
+					ctx.ui.notify(`9router-pi: refreshed ${registeredModels.length} model(s).`, "info");
+				} catch (error) {
+					lastDiscoveryError = error instanceof Error ? error.message : String(error);
+					ctx.ui.notify(`9router-pi: refresh failed: ${lastDiscoveryError}`, "error");
+				}
+				return;
+			}
+
+			if (command === "status") {
+				const discovery = lastDiscoveryError ? `last error: ${lastDiscoveryError}` : "discovery ready";
+				ctx.ui.notify(
+					`9router-pi: ${registeredModels.length} discovered model(s) at ${registeredBaseUrl}; ${discovery}.`,
+					"info",
+				);
+				return;
+			}
+
+			if (command === "help") {
+				ctx.ui.notify("Usage: /9router-pi [status|refresh|help]", "info");
+				return;
+			}
+
+			ctx.ui.notify(`9router-pi: unknown command '${command}'. Try /9router-pi help.`, "warning");
+		},
+	});
+
+	if (process.env.PI_OFFLINE !== undefined) return;
+
+	try {
+		await discoverAndRegister(pi);
+	} catch (error) {
+		notifyDiscoveryError(error);
+		// A models.json provider configuration remains available as a static
+		// fallback when startup discovery cannot reach the local router.
+	}
+}

--- a/extensions/9router-pi/src/index.ts
+++ b/extensions/9router-pi/src/index.ts
@@ -1,4 +1,6 @@
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { getAgentDir, type ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 
 const PROVIDER_ID = "9router";
 const DEFAULT_BASE_URL = "http://localhost:20128/v1";
@@ -144,6 +146,29 @@ function apiKeyFromEnvironment(): string | undefined {
 	return value || undefined;
 }
 
+function stripJsonComments(input: string): string {
+	return input
+		.replace(/"(?:\\.|[^"\\])*"|\/\/[^\n]*/gu, (match) => (match.startsWith('"') ? match : ""))
+		.replace(/,\s*([}\]])/gu, "$1");
+}
+
+function apiKeyFromModelsJson(): string | undefined {
+	try {
+		const modelsPath = join(getAgentDir(), "models.json");
+		const config = JSON.parse(stripJsonComments(readFileSync(modelsPath, "utf8"))) as {
+			providers?: Record<string, { apiKey?: unknown }>;
+		};
+		const value = config.providers?.[PROVIDER_ID]?.apiKey;
+		return typeof value === "string" && value.trim() ? value : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function configuredApiKey(): string | undefined {
+	return apiKeyFromEnvironment() ?? apiKeyFromModelsJson();
+}
+
 let registeredModels: RouterPiModel[] = [];
 let registeredBaseUrl = normalizeBaseUrl(process.env.NINE_ROUTER_BASE_URL);
 let providerRegistered = false;
@@ -154,7 +179,7 @@ function registerDynamicProvider(pi: ExtensionAPI, baseUrl: string, initialModel
 	registeredModels = initialModels;
 	lastDiscoveryError = undefined;
 
-	const apiKey = apiKeyFromEnvironment();
+	const apiKey = configuredApiKey();
 	pi.registerProvider(PROVIDER_ID, {
 		name: "9router",
 		baseUrl,

--- a/extensions/9router-pi/src/index.ts
+++ b/extensions/9router-pi/src/index.ts
@@ -147,9 +147,37 @@ function apiKeyFromEnvironment(): string | undefined {
 }
 
 function stripJsonComments(input: string): string {
-	return input
-		.replace(/"(?:\\.|[^"\\])*"|\/\/[^\n]*/gu, (match) => (match.startsWith('"') ? match : ""))
-		.replace(/,\s*([}\]])/gu, "$1");
+	const withoutComments = input.replace(/"(?:\\.|[^"\\])*"|\/\/[^\n]*/gu, (match) =>
+		match.startsWith('"') ? match : "",
+	);
+	let output = "";
+	let inString = false;
+	let escaped = false;
+
+	for (let index = 0; index < withoutComments.length; index += 1) {
+		const character = withoutComments[index];
+		if (inString) {
+			output += character;
+			if (escaped) escaped = false;
+			else if (character === "\\") escaped = true;
+			else if (character === '"') inString = false;
+			continue;
+		}
+
+		if (character === '"') {
+			inString = true;
+			output += character;
+			continue;
+		}
+		if (character === ",") {
+			let next = index + 1;
+			while (/\s/u.test(withoutComments[next] ?? "")) next += 1;
+			if (withoutComments[next] === "}" || withoutComments[next] === "]") continue;
+		}
+		output += character;
+	}
+
+	return output;
 }
 
 type ModelsJsonProvider = {
@@ -216,6 +244,21 @@ function registerDynamicProvider(pi: ExtensionAPI, baseUrl: string, initialModel
 			lastDiscoveryError = undefined;
 			return refreshed;
 		},
+	});
+	providerRegistered = true;
+}
+
+function registerFallbackProvider(pi: ExtensionAPI): void {
+	const baseUrl = configuredBaseUrl();
+	registeredBaseUrl = baseUrl;
+	registeredModels = [];
+
+	const apiKey = configuredApiKey();
+	pi.registerProvider(PROVIDER_ID, {
+		name: "9router",
+		baseUrl,
+		api: "openai-completions",
+		...(apiKey ? { apiKey } : {}),
 	});
 	providerRegistered = true;
 }
@@ -288,7 +331,10 @@ export default async function nineRouterPi(pi: ExtensionAPI) {
 		},
 	});
 
-	if (process.env.PI_OFFLINE !== undefined) return;
+	if (process.env.PI_OFFLINE !== undefined) {
+		registerFallbackProvider(pi);
+		return;
+	}
 
 	try {
 		await discoverAndRegister(pi);
@@ -296,5 +342,6 @@ export default async function nineRouterPi(pi: ExtensionAPI) {
 		notifyDiscoveryError(error);
 		// A models.json provider configuration remains available as a static
 		// fallback when startup discovery cannot reach the local router.
+		registerFallbackProvider(pi);
 	}
 }

--- a/extensions/9router-pi/tsconfig.json
+++ b/extensions/9router-pi/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/scripts/publish-npm-extensions.sh
+++ b/scripts/publish-npm-extensions.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 OTP="${1:-${NPM_OTP:-}}"
 
-EXTENSIONS=(advisor-pi agy-pi claude-code-pi grok-pi model-debugger opencode-pi statusline-pi subagents-pi timestamp-pi)
+EXTENSIONS=(9router-pi advisor-pi agy-pi claude-code-pi grok-pi model-debugger opencode-pi statusline-pi subagents-pi timestamp-pi)
 
 echo "===== packaging check ====="
 node "$ROOT/scripts/check-packaging.mjs"


### PR DESCRIPTION
Closes #50

## Summary
- Add **9router-pi**: registers the `9router` provider with dynamic discovery from a local OpenAI-compatible `/v1/models` endpoint, manual refresh (`/9router-pi refresh`), and offline fallback support
- Add `9router-pi` to the npm publish flow (`scripts/publish-npm-extensions.sh`, now ten extensions)
- Sync README (feature list, extension section, project tree), `docs/DEVELOPMENT.md` (tree + publish docs), and root `CHANGELOG.md`

## Validation
- `npm run build` in `extensions/9router-pi/` — clean tsc build
- `npm test` in `extensions/9router-pi/` — 13/13 tests pass
- Not yet published to npm; install from clone via `pi -e ./extensions/9router-pi`

## Notes
- Credentials stay in `~/.pi/agent/models.json`; the gateway URL is configurable via `PI_9ROUTER_BASE_URL`

## Decision Record
- Root cause: Dynamic provider discovery needed to combine local models.json configuration, environment overrides, and runtime model discovery without losing static fallback metadata.
- Options considered: Use environment-only configuration; repeatedly re-register the provider during refresh; or keep one provider registration with a stateful refresh callback.
- Options rejected: Environment-only configuration omits the documented models.json credential and model settings, while repeated registration risks duplicate provider state and stale refresh results.
- Selected option: Resolve environment-over-models.json precedence, preserve model metadata and compatibility defaults, and publish refresh candidates transactionally through Pi's generation-checked callback.
- Residual risk: A gateway that remains unreachable cannot provide new models; the extension retains the last accepted or static catalog and reports discovery errors.

## Acceptance Criteria Verification
No acceptance criteria defined (PR has no linked issue).