### PR TITLE
feat(cache-warm): add prompt-cache keep-alive (#51)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **cache-warm**: Opt-in prompt-cache keep-alive extension (`/cache-warm on`, `off`, `status`, `metrics`) with avoided-miss and estimated net USD-saved metrics. Separate package from timestamp-pi; default off so install/session start never bills a warm turn (#51).
 - **9router-pi**: Dynamic `9router` provider discovery from the local OpenAI-compatible `/v1/models` endpoint, with manual refresh and offline fallback support.
 
 ## [0.2.0] — 2026-08-21

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ More assets live in [`assets/`](assets/) (e.g. `statusline-pi-gpt-5-mini-195toks
 - **9router-pi** — Register the `9router` provider with dynamic discovery from a local OpenAI-compatible `/v1/models` endpoint.
 - **agy-pi** — Bridge `agy` CLI models (Gemini flash/pro variants, Claude Sonnet, GPT OSS) into Pi via an `agy` provider, with auto-discovery from `agy models` output (`extensions/agy-pi/src/index.ts`).
 - **timestamp-pi** — Per-message timestamps with age labels plus a prompt-cache countdown in the footer, stored as session entries so they persist across reloads without reaching the LLM (`extensions/timestamp-pi/src/index.ts`).
+- **cache-warm** — Opt-in prompt-cache keep-alive (default off) that sends a hidden ping before TTL expiry and reports likely avoided misses plus estimated net USD saved (`extensions/cache-warm/src/index.ts`).
 - **subagents-pi** — Fleet metrics panel for managed subagents (context, TPS, model, thinking); works with `@tintinweb/pi-subagents`.
 - **model-debugger** — Logs model requests and responses to `~/.pi/agent/logs/` for debugging provider interactions.
 - **pi-delegator** — Agent skill for delegating approved tasks to a monitored Pi subprocess, preferring free `opencode-cli` models and reporting session metrics.
@@ -83,9 +84,9 @@ Try without installing (current session only):
 pi -e npm:advisor-pi
 ```
 
-**Not on npm yet:** `9router-pi` and `subagents-pi` are packaged for npm but not yet published.
-Install them from a clone (`pi -e ./extensions/9router-pi` or
-`pi -e ./extensions/subagents-pi`) or via the repo installer below.
+**Not on npm yet:** `9router-pi`, `subagents-pi`, and `cache-warm` are packaged for npm but not yet published.
+Install them from a clone (`pi -e ./extensions/9router-pi`,
+`pi -e ./extensions/subagents-pi`, or `pi -e ./extensions/cache-warm`) or via the repo installer below.
 
 List and update installed packages:
 
@@ -293,6 +294,25 @@ pi install npm:timestamp-pi   # or: pi -e ./extensions/timestamp-pi
 
 **Commands:** `/timestamp-pi` — toggle timestamps and cache countdown
 
+### cache-warm
+
+`cache-warm` keeps the prompt cache alive with opt-in hidden keep-alive turns.
+Default is **off**: install and `session_start` never bill a warm turn. Enable
+with `/cache-warm on`. Pings use `pi.sendMessage()` (not `sendUserMessage` /
+`completeSimple`) and only fire when the session is idle, nothing is queued,
+cache activity has already been seen, and remaining TTL is under 60 seconds
+(`extensions/cache-warm/src/index.ts`). The 5-minute TTL is an Anthropic
+heuristic. Metrics report warm attempts, refreshes, likely avoided misses, and
+estimated net USD saved (gross cache discount minus warm-turn spend; `N/A` when
+rates are missing). See [extensions/cache-warm/README.md](extensions/cache-warm/README.md).
+
+```bash
+pi -e ./extensions/cache-warm   # repo-only until published
+```
+
+**Commands:** `/cache-warm on`, `/cache-warm off`, `/cache-warm` (toggle),
+`/cache-warm status`, `/cache-warm metrics`
+
 ### pi-delegator
 
 `pi-delegator` is an agent skill that lets a main AI agent delegate a clear,
@@ -363,6 +383,7 @@ pi-extensions/
 │   ├── model-debugger/
 │   ├── opencode-pi/
 │   ├── 9router-pi/
+│   ├── cache-warm/
 │   ├── statusline-pi/
 │   ├── subagents-pi/
 │   └── timestamp-pi/

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -9,3 +9,8 @@ Append-only log of documentation ambiguities resolved with the user.
 - Q: How should root README document the unpublished extensions?
 - A (user): Full usage sections (same depth as existing extensions), marked as repo-only installs until published.
 - Source: README "Quick Start" note + Usage sections for agy-pi / timestamp-pi
+
+## 2026-08-22
+- Q: Should prompt-cache keep-alive ship by extending timestamp-pi, or as a separate `cache-warm` package?
+- A: Separate `extensions/cache-warm` npm package. timestamp-pi stays TUI-only (timestamps never reach the LLM). Warming is paid session traffic and must be independently togglable (default off). Countdown helpers (`CACHE_TTL_MS`, `computeCacheStatus`) are copied (~20 lines) rather than extracted into a shared library; no runtime imports from timestamp-pi or statusline-pi.
+- Source: issue #51

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -10,6 +10,7 @@ pi-extensions/
 │   ├── 9router-pi/                 # Dynamic 9router model discovery (src/index.ts)
 │   ├── advisor-pi/                 # Advisor tool + /advisor-pi command (src/index.ts)
 │   ├── agy-pi/                     # agy CLI provider bridge (src/index.ts)
+│   ├── cache-warm/                 # prompt-cache keep-alive + savings metrics (src/index.ts)
 │   ├── claude-code-pi/             # registerProvider + claude -p stream adapter (src/index.ts)
 │   ├── grok-pi/                    # grok-cli provider bridge (src/index.ts)
 │   ├── model-debugger/             # model request logging (index.ts)
@@ -23,7 +24,7 @@ pi-extensions/
 │   └── opencode.json               # OpenCode-branded theme
 ├── scripts/
 │   ├── check-packaging.mjs         # pi.extensions vs files allowlist guard
-│   └── publish-npm-extensions.sh   # publish all ten npm extensions
+│   └── publish-npm-extensions.sh   # publish all eleven npm extensions
 ├── install.sh                      # Interactive/automated installer
 └── package.json                    # npm convenience scripts
 ```
@@ -185,7 +186,7 @@ load from the installed package — see issue #32):
 node scripts/check-packaging.mjs   # also run automatically by publish-npm-extensions.sh
 ```
 
-Publish all ten npm extensions from repo root (approve the 2FA link in your browser):
+Publish all eleven npm extensions from repo root (approve the 2FA link in your browser):
 
 ```bash
 chmod +x scripts/publish-npm-extensions.sh
@@ -195,7 +196,7 @@ chmod +x scripts/publish-npm-extensions.sh
 ```
 
 The extension list lives in `EXTENSIONS` at `scripts/publish-npm-extensions.sh:12`;
-all listed extensions except `9router-pi` and `subagents-pi` are published to npm —
+all listed extensions except `9router-pi`, `subagents-pi`, and `cache-warm` are published to npm —
 the script's next run performs their initial publishes.
 
 ### Gallery `pi.image` URLs (npm metadata)
@@ -208,7 +209,7 @@ the script's next run performs their initial publishes.
 | opencode-pi | `assets/pi-opencode-cli-model-list.png` |
 | statusline-pi | `assets/statusline-pi-150toks-haiku-4.5.png` |
 | timestamp-pi | (none — `pi.image` points to a missing asset) |
-| claude-code-pi / subagents-pi / model-debugger | (none yet) |
+| claude-code-pi / subagents-pi / model-debugger / cache-warm | (none yet) |
 
 <!-- FLAG: agy-pi and timestamp-pi pi.image URLs reference assets not present in assets/ — add the files or remove the pi.image field before the images can appear on pi.dev -->
 
@@ -325,6 +326,16 @@ select the effort. `AGY_PI_BIN` overrides the binary (`index.ts:69`);
 counting down the 5-minute prompt-cache TTL (`CACHE_TTL_MS`, `index.ts:8`;
 yellow under 60s, red once expired, `index.ts:11,223`). Entries are custom
 session entries, so history survives reloads and never reaches the LLM.
+
+### cache-warm
+
+`cache-warm` is a separate keep-alive extension (not part of timestamp-pi).
+Default is off: `/cache-warm on` starts a timer that may `pi.sendMessage()` a
+hidden ping when remaining TTL is under 60s, the session is idle, and cache
+activity has already been observed (`extensions/cache-warm/src/index.ts`).
+Metrics (`attempts`, `refreshes`, `likelyAvoidedMisses`, estimated net USD)
+live in `src/warm.ts` / `src/metrics.ts`; cost math is copied from
+statusline-pi rather than imported. The 5-minute TTL is an Anthropic heuristic.
 
 ## Adding a New Extension
 

--- a/extensions/cache-warm/README.md
+++ b/extensions/cache-warm/README.md
@@ -9,10 +9,11 @@ This is a separate package from [timestamp-pi](../timestamp-pi/README.md). times
 ## What it does
 
 - **Keep-alive pings** — when the remaining 5-minute prompt-cache TTL drops under 60 seconds, and the session is idle with no queued messages, `cache-warm` injects a `display: false` custom message (`Reply "." only. Do not use tools.`) via `sendMessage`
+- **Tool isolation** — once the hidden turn is confirmed, every tool call is forcibly blocked until Pi emits `agent_settled`, including retries, continuations, and interrupted turns. The extension never changes the global active-tool list.
 - **Easy toggle** — `/cache-warm on`, `/cache-warm off`, or `/cache-warm` to toggle
 - **Honest metrics** — attempts, successful refreshes, likely avoided misses, and estimated net USD saved
 
-The 5-minute TTL is an Anthropic heuristic, not a universal provider guarantee.
+The 5-minute TTL is an Anthropic heuristic, not a universal provider guarantee. An unconfirmed dispatch is never retried within the same cache-activity epoch because a late first dispatch could otherwise create duplicate billed turns.
 
 Pings enter the LLM context. The assistant reply cannot be guaranteed invisible.
 
@@ -30,10 +31,12 @@ Pings enter the LLM context. The assistant reply cannot be guaranteed invisible.
 
 | Counter | Meaning |
 |---------|---------|
-| `attempts` | Warm pings sent |
-| `refreshes` | Warm-triggered assistant turns that read cache (`cacheRead > 0`) |
-| `likely avoided misses` | Later **non-warm** turns that still hit cache after the pre-warm cache would have expired. Counted once per warm chain. A cache read on the warm ping itself is a refresh, not an avoided miss. |
-| `estimated net USD saved` | Gross cache discount of those avoided-miss turns minus warm-turn spend. Missing/invalid model rates report `N/A`, not `$0`. Net savings may be negative. |
+| `attempts` | Warm runs whose hidden message reached a confirmed lifecycle start. Merely requesting `sendMessage` does not count. |
+| `refreshes` | Confirmed warm runs with cache activity (read or recreation), at most once per run. |
+| `likely avoided misses` | Later **external non-warm** runs that still hit cache after the pre-warm cache would have expired. Counted once per warm chain from the external run's first request start. Warm retries and continuations never qualify. |
+| `estimated net USD saved` | Pi-native actual-vs-counterfactual cost delta for eligible hits, minus all warm-run spend. Unknown pricing reports `N/A`, not `$0`. Net savings may be negative. |
+
+Cost estimation uses `@earendil-works/pi-ai` pricing, including tiered rates and Anthropic 1-hour cache writes. The miss-billing heuristic is intentionally narrow: official OpenAI APIs are treated as ordinary uncached input; official Anthropic or explicit Anthropic-compatible cache control uses a 5-minute cache write; an observed `cacheWrite1h` uses a 1-hour write. Unknown providers and ambiguous proxy modes report `N/A`.
 
 While enabled, the footer shows a short `warm 4:32 · 2 hits · $0.041` line (countdown, avoided-miss hits, estimated net saved).
 

--- a/extensions/cache-warm/README.md
+++ b/extensions/cache-warm/README.md
@@ -8,12 +8,12 @@ This is a separate package from [timestamp-pi](../timestamp-pi/README.md). times
 
 ## What it does
 
-- **Keep-alive pings** — when the remaining 5-minute prompt-cache TTL drops under 60 seconds, and the session is idle with no queued messages, `cache-warm` injects a `display: false` custom message (`Reply "." only. Do not use tools.`) via `sendMessage`
-- **Tool isolation** — once the hidden turn is confirmed, every tool call is forcibly blocked until Pi emits `agent_settled`, including retries, continuations, and interrupted turns. The extension never changes the global active-tool list.
+- **Keep-alive pings** — when the remaining prompt-cache TTL drops under 60 seconds, and the session is idle with no queued messages, `cache-warm` injects a `display: false` custom message (`Reply "." only. Do not use tools.`) via `sendMessage`. Observed full one-hour Anthropic writes use a one-hour TTL; short and mixed writes schedule conservatively at five minutes.
+- **Tool isolation** — once the hidden turn is confirmed, every hidden tool call is forcibly blocked, including retries, continuations, and interrupted work. If Pi drains queued user or foreign custom work before `agent_settled`, the guard is released at that message boundary so the external turn can use tools normally. The extension never changes the global active-tool list.
 - **Easy toggle** — `/cache-warm on`, `/cache-warm off`, or `/cache-warm` to toggle
 - **Honest metrics** — attempts, successful refreshes, likely avoided misses, and estimated net USD saved
 
-The 5-minute TTL is an Anthropic heuristic, not a universal provider guarantee. An unconfirmed dispatch is never retried within the same cache-activity epoch because a late first dispatch could otherwise create duplicate billed turns.
+The five-minute fallback is an Anthropic heuristic, not a universal provider guarantee. Cache reads without new write evidence retain the most recent observed retention for the model/session. An unconfirmed dispatch is never retried within the same cache-activity epoch because a late first dispatch could otherwise create duplicate billed turns.
 
 Pings enter the LLM context. The assistant reply cannot be guaranteed invisible.
 
@@ -36,7 +36,7 @@ Pings enter the LLM context. The assistant reply cannot be guaranteed invisible.
 | `likely avoided misses` | Later **external non-warm** runs that still hit cache after the pre-warm cache would have expired. Counted once per warm chain from the external run's first request start. Warm retries and continuations never qualify. |
 | `estimated net USD saved` | Pi-native actual-vs-counterfactual cost delta for eligible hits, minus all warm-run spend. Unknown pricing reports `N/A`, not `$0`. Net savings may be negative. |
 
-Cost estimation uses `@earendil-works/pi-ai` pricing, including tiered rates and Anthropic 1-hour cache writes. The miss-billing heuristic is intentionally narrow: official OpenAI APIs are treated as ordinary uncached input; official Anthropic or explicit Anthropic-compatible cache control uses a 5-minute cache write; an observed `cacheWrite1h` uses a 1-hour write. Unknown providers and ambiguous proxy modes report `N/A`.
+Cost estimation uses `@earendil-works/pi-ai` pricing, including tiered rates and Anthropic one-hour cache writes. For OpenAI Responses requests, a validated reported/base cost ratio preserves flex or priority service-tier pricing in the counterfactual; unsafe or missing multiplier evidence reports `N/A`. The miss-billing heuristic is intentionally narrow: official OpenAI APIs are treated as ordinary uncached input; official Anthropic or explicit Anthropic-compatible cache control uses a five-minute cache write; a full observed `cacheWrite1h` uses a one-hour write. Mixed short/long writes are warmed on the shorter schedule but do not claim an avoided miss or estimated savings.
 
 While enabled, the footer shows a short `warm 4:32 · 2 hits · $0.041` line (countdown, avoided-miss hits, estimated net saved).
 

--- a/extensions/cache-warm/README.md
+++ b/extensions/cache-warm/README.md
@@ -1,0 +1,66 @@
+# cache-warm
+
+Opt-in keep-alive for Pi's prompt cache. When enabled, the extension sends a tiny hidden turn before the cache TTL expires so a later user message is more likely to hit cache instead of paying for a miss.
+
+**Default is off.** Installing the extension or starting a session never bills a warm turn. Enable it with `/cache-warm on`.
+
+This is a separate package from [timestamp-pi](../timestamp-pi/README.md). timestamp-pi only shows TUI timestamps and a countdown; it never sends keep-alive traffic. See [docs/DECISIONS.md](../../docs/DECISIONS.md).
+
+## What it does
+
+- **Keep-alive pings** — when the remaining 5-minute prompt-cache TTL drops under 60 seconds, and the session is idle with no queued messages, `cache-warm` injects a `display: false` custom message (`Reply "." only. Do not use tools.`) via `sendMessage`
+- **Easy toggle** — `/cache-warm on`, `/cache-warm off`, or `/cache-warm` to toggle
+- **Honest metrics** — attempts, successful refreshes, likely avoided misses, and estimated net USD saved
+
+The 5-minute TTL is an Anthropic heuristic, not a universal provider guarantee.
+
+Pings enter the LLM context. The assistant reply cannot be guaranteed invisible.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `/cache-warm` | Toggle keep-alive on/off |
+| `/cache-warm on` | Enable warming |
+| `/cache-warm off` | Disable warming |
+| `/cache-warm status` | Enabled state, cache countdown, and metrics |
+| `/cache-warm metrics` | Attempts, refreshes, likely avoided misses, estimated net USD saved |
+
+## Metrics
+
+| Counter | Meaning |
+|---------|---------|
+| `attempts` | Warm pings sent |
+| `refreshes` | Warm-triggered assistant turns that read cache (`cacheRead > 0`) |
+| `likely avoided misses` | Later **non-warm** turns that still hit cache after the pre-warm cache would have expired. Counted once per warm chain. A cache read on the warm ping itself is a refresh, not an avoided miss. |
+| `estimated net USD saved` | Gross cache discount of those avoided-miss turns minus warm-turn spend. Missing/invalid model rates report `N/A`, not `$0`. Net savings may be negative. |
+
+While enabled, the footer shows a short `warm 4:32 · 2 hits · $0.041` line (countdown, avoided-miss hits, estimated net saved).
+
+## Install from this repository
+
+Not published to npm yet. From the repository root:
+
+```bash
+pi -e ./extensions/cache-warm
+```
+
+Or install it persistently:
+
+```bash
+pi install -l ./extensions/cache-warm
+```
+
+Then run `/reload` in Pi (or restart it). Warming stays **off** until `/cache-warm on`.
+
+## Development
+
+```bash
+cd extensions/cache-warm
+npm install
+npm test
+```
+
+## License
+
+MIT — same as [pi-extensions](https://github.com/luongnv89/pi-extensions).

--- a/extensions/cache-warm/package-lock.json
+++ b/extensions/cache-warm/package-lock.json
@@ -1,0 +1,2029 @@
+{
+  "name": "cache-warm",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "cache-warm",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "typescript": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@earendil-works/pi-coding-agent": "^0.84.2",
+        "@earendil-works/pi-tui": "^0.84.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent": {
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.84.2.tgz",
+      "integrity": "sha512-l4E+B7hgXKWddRo8bC/eSue2aWZjEgJ9xIpf5p0Og+lq8a2TArCwJ0HCoCPCgaBP/tN4zbYH/wOwvx9pJpeLCA==",
+      "hasShrinkwrap": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@earendil-works/pi-agent-core": "^0.84.2",
+        "@earendil-works/pi-ai": "^0.84.2",
+        "@earendil-works/pi-client": "^0.84.2",
+        "@earendil-works/pi-protocol": "^0.84.2",
+        "@earendil-works/pi-tui": "^0.84.2",
+        "@silvia-odwyer/photon-node": "0.3.4",
+        "chalk": "5.6.2",
+        "cross-spawn": "7.0.6",
+        "diff": "8.0.4",
+        "glob": "13.0.6",
+        "grok-mermaid": "0.2.2",
+        "highlight.js": "10.7.3",
+        "hosted-git-info": "9.0.3",
+        "ignore": "7.0.5",
+        "jiti": "2.7.0",
+        "minimatch": "10.2.5",
+        "proper-lockfile": "4.1.2",
+        "semver": "7.8.0",
+        "typebox": "1.3.7",
+        "undici": "8.9.0",
+        "yaml": "2.9.0"
+      },
+      "bin": {
+        "pi": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      },
+      "optionalDependencies": {
+        "@mariozechner/clipboard": "0.3.9"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@anthropic-ai/sdk": {
+      "version": "0.91.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/client-bedrock-runtime": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
+      "integrity": "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/credential-provider-node": "^3.972.42",
+        "@aws-sdk/eventstream-handler-node": "^3.972.16",
+        "@aws-sdk/middleware-eventstream": "^3.972.12",
+        "@aws-sdk/middleware-websocket": "^3.972.19",
+        "@aws-sdk/token-providers": "3.1048.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/core": {
+      "version": "3.974.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.11.tgz",
+      "integrity": "sha512-QpnINq5FZH6EOaDEkmHdT7eUunbvD27pDNQypaWjFyYz7Zl1q3UCMQErBZxpmfGfI7MvI2TlK8KTkgNpv8b1ug==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/xml-builder": "^3.972.24",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.37.tgz",
+      "integrity": "sha512-/jpPvEh6f7ntmIzf7dNxoNX6Q8vt8UpesCjbW6mFfk4V1NW6bIy9qxcQ6WbA8As5yQhsZOe+xeNd4xHX8kdY2Q==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.39.tgz",
+      "integrity": "sha512-pIgTpisWyWg7X1bUbzSjuUYosYTD0Ghz2M0hkSTmb3a6i3qV3uU+NYJPI/E2XSC0HcsZh5rsLPzeXrkb2DS0Cg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.41.tgz",
+      "integrity": "sha512-u2tyjaxJJzW8UtW4SM1ZcPMDwO6y+kV+llvou+Adts0FAKyzes5jG4izQN+KX3yE8ZROpS5y1LJ//xL2iSf76w==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/credential-provider-env": "^3.972.37",
+        "@aws-sdk/credential-provider-http": "^3.972.39",
+        "@aws-sdk/credential-provider-login": "^3.972.41",
+        "@aws-sdk/credential-provider-process": "^3.972.37",
+        "@aws-sdk/credential-provider-sso": "^3.972.41",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.41",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/credential-provider-imds": "^4.3.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.41.tgz",
+      "integrity": "sha512-0LBitxXiAiaE5nlFPfpNIww/8FRY/I7WIndWsc9GmNFOM7cE1wNpVNQEGEk9Outg5l8xl+3vybxFyUy4l9q/LQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.42.tgz",
+      "integrity": "sha512-D4oon2zbqqsWOJUM99Gm3/ZyJ0IJvTXVN3PyloGb3kQEyI36fjCZheZj422lAgTWWd6TSHgiImLt3RIaLdv3dQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.37",
+        "@aws-sdk/credential-provider-http": "^3.972.39",
+        "@aws-sdk/credential-provider-ini": "^3.972.41",
+        "@aws-sdk/credential-provider-process": "^3.972.37",
+        "@aws-sdk/credential-provider-sso": "^3.972.41",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.41",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/credential-provider-imds": "^4.3.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.37.tgz",
+      "integrity": "sha512-7nVaHBUaWIddASYfVaA9O4D5ZVjewU3sCol9WqZPGfW0nR+0WqE0xHZnD/U2L33PlOB8KNXGKZ6wOES/QijKzg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.41.tgz",
+      "integrity": "sha512-IOWAWEHe5LkjSKkkUUX9ciV6Y1scHTsnfEkdt5yyC4Slrc7AGbkLPrpntjqh18ksJAMOaVhoBsO8p2WyTcY2wQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/token-providers": "3.1048.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.41.tgz",
+      "integrity": "sha512-mbACk9Yypa8nm4iGZLs0PofOXEcTDOUw6wDnsPXNDNSd2WNXs1tSo+6nc/fh0jLYdfVZThhBL98PHW4aXFsG5A==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/eventstream-handler-node": {
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.16.tgz",
+      "integrity": "sha512-yedpPgKftqjU5SlPFHfqWpOw6xSCRieWRG1euWOlXn4WJxt2VX92VprCa2PpSOXjVCAeK6dTjW9eJRXVig9yGA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/middleware-eventstream": {
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.12.tgz",
+      "integrity": "sha512-tHTHHCHNrq6XklQvlzHBDJG4Iuhh7NVPRdtmvP+nHFA+5sxPlIDzlAHHgfoYHGvT3NXP1yVP/L5c3opUn6T3Qg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/middleware-websocket": {
+      "version": "3.972.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.19.tgz",
+      "integrity": "sha512-mkEhOGYozqKQkbFaVrjwr0faiwwZza1v5/jSY6Tucm3bD+uKTazIUH/4Yo6aMnQD2ua2W9cMP6s8mvwTcjtqHw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.9.tgz",
+      "integrity": "sha512-jPR3rnmRI4hWYyzfmTGBr7NblMp8QYYeflHXba1H6+7CGrWVqWKQzaXFQ4qbExqPRsXN3T3L3JxFhr6aouXUGQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.27",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.27.tgz",
+      "integrity": "sha512-0Phbz4t6HI3D3skxvG2uI+VWU034/nSIw1T8d+FPzzQG9EQTrw94o9mOKO2Gv3n3Oc8P7JD7RAUxkoneLWv5Eg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
+      "integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/types": {
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.24.tgz",
+      "integrity": "sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@nodable/entities": "2.1.0",
+        "@smithy/types": "^4.14.1",
+        "fast-xml-parser": "5.7.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.84.2.tgz",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@earendil-works/pi-ai": "^0.84.2",
+        "@earendil-works/pi-telemetry": "^0.84.2",
+        "diff": "8.0.4",
+        "ignore": "7.0.5",
+        "typebox": "1.3.7",
+        "yaml": "2.9.0"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.2.tgz",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@anthropic-ai/sdk": "0.91.1",
+        "@aws-sdk/client-bedrock-runtime": "3.1048.0",
+        "@earendil-works/pi-telemetry": "^0.84.2",
+        "@google/genai": "1.52.0",
+        "@opentelemetry/api": "1.9.0",
+        "@smithy/node-http-handler": "4.7.3",
+        "http-proxy-agent": "7.0.2",
+        "https-proxy-agent": "7.0.6",
+        "openai": "6.40.0",
+        "partial-json": "0.1.7",
+        "typebox": "1.3.7"
+      },
+      "bin": {
+        "pi-ai": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-client": {
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-client/-/pi-client-0.84.2.tgz",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@earendil-works/pi-protocol": "^0.84.2"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-protocol": {
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-protocol/-/pi-protocol-0.84.2.tgz",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "typebox": "1.3.7"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-telemetry": {
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.2.tgz",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.2.tgz",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "get-east-asian-width": "1.6.0",
+        "marked": "18.0.5"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@google/genai": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
+      "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.9.tgz",
+      "integrity": "sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@mariozechner/clipboard-darwin-arm64": "0.3.9",
+        "@mariozechner/clipboard-darwin-universal": "0.3.9",
+        "@mariozechner/clipboard-darwin-x64": "0.3.9",
+        "@mariozechner/clipboard-linux-arm64-gnu": "0.3.9",
+        "@mariozechner/clipboard-linux-arm64-musl": "0.3.9",
+        "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.9",
+        "@mariozechner/clipboard-linux-x64-gnu": "0.3.9",
+        "@mariozechner/clipboard-linux-x64-musl": "0.3.9",
+        "@mariozechner/clipboard-win32-arm64-msvc": "0.3.9",
+        "@mariozechner/clipboard-win32-x64-msvc": "0.3.9"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-arm64": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.9.tgz",
+      "integrity": "sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-universal": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.9.tgz",
+      "integrity": "sha512-BGGR4iA9Z2shAjI65eI5xtyb3LYNlDW9X3gxKxDbqtbnREohsrqznov6zpKoIrsRWpzlYVEdKphS7ksJ0/ndSQ==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-x64": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.9.tgz",
+      "integrity": "sha512-4kURmCbS6nt8uYhtmWpUcJWyPHfmAr5dTpXD1nO3pIfa+TSQ9DbrGOYCKH+aEFW47XhQ4Vp8ZTszie+wfFvDKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-arm64-gnu": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.9.tgz",
+      "integrity": "sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-arm64-musl": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.9.tgz",
+      "integrity": "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-riscv64-gnu": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.9.tgz",
+      "integrity": "sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-x64-gnu": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.9.tgz",
+      "integrity": "sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-x64-musl": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.9.tgz",
+      "integrity": "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-win32-arm64-msvc": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.9.tgz",
+      "integrity": "sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-win32-x64-msvc": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.9.tgz",
+      "integrity": "sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@silvia-odwyer/photon-node": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
+      "integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
+      "license": "Apache-2.0",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/core": {
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.3.tgz",
+      "integrity": "sha512-Ep/7tPamGY8mgESE3LyLKtxJyy6U52WWAqr/3wial47Sj4u3PiIF73AOGI27UyLy9duTkhZbgzodOfLV4TduZg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/credential-provider-imds": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.3.tgz",
+      "integrity": "sha512-I2Bti0DKFo2IJyN28ijCsx51BAumEYR4/1yZ1FXyBygy9MqbnMqCev4JPth/MbpRfBSRAX35hITSnAdJRo1u5w==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/fetch-http-handler": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.3.tgz",
+      "integrity": "sha512-F+DRf8IJazRJgYog2A/yJK7eYVc0rqTlRzO+5ZxjJd4WkZoKz0IJRncf7G6t1pdVT3kryJcwuTFhN1c5m6N47A==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/node-http-handler": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
+      "integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/signature-v4": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.3.tgz",
+      "integrity": "sha512-53+75QuPl6DL+ct6vVEB51FDO5oulXr20TPV46VvJZg76lIlXNWfxi8j+G2V/t0I2qxCBOa3vX/8bmjrpFVo9g==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/types": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
+      "integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-parser": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "peer": true,
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/google-auth-library": {
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/grok-mermaid": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/grok-mermaid/-/grok-mermaid-0.2.2.tgz",
+      "integrity": "sha512-XcJEP5dDC8liHBh52mlLjU18fNvu1ckFsu0QpIG3+APZ270fsj9wxpiA6cOURmbUEuoMVgjbC2+UYgTdCqqgzA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/hosted-git-info": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+      "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "lru-cache": "^11.1.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/lru-cache": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.4.0.tgz",
+      "integrity": "sha512-W+R+kFL4HgVxONq2bhXPi3bGpzGe/yEhVOp233qw9wCRtgncJ15P3bC+e4zZMu4Cq7d+WAJjXGW0uUkifhcatA==",
+      "license": "BlueOak-1.0.0",
+      "peer": true,
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/marked": {
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "peer": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/openai": {
+      "version": "6.40.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.40.0.tgz",
+      "integrity": "sha512-MWtTjd/gQt4jpbji61NTgFWJLoY/PdRJ6wG9/ZDRMYNMlBKrCrSlkLI+KgHP1vR1qT6LKSAyAqIxno6lcK9JiA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/p-retry/node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/partial-json": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
+      "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "peer": true,
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/proper-lockfile/node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/protobufjs": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "license": "ISC",
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/strnum": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/typebox": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.7.tgz",
+      "integrity": "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/undici": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.9.0.tgz",
+      "integrity": "sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/@earendil-works/pi-tui": {
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.2.tgz",
+      "integrity": "sha512-ds2TLihOnM5sLJB3VpXV6y0uR5efVuHf4MN7yDpsty6hA2DUO/EDVzjp/0od0G2JslzVLMjT8T8zavtxVb+qbg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "get-east-asian-width": "1.6.0",
+        "marked": "18.0.5"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/marked": {
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/extensions/cache-warm/package-lock.json
+++ b/extensions/cache-warm/package-lock.json
@@ -15,8 +15,525 @@
         "node": ">=18"
       },
       "peerDependencies": {
+        "@earendil-works/pi-ai": "^0.84.2",
         "@earendil-works/pi-coding-agent": "^0.84.2",
         "@earendil-works/pi-tui": "^0.84.2"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.91.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-runtime": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
+      "integrity": "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/credential-provider-node": "^3.972.42",
+        "@aws-sdk/eventstream-handler-node": "^3.972.16",
+        "@aws-sdk/middleware-eventstream": "^3.972.12",
+        "@aws-sdk/middleware-websocket": "^3.972.19",
+        "@aws-sdk/token-providers": "3.1048.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.977.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.9.tgz",
+      "integrity": "sha512-reqPFEQrZxDZpeGj4PFMepBeR5LGYHRqq/L0motTzgFkCRBA4rFdaVXDSLYyGHhxVz7sT2PDnPN9CluGSfgyJA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.5",
+        "@aws-sdk/xml-builder": "^3.972.40",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.33.3",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.17.2",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.70.tgz",
+      "integrity": "sha512-H404B7dJl2mCrBqahDEYsanB0xhdDp6tXnXcTUnXmmpy2Q3J0Ho0bUajZ2jr/RdwzCyS59Gi8xXIFwPLGBl6Uw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.72",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.72.tgz",
+      "integrity": "sha512-X98zYOrVOeuosCX+6ktf29FC2N2GHPLia7qv6mzPzTc+RPAuHWCDS++Z6JK7eGYqb/v6uaW7bAXaOvDBfol+0w==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/node-http-handler": "^4.11.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-http-handler": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.11.3.tgz",
+      "integrity": "sha512-2jY1tSpERfPfWqyBV2pH+iGFaghVsIJszJNsT7hxtQYhVJpWDyc0LqOWI+nXOxOAHaEfZ4PXXtp1wW1TGpHhkA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.973.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.15.tgz",
+      "integrity": "sha512-Rykg6s5ceBuynMOGWgoowO4N+27JfnqXAnVaSunZl0hOO1XodSrxGNz6sCEbnmS0lAfQZDKyb3fbr46gSuv6Sg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/credential-provider-env": "^3.972.70",
+        "@aws-sdk/credential-provider-http": "^3.972.72",
+        "@aws-sdk/credential-provider-login": "^3.972.77",
+        "@aws-sdk/credential-provider-process": "^3.972.70",
+        "@aws-sdk/credential-provider-sso": "^3.973.14",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.76",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.77",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.77.tgz",
+      "integrity": "sha512-Jb59xfEISoN5mmbnA+HYqdtrSX3CgCtJoof+V5D8/TgUI56W63GEEd5Y58WijU3Ou6+WEgaLD1feVzaRXV5IDQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.81",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.81.tgz",
+      "integrity": "sha512-Rml+WitoFvXmv6JZ18U/xGdGDGGvB/mOin0ya0lTnTrdC0Z1lrVxTYh7iNklZBcvcRMrs4DoEf6xy1KWyrLQQw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.70",
+        "@aws-sdk/credential-provider-http": "^3.972.72",
+        "@aws-sdk/credential-provider-ini": "^3.973.15",
+        "@aws-sdk/credential-provider-process": "^3.972.70",
+        "@aws-sdk/credential-provider-sso": "^3.973.14",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.76",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.70.tgz",
+      "integrity": "sha512-2ry03fGRJr4sV3jI+ocjj5JqALnFD6ymM5KiNCDZMvq8bX2GSbE0vji4aM43TVCl2nXqqLRZaUxdq/KeWRAY4Q==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.973.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.14.tgz",
+      "integrity": "sha512-jkhg/8ocAAoc0RFyLMhCw+/zZh7gystQgd4F4hznNa8P4Cc501PQmxd+jGLiMHodPJ+7Zv/3znM62gZojyasmA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/token-providers": "3.1116.0",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1116.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1116.0.tgz",
+      "integrity": "sha512-ygIivKqh8aHzNkucOCXHyIBgBpLPfrSI0mCqXF+vLBsPTUKqj0VSqAY0GFPe7lQl4HntjOcQ+KSyS7oUV2C54Q==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.76",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.76.tgz",
+      "integrity": "sha512-d3AGyVu759PGr35mEB2s22xxlNEA5rpdxtSPJthfPFJvoQ8dt357iVPECqWfUxXp1toJAvKmbtcIYVGigaGsCA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-handler-node": {
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.34.tgz",
+      "integrity": "sha512-cTeVzpu1xEAkryTZBYhGwnQ6gOGyp8ZYZvmn0Sg/nI/ABmy/CRHHxPDJDUi9PxwxUtGGaatvfRUB3FCgT/rSWw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-eventstream": {
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.29.tgz",
+      "integrity": "sha512-dlRzHCgyB8W6hLuDC5pcT5q+ziPt00n4QGgGBE17ucLVU4zMa6lsbuUdQ2Pm75Z5VA8GF+R/+SgrRcaTdIzSIQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-websocket": {
+      "version": "3.972.52",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.52.tgz",
+      "integrity": "sha512-vsPPM+nMbKJlUCFU+eoGZbdxdxDIAX9LbpjSXaR5Ufpmqgp8TdYQnoExhLu4T3umW/JIIPny1ydbhWidZZYokQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.44",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.44.tgz",
+      "integrity": "sha512-NhEgryjlBF9w38ZXqGymQV28IhkYa1mKhlbYnqIis57AYwWGVYfUPgg/qC2rLRqOUfblxx++irvju10kVTa8Vw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.46",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/node-http-handler": "^4.11.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-http-handler": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.11.3.tgz",
+      "integrity": "sha512-2jY1tSpERfPfWqyBV2pH+iGFaghVsIJszJNsT7hxtQYhVJpWDyc0LqOWI+nXOxOAHaEfZ4PXXtp1wW1TGpHhkA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.46.tgz",
+      "integrity": "sha512-L+2xZTye/2T96f3lwCws0Zw6GG2JHZW9e8FpVgGBeeExSKyeoZ6CWRpBml/7DNiK/O26jrgPM9F+Ay8VkgzUWQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
+      "integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.974.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.5.tgz",
+      "integrity": "sha512-LkwLL2BLbC6wNNm4JaH9mbEqBMdOZCct6VAYqhdN4U1xrWM+fUJQEfbHwQgDypapOWTRtlk25akb5afM0P8CIQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.10.tgz",
+      "integrity": "sha512-ycwH6Zd2GhuSqdXX9ihbCjeGTB6xOJs+O3+Jb8/zDG9978XU80qs75dfkPJRMNKe5MvBZPuNeFpd4JZKPoUF4g==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.40",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.40.tgz",
+      "integrity": "sha512-wlFmCIGUlwF4zx/kncw+bmxTQh1HeSJq4mYV/V5cZUSJadDP3kXvGW8Rn21cimj/7y9ju+47oYWXi97vF7czaA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-ai": {
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.2.tgz",
+      "integrity": "sha512-6MzsrYIYNVlE7SfpbL2yYb67Qo58p/7Q+xWG1RZvoX1P80aRCHSod2/13aFpxkow1lPO2LEh3c495J0Gwmyjig==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@anthropic-ai/sdk": "0.91.1",
+        "@aws-sdk/client-bedrock-runtime": "3.1048.0",
+        "@earendil-works/pi-telemetry": "^0.84.2",
+        "@google/genai": "1.52.0",
+        "@opentelemetry/api": "1.9.0",
+        "@smithy/node-http-handler": "4.7.3",
+        "http-proxy-agent": "7.0.2",
+        "https-proxy-agent": "7.0.6",
+        "openai": "6.40.0",
+        "partial-json": "0.1.7",
+        "typebox": "1.3.7"
+      },
+      "bin": {
+        "pi-ai": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent": {
@@ -1971,6 +2488,16 @@
         "url": "https://github.com/sponsors/eemeli"
       }
     },
+    "node_modules/@earendil-works/pi-telemetry": {
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.2.tgz",
+      "integrity": "sha512-wg5caea7uIv1BHRBm2Y116RvFG4oSAiP5qk9tA2463PDGIr4K8M1Ceyyg5DOpF/shUUl0gk826yQJAeAcHYB9g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
     "node_modules/@earendil-works/pi-tui": {
       "version": "0.84.2",
       "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.2.tgz",
@@ -1983,6 +2510,419 @@
       },
       "engines": {
         "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@google/genai": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
+      "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.33.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.33.3.tgz",
+      "integrity": "sha512-CsOeKq/9kA3y6VJHt+/+VTCtBaxJ4OTFpgrjIUhPpDIKxBci1k2bJaQASF2h/ELWrulGp+t97DZ0mevfAD8idg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.5.2.tgz",
+      "integrity": "sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.7.2.tgz",
+      "integrity": "sha512-nZyWTmSpJEXl6VtWVMBJve/7x12DZu6sIX1z1a+ZMaHlQQRs9Zpu6NbTe/gmxYXVRpkjxyDYpZ5gx2IM6f/Wkw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
+      "integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.7.3.tgz",
+      "integrity": "sha512-7ImGm+FkHRLcBaRttIAMZ6bzJZWb2cJGoYjq46F2UjycujWzrL9GEN9h4w7eQyXJYnltrUhxbbieBAIRrdqpow==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.17.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.17.2.tgz",
+      "integrity": "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.1.tgz",
+      "integrity": "sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/get-east-asian-width": {
@@ -1998,6 +2938,116 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.1.tgz",
+      "integrity": "sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0",
+      "peer": true
+    },
     "node_modules/marked": {
       "version": "18.0.5",
       "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
@@ -2011,6 +3061,169 @@
         "node": ">= 20"
       }
     },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.40.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.40.0.tgz",
+      "integrity": "sha512-MWtTjd/gQt4jpbji61NTgFWJLoY/PdRJ6wG9/ZDRMYNMlBKrCrSlkLI+KgHP1vR1qT6LKSAyAqIxno6lcK9JiA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/partial-json": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
+      "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "peer": true
+    },
+    "node_modules/typebox": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.7.tgz",
+      "integrity": "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -2023,6 +3236,45 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     }
   }

--- a/extensions/cache-warm/package.json
+++ b/extensions/cache-warm/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "cache-warm",
+  "version": "0.1.0",
+  "description": "Opt-in prompt-cache keep-alive for Pi with avoided-miss and USD-saved metrics",
+  "type": "module",
+  "main": "./src/index.ts",
+  "files": [
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "prepublishOnly": "npm run build",
+    "test": "npm run build && node --test"
+  },
+  "pi": {
+    "extensions": [
+      "./src/index.ts"
+    ]
+  },
+  "keywords": [
+    "pi-package",
+    "pi",
+    "cache",
+    "prompt-cache",
+    "keep-alive",
+    "cache-warm"
+  ],
+  "author": "pi-extensions contributors",
+  "license": "MIT",
+  "engines": {
+    "node": ">=18"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/luongnv89/pi-extensions.git"
+  },
+  "bugs": {
+    "url": "https://github.com/luongnv89/pi-extensions/issues"
+  },
+  "homepage": "https://github.com/luongnv89/pi-extensions/tree/main/extensions/cache-warm",
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": "^0.84.2",
+    "@earendil-works/pi-tui": "^0.84.2"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/extensions/cache-warm/package.json
+++ b/extensions/cache-warm/package.json
@@ -40,6 +40,7 @@
   },
   "homepage": "https://github.com/luongnv89/pi-extensions/tree/main/extensions/cache-warm",
   "peerDependencies": {
+    "@earendil-works/pi-ai": "^0.84.2",
     "@earendil-works/pi-coding-agent": "^0.84.2",
     "@earendil-works/pi-tui": "^0.84.2"
   },

--- a/extensions/cache-warm/src/cache.ts
+++ b/extensions/cache-warm/src/cache.ts
@@ -1,0 +1,42 @@
+/** Prompt cache TTL (Anthropic default is 5 minutes). Documented heuristic, not universal. */
+export const CACHE_TTL_MS = 5 * 60 * 1000;
+
+/** Warn / warm when less than this time remains before the cache expires. */
+export const CACHE_WARN_MS = 60 * 1000;
+
+export interface CacheStatus {
+	/** "idle": no cache activity yet; "active": counting down; "expired": TTL elapsed */
+	state: "idle" | "active" | "expired";
+	label: string;
+	/** Milliseconds left before the cache expires (0 when expired/idle). */
+	remainingMs: number;
+}
+
+/** Format a countdown as m:ss, clamped at 0:00. */
+export function formatCountdown(ms: number): string {
+	const totalSeconds = Math.max(0, Math.ceil(ms / 1000));
+	const minutes = Math.floor(totalSeconds / 60);
+	const seconds = totalSeconds % 60;
+	return `${minutes}:${String(seconds).padStart(2, "0")}`;
+}
+
+/**
+ * Compute the prompt-cache countdown state.
+ *
+ * The cache stays warm for CACHE_TTL_MS after the last request that read from
+ * or wrote to it; once the TTL elapses the next request is a cache miss.
+ */
+export function computeCacheStatus(
+	lastActive: number | undefined,
+	now: number,
+	ttlMs: number = CACHE_TTL_MS,
+): CacheStatus {
+	if (lastActive === undefined) {
+		return { state: "idle", label: "", remainingMs: 0 };
+	}
+	const remainingMs = Math.max(0, ttlMs - (now - lastActive));
+	if (remainingMs <= 0) {
+		return { state: "expired", label: "cache expired", remainingMs };
+	}
+	return { state: "active", label: `cache ${formatCountdown(remainingMs)}`, remainingMs };
+}

--- a/extensions/cache-warm/src/cache.ts
+++ b/extensions/cache-warm/src/cache.ts
@@ -1,5 +1,8 @@
-/** Prompt cache TTL (Anthropic default is 5 minutes). Documented heuristic, not universal. */
+/** Short prompt-cache TTL (Anthropic default is 5 minutes). */
 export const CACHE_TTL_MS = 5 * 60 * 1000;
+
+/** Anthropic long prompt-cache TTL when every cache-write token is billed at 1 hour. */
+export const CACHE_TTL_LONG_MS = 60 * 60 * 1000;
 
 /** Warn / warm when less than this time remains before the cache expires. */
 export const CACHE_WARN_MS = 60 * 1000;
@@ -23,8 +26,8 @@ export function formatCountdown(ms: number): string {
 /**
  * Compute the prompt-cache countdown state.
  *
- * The cache stays warm for CACHE_TTL_MS after the last request that read from
- * or wrote to it; once the TTL elapses the next request is a cache miss.
+ * The cache stays warm for the selected retention TTL after the last request
+ * that read from or wrote to it; once the TTL elapses the next request is a miss.
  */
 export function computeCacheStatus(
 	lastActive: number | undefined,

--- a/extensions/cache-warm/src/command.ts
+++ b/extensions/cache-warm/src/command.ts
@@ -1,0 +1,22 @@
+export type CacheWarmAction = "on" | "off" | "status" | "metrics" | "toggle" | "unknown";
+
+/** Parse `/cache-warm` args. Empty input toggles. */
+export function parseCacheWarmArgs(args: string): CacheWarmAction {
+	const token = args.trim().split(/\s+/).filter(Boolean)[0]?.toLowerCase() ?? "";
+	switch (token) {
+		case "":
+			return "toggle";
+		case "on":
+		case "enable":
+			return "on";
+		case "off":
+		case "disable":
+			return "off";
+		case "status":
+			return "status";
+		case "metrics":
+			return "metrics";
+		default:
+			return "unknown";
+	}
+}

--- a/extensions/cache-warm/src/index.ts
+++ b/extensions/cache-warm/src/index.ts
@@ -1,0 +1,240 @@
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { parseCacheWarmArgs } from "./command.js";
+import { formatMetrics } from "./metrics.js";
+import {
+	applyAssistantUsage,
+	applyModelChange,
+	beginWarmPing,
+	createWarmState,
+	ENTRY_TYPE,
+	expireStaleInFlight,
+	formatStatusReport,
+	formatWarmFooter,
+	modelKeyOf,
+	noteInterveningTurn,
+	noteTurnEnd,
+	noteTurnStart,
+	PING_CONTENT,
+	resetSession,
+	setEnabled,
+	shouldSendWarmPing,
+	STATUS_KEY,
+} from "./warm.js";
+
+export {
+	CACHE_TTL_MS,
+	CACHE_WARN_MS,
+	computeCacheStatus,
+	formatCountdown,
+} from "./cache.js";
+export { parseCacheWarmArgs } from "./command.js";
+export type { CacheWarmAction } from "./command.js";
+export {
+	calculateCostFromModelRates,
+	createMetrics,
+	estimateGrossDiscountUsd,
+	estimateTurnUsd,
+	formatMetrics,
+	formatUsd,
+	hasValidRates,
+	netUsdSaved,
+	normalizeUsage,
+} from "./metrics.js";
+export type { Metrics, ModelRates, TokenUsage } from "./metrics.js";
+export {
+	applyAssistantUsage,
+	applyModelChange,
+	beginWarmPing,
+	closeChain,
+	createWarmState,
+	ENTRY_TYPE,
+	expireStaleInFlight,
+	formatStatusReport,
+	formatWarmFooter,
+	MIN_WARM_INTERVAL_MS,
+	modelKeyOf,
+	noteInterveningTurn,
+	noteTurnEnd,
+	noteTurnStart,
+	PING_CONTENT,
+	resetSession,
+	setEnabled,
+	shouldSendWarmPing,
+	STATUS_KEY,
+	WARM_TIMEOUT_MS,
+} from "./warm.js";
+export type { PendingTurn, WarmPingGate, WarmState } from "./warm.js";
+
+const TICK_MS = 1_000;
+
+export default function cacheWarmExtension(pi: ExtensionAPI) {
+	const state = createWarmState();
+	let timer: ReturnType<typeof setInterval> | undefined;
+	let mountedCtx: ExtensionContext | undefined;
+
+	pi.on("session_start", async (_event, ctx) => {
+		mountedCtx = ctx;
+		applyModelChange(state, modelKeyOf(ctx.model));
+		syncStatus(ctx);
+	});
+
+	pi.on("session_shutdown", async () => {
+		stopTimer();
+		resetSession(state);
+		if (mountedCtx?.hasUI) {
+			mountedCtx.ui.setStatus(STATUS_KEY, undefined);
+		}
+		mountedCtx = undefined;
+	});
+
+	pi.on("model_select", async (event, ctx) => {
+		applyModelChange(state, modelKeyOf(event.model ?? ctx.model));
+		syncStatus(ctx);
+	});
+
+	pi.on("turn_start", async (event) => {
+		noteTurnStart(state, event.timestamp ?? Date.now());
+	});
+
+	pi.on("turn_end", async () => {
+		noteTurnEnd(state);
+	});
+
+	pi.on("message_end", async (event, ctx) => {
+		const message = event.message as {
+			role?: string;
+			customType?: string;
+			usage?: { input?: number; output?: number; cacheRead?: number; cacheWrite?: number };
+		};
+
+		if (message.role === "user") {
+			noteInterveningTurn(state);
+			return;
+		}
+
+		if (message.role === "custom") {
+			if (message.customType !== ENTRY_TYPE) {
+				noteInterveningTurn(state);
+			}
+			return;
+		}
+
+		if (message.role !== "assistant") return;
+
+		applyAssistantUsage(state, {
+			now: Date.now(),
+			usage: message.usage,
+			model: ctx.model,
+		});
+		syncStatus(ctx);
+	});
+
+	pi.registerCommand("cache-warm", {
+		description: "Enable, disable, or show prompt-cache keep-alive status and savings",
+		handler: async (args, ctx) => {
+			mountedCtx = ctx;
+			const action = parseCacheWarmArgs(args);
+			switch (action) {
+				case "on":
+					enable(ctx);
+					notify(ctx, "cache-warm enabled", "info");
+					return;
+				case "off":
+					disable(ctx);
+					notify(ctx, "cache-warm disabled", "info");
+					return;
+				case "toggle":
+					if (state.enabled) {
+						disable(ctx);
+						notify(ctx, "cache-warm disabled", "info");
+					} else {
+						enable(ctx);
+						notify(ctx, "cache-warm enabled", "info");
+					}
+					return;
+				case "status":
+					notify(ctx, formatStatusReport(state, Date.now()), "info");
+					return;
+				case "metrics":
+					notify(ctx, formatMetrics(state.metrics), "info");
+					return;
+				default:
+					notify(ctx, "Usage: /cache-warm [on|off|status|metrics]", "warning");
+			}
+		},
+	});
+
+	function enable(ctx: ExtensionContext): void {
+		setEnabled(state, true);
+		mountedCtx = ctx;
+		startTimer();
+		syncStatus(ctx);
+	}
+
+	function disable(ctx: ExtensionContext): void {
+		setEnabled(state, false);
+		stopTimer();
+		syncStatus(ctx);
+	}
+
+	function startTimer(): void {
+		if (timer) return;
+		timer = setInterval(() => {
+			const ctx = mountedCtx;
+			if (!ctx) return;
+			tick(ctx);
+		}, TICK_MS);
+	}
+
+	function stopTimer(): void {
+		if (!timer) return;
+		clearInterval(timer);
+		timer = undefined;
+	}
+
+	function tick(ctx: ExtensionContext): void {
+		const now = Date.now();
+		expireStaleInFlight(state, now);
+		const idle = ctx.isIdle();
+		const pending = ctx.hasPendingMessages();
+		if (
+			shouldSendWarmPing({
+				enabled: state.enabled,
+				now,
+				cacheLastActive: state.cacheLastActive,
+				inFlight: state.inFlight,
+				idle,
+				hasPendingMessages: pending,
+				lastAttemptAt: state.lastAttemptAt,
+			}) &&
+			ctx.isIdle() &&
+			!ctx.hasPendingMessages()
+		) {
+			beginWarmPing(state, now);
+			try {
+				pi.sendMessage(
+					{
+						customType: ENTRY_TYPE,
+						content: PING_CONTENT,
+						display: false,
+					},
+					{ triggerTurn: true },
+				);
+			} catch {
+				state.inFlight = false;
+			}
+		}
+		syncStatus(ctx);
+	}
+
+	function syncStatus(ctx?: ExtensionContext): void {
+		const target = ctx ?? mountedCtx;
+		if (!target?.hasUI) return;
+		target.ui.setStatus(STATUS_KEY, formatWarmFooter(state, Date.now()));
+	}
+
+	function notify(ctx: ExtensionContext, message: string, level: "info" | "warning" | "error"): void {
+		if (!ctx.hasUI) return;
+		ctx.ui.notify(message, level);
+	}
+}

--- a/extensions/cache-warm/src/index.ts
+++ b/extensions/cache-warm/src/index.ts
@@ -1,18 +1,23 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { Model, Usage } from "@earendil-works/pi-ai";
 import { parseCacheWarmArgs } from "./command.js";
 import { formatMetrics } from "./metrics.js";
 import {
 	applyAssistantUsage,
 	applyModelChange,
-	beginWarmPing,
+	beginWarmDispatch,
+	confirmWarmDispatch,
 	createWarmState,
 	ENTRY_TYPE,
-	expireStaleInFlight,
+	expirePendingDispatch,
+	failPendingDispatch,
 	formatStatusReport,
 	formatWarmFooter,
+	markWarmAbortCalled,
 	modelKeyOf,
-	noteInterveningTurn,
-	noteTurnEnd,
+	noteAgentSettled,
+	noteAgentStart,
+	noteExternalInput,
 	noteTurnStart,
 	PING_CONTENT,
 	resetSession,
@@ -21,40 +26,39 @@ import {
 	STATUS_KEY,
 } from "./warm.js";
 
-export {
-	CACHE_TTL_MS,
-	CACHE_WARN_MS,
-	computeCacheStatus,
-	formatCountdown,
-} from "./cache.js";
+export { CACHE_TTL_MS, CACHE_WARN_MS, computeCacheStatus, formatCountdown } from "./cache.js";
 export { parseCacheWarmArgs } from "./command.js";
 export type { CacheWarmAction } from "./command.js";
 export {
-	calculateCostFromModelRates,
+	cloneUsage,
 	createMetrics,
-	estimateGrossDiscountUsd,
+	estimateGrossBenefitUsd,
 	estimateTurnUsd,
 	formatMetrics,
 	formatUsd,
-	hasValidRates,
+	hasCacheActivity,
+	inferMissBillingMode,
 	netUsdSaved,
 	normalizeUsage,
 } from "./metrics.js";
-export type { Metrics, ModelRates, TokenUsage } from "./metrics.js";
+export type { Metrics, MissBillingMode, TokenUsage } from "./metrics.js";
 export {
 	applyAssistantUsage,
 	applyModelChange,
-	beginWarmPing,
+	beginWarmDispatch,
 	closeChain,
+	confirmWarmDispatch,
 	createWarmState,
 	ENTRY_TYPE,
-	expireStaleInFlight,
+	expirePendingDispatch,
+	failPendingDispatch,
 	formatStatusReport,
 	formatWarmFooter,
-	MIN_WARM_INTERVAL_MS,
+	markWarmAbortCalled,
 	modelKeyOf,
-	noteInterveningTurn,
-	noteTurnEnd,
+	noteAgentSettled,
+	noteAgentStart,
+	noteExternalInput,
 	noteTurnStart,
 	PING_CONTENT,
 	resetSession,
@@ -63,9 +67,11 @@ export {
 	STATUS_KEY,
 	WARM_TIMEOUT_MS,
 } from "./warm.js";
-export type { PendingTurn, WarmPingGate, WarmState } from "./warm.js";
+export type { PendingTurn, WarmDispatch, WarmPingGate, WarmRun, WarmState } from "./warm.js";
 
 const TICK_MS = 1_000;
+const TOOL_BLOCK_REASON = "cache-warm hidden turns cannot call tools";
+const DISPATCH_ID_KEY = "cacheWarmDispatchId";
 
 export default function cacheWarmExtension(pi: ExtensionAPI) {
 	const state = createWarmState();
@@ -81,52 +87,69 @@ export default function cacheWarmExtension(pi: ExtensionAPI) {
 	pi.on("session_shutdown", async () => {
 		stopTimer();
 		resetSession(state);
-		if (mountedCtx?.hasUI) {
-			mountedCtx.ui.setStatus(STATUS_KEY, undefined);
-		}
+		if (mountedCtx?.hasUI) mountedCtx.ui.setStatus(STATUS_KEY, undefined);
 		mountedCtx = undefined;
 	});
 
 	pi.on("model_select", async (event, ctx) => {
-		applyModelChange(state, modelKeyOf(event.model ?? ctx.model));
+		if (applyModelChange(state, modelKeyOf(event.model ?? ctx.model))) ctx.abort();
 		syncStatus(ctx);
+	});
+
+	pi.on("input", async (_event, ctx) => {
+		if (noteExternalInput(state)) ctx.abort();
+	});
+
+	pi.on("before_agent_start", async (_event, ctx) => {
+		if (noteExternalInput(state)) ctx.abort();
+	});
+
+	pi.on("agent_start", async () => {
+		noteAgentStart(state);
 	});
 
 	pi.on("turn_start", async (event) => {
-		noteTurnStart(state, event.timestamp ?? Date.now());
+		noteTurnStart(state, event.timestamp);
 	});
 
-	pi.on("turn_end", async () => {
-		noteTurnEnd(state);
-	});
-
-	pi.on("message_end", async (event, ctx) => {
+	pi.on("message_start", async (event, ctx) => {
 		const message = event.message as {
 			role?: string;
 			customType?: string;
-			usage?: { input?: number; output?: number; cacheRead?: number; cacheWrite?: number };
+			details?: Record<string, unknown>;
 		};
-
-		if (message.role === "user") {
-			noteInterveningTurn(state);
+		const dispatchId =
+			message.role === "custom" && message.customType === ENTRY_TYPE
+				? message.details?.[DISPATCH_ID_KEY]
+				: undefined;
+		if (typeof dispatchId === "string") {
+			const result = confirmWarmDispatch(state, dispatchId);
+			if (result.abort && markWarmAbortCalled(state)) ctx.abort();
 			return;
 		}
-
-		if (message.role === "custom") {
-			if (message.customType !== ENTRY_TYPE) {
-				noteInterveningTurn(state);
-			}
-			return;
+		if (message.role === "user" || message.role === "custom") {
+			if (noteExternalInput(state)) ctx.abort();
 		}
+	});
 
+	pi.on("message_end", async (event, ctx) => {
+		const message = event.message as { role?: string; usage?: Partial<Usage> };
 		if (message.role !== "assistant") return;
-
 		applyAssistantUsage(state, {
-			now: Date.now(),
 			usage: message.usage,
-			model: ctx.model,
+			model: ctx.model as Model<any> | undefined,
 		});
 		syncStatus(ctx);
+	});
+
+	pi.on("agent_settled", async (_event, ctx) => {
+		noteAgentSettled(state);
+		syncStatus(ctx);
+	});
+
+	pi.on("tool_call", async () => {
+		if (!state.warmRunActive) return;
+		return { block: true, reason: TOOL_BLOCK_REASON, terminate: true };
 	});
 
 	pi.registerCommand("cache-warm", {
@@ -136,30 +159,30 @@ export default function cacheWarmExtension(pi: ExtensionAPI) {
 			const action = parseCacheWarmArgs(args);
 			switch (action) {
 				case "on":
-					enable(ctx);
-					notify(ctx, "cache-warm enabled", "info");
-					return;
+				enable(ctx);
+				notify(ctx, "cache-warm enabled", "info");
+				return;
 				case "off":
+				disable(ctx);
+				notify(ctx, "cache-warm disabled", "info");
+				return;
+				case "toggle":
+				if (state.enabled) {
 					disable(ctx);
 					notify(ctx, "cache-warm disabled", "info");
-					return;
-				case "toggle":
-					if (state.enabled) {
-						disable(ctx);
-						notify(ctx, "cache-warm disabled", "info");
-					} else {
-						enable(ctx);
-						notify(ctx, "cache-warm enabled", "info");
-					}
-					return;
+				} else {
+					enable(ctx);
+					notify(ctx, "cache-warm enabled", "info");
+				}
+				return;
 				case "status":
-					notify(ctx, formatStatusReport(state, Date.now()), "info");
-					return;
+				notify(ctx, formatStatusReport(state, Date.now()), "info");
+				return;
 				case "metrics":
-					notify(ctx, formatMetrics(state.metrics), "info");
-					return;
+				notify(ctx, formatMetrics(state.metrics), "info");
+				return;
 				default:
-					notify(ctx, "Usage: /cache-warm [on|off|status|metrics]", "warning");
+				notify(ctx, "Usage: /cache-warm [on|off|status|metrics]", "warning");
 			}
 		},
 	});
@@ -172,7 +195,7 @@ export default function cacheWarmExtension(pi: ExtensionAPI) {
 	}
 
 	function disable(ctx: ExtensionContext): void {
-		setEnabled(state, false);
+		if (setEnabled(state, false)) ctx.abort();
 		stopTimer();
 		syncStatus(ctx);
 	}
@@ -180,9 +203,7 @@ export default function cacheWarmExtension(pi: ExtensionAPI) {
 	function startTimer(): void {
 		if (timer) return;
 		timer = setInterval(() => {
-			const ctx = mountedCtx;
-			if (!ctx) return;
-			tick(ctx);
+			if (mountedCtx) tick(mountedCtx);
 		}, TICK_MS);
 	}
 
@@ -194,34 +215,42 @@ export default function cacheWarmExtension(pi: ExtensionAPI) {
 
 	function tick(ctx: ExtensionContext): void {
 		const now = Date.now();
-		expireStaleInFlight(state, now);
+		expirePendingDispatch(state, now);
 		const idle = ctx.isIdle();
-		const pending = ctx.hasPendingMessages();
+		const hasPendingMessages = ctx.hasPendingMessages();
 		if (
 			shouldSendWarmPing({
 				enabled: state.enabled,
 				now,
 				cacheLastActive: state.cacheLastActive,
-				inFlight: state.inFlight,
+				cacheEpoch: state.cacheEpoch,
+				dispatchPending: state.dispatchPending !== undefined,
+				warmRunActive: state.warmRunActive !== undefined,
+				suppressedEpoch: state.suppressedEpoch,
 				idle,
-				hasPendingMessages: pending,
-				lastAttemptAt: state.lastAttemptAt,
+				hasPendingMessages,
 			}) &&
 			ctx.isIdle() &&
-			!ctx.hasPendingMessages()
+			!ctx.hasPendingMessages() &&
+			state.enabled &&
+			!state.dispatchPending &&
+			!state.warmRunActive
 		) {
-			beginWarmPing(state, now);
-			try {
-				pi.sendMessage(
-					{
-						customType: ENTRY_TYPE,
-						content: PING_CONTENT,
-						display: false,
-					},
-					{ triggerTurn: true },
-				);
-			} catch {
-				state.inFlight = false;
+			const dispatch = beginWarmDispatch(state, now, ctx.model as Model<any> | undefined);
+			if (dispatch) {
+				try {
+					pi.sendMessage(
+						{
+							customType: ENTRY_TYPE,
+							content: PING_CONTENT,
+							display: false,
+							details: { [DISPATCH_ID_KEY]: dispatch.id },
+						},
+						{ triggerTurn: true },
+					);
+				} catch {
+					failPendingDispatch(state);
+				}
 			}
 		}
 		syncStatus(ctx);
@@ -229,12 +258,10 @@ export default function cacheWarmExtension(pi: ExtensionAPI) {
 
 	function syncStatus(ctx?: ExtensionContext): void {
 		const target = ctx ?? mountedCtx;
-		if (!target?.hasUI) return;
-		target.ui.setStatus(STATUS_KEY, formatWarmFooter(state, Date.now()));
+		if (target?.hasUI) target.ui.setStatus(STATUS_KEY, formatWarmFooter(state, Date.now()));
 	}
 
 	function notify(ctx: ExtensionContext, message: string, level: "info" | "warning" | "error"): void {
-		if (!ctx.hasUI) return;
-		ctx.ui.notify(message, level);
+		if (ctx.hasUI) ctx.ui.notify(message, level);
 	}
 }

--- a/extensions/cache-warm/src/index.ts
+++ b/extensions/cache-warm/src/index.ts
@@ -18,6 +18,7 @@ import {
 	noteAgentSettled,
 	noteAgentStart,
 	noteExternalInput,
+	noteExternalMessageStart,
 	noteTurnStart,
 	PING_CONTENT,
 	resetSession,
@@ -26,7 +27,7 @@ import {
 	STATUS_KEY,
 } from "./warm.js";
 
-export { CACHE_TTL_MS, CACHE_WARN_MS, computeCacheStatus, formatCountdown } from "./cache.js";
+export { CACHE_TTL_LONG_MS, CACHE_TTL_MS, CACHE_WARN_MS, computeCacheStatus, formatCountdown } from "./cache.js";
 export { parseCacheWarmArgs } from "./command.js";
 export type { CacheWarmAction } from "./command.js";
 export {
@@ -59,6 +60,7 @@ export {
 	noteAgentSettled,
 	noteAgentStart,
 	noteExternalInput,
+	noteExternalMessageStart,
 	noteTurnStart,
 	PING_CONTENT,
 	resetSession,
@@ -67,7 +69,15 @@ export {
 	STATUS_KEY,
 	WARM_TIMEOUT_MS,
 } from "./warm.js";
-export type { PendingTurn, WarmDispatch, WarmPingGate, WarmRun, WarmState } from "./warm.js";
+export type {
+	CacheRetentionState,
+	PendingTurn,
+	RetentionKind,
+	WarmDispatch,
+	WarmPingGate,
+	WarmRun,
+	WarmState,
+} from "./warm.js";
 
 const TICK_MS = 1_000;
 const TOOL_BLOCK_REASON = "cache-warm hidden turns cannot call tools";
@@ -128,7 +138,7 @@ export default function cacheWarmExtension(pi: ExtensionAPI) {
 			return;
 		}
 		if (message.role === "user" || message.role === "custom") {
-			if (noteExternalInput(state)) ctx.abort();
+			noteExternalMessageStart(state);
 		}
 	});
 
@@ -229,6 +239,7 @@ export default function cacheWarmExtension(pi: ExtensionAPI) {
 				suppressedEpoch: state.suppressedEpoch,
 				idle,
 				hasPendingMessages,
+				ttlMs: state.retention?.ttlMs,
 			}) &&
 			ctx.isIdle() &&
 			!ctx.hasPendingMessages() &&

--- a/extensions/cache-warm/src/metrics.ts
+++ b/extensions/cache-warm/src/metrics.ts
@@ -1,0 +1,115 @@
+export interface TokenUsage {
+	input: number;
+	output: number;
+	cacheRead: number;
+	cacheWrite: number;
+}
+
+export interface ModelRates {
+	cost: {
+		input: number;
+		output: number;
+		cacheRead: number;
+		cacheWrite: number;
+	};
+}
+
+export interface Metrics {
+	warmAttempts: number;
+	warmRefreshes: number;
+	likelyAvoidedMisses: number;
+	warmSpendUsd: number;
+	grossDiscountUsd: number;
+	pricingKnown: boolean;
+}
+
+export function createMetrics(): Metrics {
+	return {
+		warmAttempts: 0,
+		warmRefreshes: 0,
+		likelyAvoidedMisses: 0,
+		warmSpendUsd: 0,
+		grossDiscountUsd: 0,
+		pricingKnown: true,
+	};
+}
+
+export function normalizeUsage(usage?: Partial<TokenUsage> | null): TokenUsage {
+	return {
+		input: numberOrZero(usage?.input),
+		output: numberOrZero(usage?.output),
+		cacheRead: numberOrZero(usage?.cacheRead),
+		cacheWrite: numberOrZero(usage?.cacheWrite),
+	};
+}
+
+export function hasCacheActivity(usage: TokenUsage): boolean {
+	return usage.cacheRead > 0 || usage.cacheWrite > 0;
+}
+
+export function hasValidRates(model: unknown): model is ModelRates {
+	if (!model || typeof model !== "object") return false;
+	const cost = (model as { cost?: unknown }).cost;
+	if (!cost || typeof cost !== "object") return false;
+	const rates = cost as Record<string, unknown>;
+	return (["input", "output", "cacheRead", "cacheWrite"] as const).every((key) => isNonNegativeFinite(rates[key]));
+}
+
+/** Per-million token rates (same formula as Pi's calculateCost). */
+export function calculateCostFromModelRates(model: ModelRates, usage: TokenUsage): number {
+	const { input, output, cacheRead, cacheWrite } = model.cost;
+	return (
+		(input / 1_000_000) * usage.input +
+		(output / 1_000_000) * usage.output +
+		(cacheRead / 1_000_000) * usage.cacheRead +
+		(cacheWrite / 1_000_000) * usage.cacheWrite
+	);
+}
+
+/** USD cost of a turn from model rates, or null when rates are missing/invalid. */
+export function estimateTurnUsd(model: unknown, usage: Partial<TokenUsage> | TokenUsage): number | null {
+	if (!hasValidRates(model)) return null;
+	return calculateCostFromModelRates(model, normalizeUsage(usage));
+}
+
+/**
+ * Gross cache discount vs paying full input price for cacheRead tokens.
+ * null when rates are missing/invalid.
+ */
+export function estimateGrossDiscountUsd(model: unknown, cacheRead: number): number | null {
+	if (!hasValidRates(model)) return null;
+	const tokens = numberOrZero(cacheRead);
+	return (tokens / 1_000_000) * (model.cost.input - model.cost.cacheRead);
+}
+
+export function netUsdSaved(metrics: Metrics): number | null {
+	if (!metrics.pricingKnown) return null;
+	return metrics.grossDiscountUsd - metrics.warmSpendUsd;
+}
+
+export function formatUsd(amount: number | null): string {
+	if (amount === null || !Number.isFinite(amount)) return "N/A";
+	const sign = amount < 0 ? "-" : "";
+	const abs = Math.abs(amount);
+	if (abs === 0) return "$0.00";
+	if (abs < 0.01) return `${sign}$${abs.toFixed(4)}`;
+	if (abs < 1) return `${sign}$${abs.toFixed(3)}`;
+	return `${sign}$${abs.toFixed(2)}`;
+}
+
+export function formatMetrics(metrics: Metrics): string {
+	return [
+		`attempts: ${metrics.warmAttempts}`,
+		`refreshes: ${metrics.warmRefreshes}`,
+		`likely avoided misses: ${metrics.likelyAvoidedMisses}`,
+		`estimated net USD saved: ${formatUsd(netUsdSaved(metrics))}`,
+	].join("\n");
+}
+
+function numberOrZero(value: unknown): number {
+	return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function isNonNegativeFinite(value: unknown): value is number {
+	return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}

--- a/extensions/cache-warm/src/metrics.ts
+++ b/extensions/cache-warm/src/metrics.ts
@@ -168,7 +168,9 @@ function calculateNativeCost(model: unknown, usage: Usage): Usage["cost"] | null
 }
 
 function supportsRequestServiceTier(model: unknown): boolean {
-	return !!model && typeof model === "object" && (model as { api?: unknown }).api === "openai-responses";
+	if (!model || typeof model !== "object") return false;
+	const api = (model as { api?: unknown }).api;
+	return api === "openai-responses" || api === "openai-codex-responses";
 }
 
 function inferUniformCostMultiplier(reported: Usage["cost"], base: Usage["cost"]): number | null {

--- a/extensions/cache-warm/src/metrics.ts
+++ b/extensions/cache-warm/src/metrics.ts
@@ -1,18 +1,7 @@
-export interface TokenUsage {
-	input: number;
-	output: number;
-	cacheRead: number;
-	cacheWrite: number;
-}
+import { calculateCost, type Model, type Usage } from "@earendil-works/pi-ai";
 
-export interface ModelRates {
-	cost: {
-		input: number;
-		output: number;
-		cacheRead: number;
-		cacheWrite: number;
-	};
-}
+export type TokenUsage = Usage;
+export type MissBillingMode = "input" | "cacheWrite" | "cacheWrite1h";
 
 export interface Metrics {
 	warmAttempts: number;
@@ -34,52 +23,101 @@ export function createMetrics(): Metrics {
 	};
 }
 
-export function normalizeUsage(usage?: Partial<TokenUsage> | null): TokenUsage {
+export function normalizeUsage(usage?: Partial<Usage> | null): Usage {
+	const input = tokenCount(usage?.input);
+	const output = tokenCount(usage?.output);
+	const cacheRead = tokenCount(usage?.cacheRead);
+	const cacheWrite = tokenCount(usage?.cacheWrite);
+	const cacheWrite1h = optionalTokenCount(usage?.cacheWrite1h);
+	const reasoning = optionalTokenCount(usage?.reasoning);
 	return {
-		input: numberOrZero(usage?.input),
-		output: numberOrZero(usage?.output),
-		cacheRead: numberOrZero(usage?.cacheRead),
-		cacheWrite: numberOrZero(usage?.cacheWrite),
+		input,
+		output,
+		cacheRead,
+		cacheWrite,
+		...(cacheWrite1h === undefined ? {} : { cacheWrite1h }),
+		...(reasoning === undefined ? {} : { reasoning }),
+		totalTokens: tokenCount(usage?.totalTokens) || input + output + cacheRead + cacheWrite,
+		cost: {
+			input: money(usage?.cost?.input),
+			output: money(usage?.cost?.output),
+			cacheRead: money(usage?.cost?.cacheRead),
+			cacheWrite: money(usage?.cost?.cacheWrite),
+			total: money(usage?.cost?.total),
+		},
 	};
 }
 
-export function hasCacheActivity(usage: TokenUsage): boolean {
-	return usage.cacheRead > 0 || usage.cacheWrite > 0;
+export function cloneUsage(usage: Partial<Usage> | Usage): Usage {
+	return normalizeUsage(usage);
 }
 
-export function hasValidRates(model: unknown): model is ModelRates {
-	if (!model || typeof model !== "object") return false;
-	const cost = (model as { cost?: unknown }).cost;
-	if (!cost || typeof cost !== "object") return false;
-	const rates = cost as Record<string, unknown>;
-	return (["input", "output", "cacheRead", "cacheWrite"] as const).every((key) => isNonNegativeFinite(rates[key]));
+export function hasCacheActivity(usage: Usage): boolean {
+	return usage.cacheRead > 0 || usage.cacheWrite > 0 || (usage.cacheWrite1h ?? 0) > 0;
 }
 
-/** Per-million token rates (same formula as Pi's calculateCost). */
-export function calculateCostFromModelRates(model: ModelRates, usage: TokenUsage): number {
-	const { input, output, cacheRead, cacheWrite } = model.cost;
-	return (
-		(input / 1_000_000) * usage.input +
-		(output / 1_000_000) * usage.output +
-		(cacheRead / 1_000_000) * usage.cacheRead +
-		(cacheWrite / 1_000_000) * usage.cacheWrite
-	);
+export function inferMissBillingMode(model: unknown, usage?: Partial<Usage>): MissBillingMode | null {
+	const cacheWrite = usage?.cacheWrite ?? 0;
+	const cacheWrite1h = usage?.cacheWrite1h ?? 0;
+	if (cacheWrite1h > cacheWrite) return null;
+	if (cacheWrite1h > 0) return "cacheWrite1h";
+	if (!model || typeof model !== "object") return null;
+	const candidate = model as {
+		api?: unknown;
+		provider?: unknown;
+		compat?: { cacheControlFormat?: unknown };
+	};
+	if (
+		(candidate.api === "anthropic-messages" && candidate.provider === "anthropic") ||
+		candidate.compat?.cacheControlFormat === "anthropic"
+	) {
+		return "cacheWrite";
+	}
+	if (
+		((candidate.api === "openai-completions" || candidate.api === "openai-responses") &&
+			candidate.provider === "openai") ||
+		(candidate.api === "azure-openai-responses" && candidate.provider === "azure-openai") ||
+		(candidate.api === "openai-codex-responses" &&
+			(candidate.provider === "openai" || candidate.provider === "openai-codex"))
+	) {
+		return "input";
+	}
+	return null;
 }
 
-/** USD cost of a turn from model rates, or null when rates are missing/invalid. */
-export function estimateTurnUsd(model: unknown, usage: Partial<TokenUsage> | TokenUsage): number | null {
-	if (!hasValidRates(model)) return null;
-	return calculateCostFromModelRates(model, normalizeUsage(usage));
+/** Actual reported cost when valid, otherwise Pi-native pricing of the full usage. */
+export function estimateTurnUsd(model: unknown, usage: Partial<Usage> | Usage): number | null {
+	if (!isUsageCoherent(usage)) return null;
+	const normalized = normalizeUsage(usage);
+	if (hasValidReportedCost(usage.cost)) return usage.cost.total;
+	return calculateNativeTotal(model, normalized);
 }
 
-/**
- * Gross cache discount vs paying full input price for cacheRead tokens.
- * null when rates are missing/invalid.
- */
-export function estimateGrossDiscountUsd(model: unknown, cacheRead: number): number | null {
-	if (!hasValidRates(model)) return null;
-	const tokens = numberOrZero(cacheRead);
-	return (tokens / 1_000_000) * (model.cost.input - model.cost.cacheRead);
+/** Actual-vs-counterfactual cost delta for cache-read tokens. */
+export function estimateGrossBenefitUsd(
+	model: unknown,
+	actualUsage: Partial<Usage> | Usage,
+	mode: MissBillingMode | null,
+): number | null {
+	if (mode === null || !isUsageCoherent(actualUsage)) return null;
+	const actual = normalizeUsage(actualUsage);
+	if (actual.cacheRead <= 0) return null;
+	const miss = cloneUsage(actual);
+	const attributable = miss.cacheRead;
+	miss.cacheRead = 0;
+	if (mode === "input") {
+		miss.input += attributable;
+	} else if (mode === "cacheWrite") {
+		miss.cacheWrite += attributable;
+	} else {
+		miss.cacheWrite += attributable;
+		miss.cacheWrite1h = (miss.cacheWrite1h ?? 0) + attributable;
+	}
+	const actualTotal = calculateNativeTotal(model, actual);
+	const missTotal = calculateNativeTotal(model, miss);
+	if (actualTotal === null || missTotal === null) return null;
+	const gross = missTotal - actualTotal;
+	return Number.isFinite(gross) && gross >= 0 ? gross : null;
 }
 
 export function netUsdSaved(metrics: Metrics): number | null {
@@ -106,8 +144,62 @@ export function formatMetrics(metrics: Metrics): string {
 	].join("\n");
 }
 
-function numberOrZero(value: unknown): number {
-	return typeof value === "number" && Number.isFinite(value) ? value : 0;
+function calculateNativeTotal(model: unknown, usage: Usage): number | null {
+	if ((usage.cacheWrite1h ?? 0) > usage.cacheWrite) return null;
+	if (!isPriceableModel(model)) return null;
+	try {
+		const total = calculateCost(model, usage).total;
+		return isNonNegativeFinite(total) ? total : null;
+	} catch {
+		return null;
+	}
+}
+
+function hasValidReportedCost(cost: Usage["cost"] | undefined): cost is Usage["cost"] {
+	if (!cost) return false;
+	if (![cost.input, cost.output, cost.cacheRead, cost.cacheWrite, cost.total].every(isNonNegativeFinite)) {
+		return false;
+	}
+	const componentTotal = cost.input + cost.output + cost.cacheRead + cost.cacheWrite;
+	return Math.abs(componentTotal - cost.total) <= Math.max(1e-12, Math.abs(cost.total) * 1e-9);
+}
+
+function isUsageCoherent(usage: Partial<Usage>): boolean {
+	for (const value of [
+		usage.input,
+		usage.output,
+		usage.cacheRead,
+		usage.cacheWrite,
+		usage.cacheWrite1h,
+		usage.reasoning,
+		usage.totalTokens,
+	]) {
+		if (value !== undefined && !isNonNegativeFinite(value)) return false;
+	}
+	return (usage.cacheWrite1h ?? 0) <= (usage.cacheWrite ?? 0);
+}
+
+function isPriceableModel(model: unknown): model is Model<any> {
+	if (!model || typeof model !== "object") return false;
+	const candidate = model as { cost?: Record<string, unknown> };
+	return (
+		candidate.cost !== undefined &&
+		["input", "output", "cacheRead", "cacheWrite"].every((key) =>
+			isNonNegativeFinite(candidate.cost?.[key]),
+		)
+	);
+}
+
+function tokenCount(value: unknown): number {
+	return isNonNegativeFinite(value) ? value : 0;
+}
+
+function optionalTokenCount(value: unknown): number | undefined {
+	return value === undefined ? undefined : tokenCount(value);
+}
+
+function money(value: unknown): number {
+	return isNonNegativeFinite(value) ? value : 0;
 }
 
 function isNonNegativeFinite(value: unknown): value is number {

--- a/extensions/cache-warm/src/metrics.ts
+++ b/extensions/cache-warm/src/metrics.ts
@@ -113,10 +113,17 @@ export function estimateGrossBenefitUsd(
 		miss.cacheWrite += attributable;
 		miss.cacheWrite1h = (miss.cacheWrite1h ?? 0) + attributable;
 	}
-	const actualTotal = calculateNativeTotal(model, actual);
-	const missTotal = calculateNativeTotal(model, miss);
-	if (actualTotal === null || missTotal === null) return null;
-	const gross = missTotal - actualTotal;
+	const baseActual = calculateNativeCost(model, actual);
+	const baseMiss = calculateNativeCost(model, miss);
+	if (baseActual === null || baseMiss === null) return null;
+	let multiplier = 1;
+	if (supportsRequestServiceTier(model)) {
+		if (!hasValidReportedCost(actualUsage.cost)) return null;
+		const inferred = inferUniformCostMultiplier(actualUsage.cost, baseActual);
+		if (inferred === null) return null;
+		multiplier = inferred;
+	}
+	const gross = (baseMiss.total - baseActual.total) * multiplier;
 	return Number.isFinite(gross) && gross >= 0 ? gross : null;
 }
 
@@ -145,14 +152,35 @@ export function formatMetrics(metrics: Metrics): string {
 }
 
 function calculateNativeTotal(model: unknown, usage: Usage): number | null {
+	return calculateNativeCost(model, usage)?.total ?? null;
+}
+
+function calculateNativeCost(model: unknown, usage: Usage): Usage["cost"] | null {
 	if ((usage.cacheWrite1h ?? 0) > usage.cacheWrite) return null;
 	if (!isPriceableModel(model)) return null;
 	try {
-		const total = calculateCost(model, usage).total;
-		return isNonNegativeFinite(total) ? total : null;
+		const priced = cloneUsage(usage);
+		const cost = calculateCost(model, priced);
+		return hasValidReportedCost(cost) ? { ...cost } : null;
 	} catch {
 		return null;
 	}
+}
+
+function supportsRequestServiceTier(model: unknown): boolean {
+	return !!model && typeof model === "object" && (model as { api?: unknown }).api === "openai-responses";
+}
+
+function inferUniformCostMultiplier(reported: Usage["cost"], base: Usage["cost"]): number | null {
+	if (!isNonNegativeFinite(base.total) || base.total <= 0) return null;
+	const multiplier = reported.total / base.total;
+	if (!Number.isFinite(multiplier) || multiplier <= 0) return null;
+	for (const key of ["input", "output", "cacheRead", "cacheWrite"] as const) {
+		const expected = base[key] * multiplier;
+		const tolerance = Math.max(1e-12, Math.abs(expected) * 1e-7, Math.abs(reported[key]) * 1e-7);
+		if (Math.abs(reported[key] - expected) > tolerance) return null;
+	}
+	return multiplier;
 }
 
 function hasValidReportedCost(cost: Usage["cost"] | undefined): cost is Usage["cost"] {

--- a/extensions/cache-warm/src/warm.ts
+++ b/extensions/cache-warm/src/warm.ts
@@ -1,243 +1,353 @@
+import type { Model, Usage } from "@earendil-works/pi-ai";
 import { CACHE_TTL_MS, CACHE_WARN_MS, computeCacheStatus, formatCountdown } from "./cache.js";
 import {
 	createMetrics,
-	estimateGrossDiscountUsd,
+	estimateGrossBenefitUsd,
 	estimateTurnUsd,
 	formatMetrics,
 	formatUsd,
 	hasCacheActivity,
+	inferMissBillingMode,
 	netUsdSaved,
 	normalizeUsage,
 	type Metrics,
-	type ModelRates,
-	type TokenUsage,
+	type MissBillingMode,
 } from "./metrics.js";
 
-/** Custom message type injected for keep-alive pings. */
 export const ENTRY_TYPE = "cache-warm";
-
-/** Tiny constant prompt. The assistant reply still enters LLM context. */
 export const PING_CONTENT = 'Reply "." only. Do not use tools.';
-
-/** Sorts before timestamp-pi's "cache-timestamp-pi" status key. */
 export const STATUS_KEY = "cache-alive-warm";
-
-/** Bound retries after a failed or unanswered ping. */
-export const MIN_WARM_INTERVAL_MS = 15_000;
-
-/** Drop in-flight attribution if the warm assistant never arrives. */
 export const WARM_TIMEOUT_MS = 60_000;
+
+export interface WarmDispatch {
+	id: string;
+	requestedAt: number;
+	cacheEpoch: number;
+	cacheLastActive: number;
+	modelKey: string | undefined;
+	model: Model<any> | undefined;
+}
+
+export interface WarmRun {
+	dispatch: WarmDispatch;
+	interrupted: boolean;
+	abortCalled: boolean;
+	refreshCounted: boolean;
+	eligible: boolean;
+}
 
 export interface PendingTurn {
 	startedAt: number;
-	isWarmOrigin: boolean;
+	origin: "warm" | "external" | "unknown";
 	assistantCount: number;
+}
+
+interface ExternalRun {
+	firstStartedAt: number | undefined;
+	adjudicated: boolean;
+}
+
+interface WarmChain {
+	counterfactualExpiry: number;
+	confirmedRefresh: boolean;
+	attributed: boolean;
+	missMode: MissBillingMode | null;
 }
 
 export interface WarmState {
 	enabled: boolean;
 	cacheLastActive: number | undefined;
-	inFlight: boolean;
+	cacheEpoch: number;
+	suppressedEpoch: number | undefined;
+	dispatchPending: WarmDispatch | undefined;
+	staleDispatches: Map<string, WarmDispatch>;
+	warmRunActive: WarmRun | undefined;
 	lastAttemptAt: number | undefined;
-	/** Snapshot of cacheLastActive when the current warm chain started. */
-	lastActiveBeforeWarm: number | undefined;
-	chainOpen: boolean;
-	/** True after a completed warm turn observed cache activity. */
-	chainEligible: boolean;
-	chainAttributed: boolean;
 	pendingTurn: PendingTurn | undefined;
+	externalRun: ExternalRun | undefined;
+	chain: WarmChain | undefined;
+	observedMissMode: MissBillingMode | null;
 	modelKey: string | undefined;
 	metrics: Metrics;
+	dispatchSequence: number;
 }
 
 export interface WarmPingGate {
 	enabled: boolean;
 	now: number;
 	cacheLastActive: number | undefined;
-	inFlight: boolean;
+	cacheEpoch: number;
+	dispatchPending: boolean;
+	warmRunActive: boolean;
+	suppressedEpoch?: number;
 	idle: boolean;
 	hasPendingMessages: boolean;
-	lastAttemptAt?: number;
 	ttlMs?: number;
 	warnMs?: number;
-	minIntervalMs?: number;
 }
 
 export function createWarmState(): WarmState {
 	return {
 		enabled: false,
 		cacheLastActive: undefined,
-		inFlight: false,
+		cacheEpoch: 0,
+		suppressedEpoch: undefined,
+		dispatchPending: undefined,
+		staleDispatches: new Map(),
+		warmRunActive: undefined,
 		lastAttemptAt: undefined,
-		lastActiveBeforeWarm: undefined,
-		chainOpen: false,
-		chainEligible: false,
-		chainAttributed: false,
 		pendingTurn: undefined,
+		externalRun: undefined,
+		chain: undefined,
+		observedMissMode: null,
 		modelKey: undefined,
 		metrics: createMetrics(),
+		dispatchSequence: 0,
 	};
 }
 
-/**
- * Gate for sending a keep-alive ping. Callers must recheck idle/pending
- * immediately before send.
- */
 export function shouldSendWarmPing(gate: WarmPingGate): boolean {
-	if (!gate.enabled) return false;
-	if (gate.inFlight) return false;
-	if (!gate.idle) return false;
-	if (gate.hasPendingMessages) return false;
-	if (gate.cacheLastActive === undefined) return false;
-	const minInterval = gate.minIntervalMs ?? MIN_WARM_INTERVAL_MS;
-	if (gate.lastAttemptAt !== undefined && gate.now - gate.lastAttemptAt < minInterval) {
-		return false;
-	}
+	if (!gate.enabled || gate.dispatchPending || gate.warmRunActive) return false;
+	if (!gate.idle || gate.hasPendingMessages || gate.cacheLastActive === undefined) return false;
+	if (gate.suppressedEpoch === gate.cacheEpoch) return false;
 	const status = computeCacheStatus(gate.cacheLastActive, gate.now, gate.ttlMs ?? CACHE_TTL_MS);
-	if (status.state !== "active") return false;
-	return status.remainingMs <= (gate.warnMs ?? CACHE_WARN_MS);
+	return status.state === "active" && status.remainingMs <= (gate.warnMs ?? CACHE_WARN_MS);
 }
 
-export function expireStaleInFlight(state: WarmState, now: number): void {
-	if (!state.inFlight || state.lastAttemptAt === undefined) return;
-	if (now - state.lastAttemptAt < WARM_TIMEOUT_MS) return;
-	state.inFlight = false;
-}
-
-export function closeChain(state: WarmState): void {
-	state.chainOpen = false;
-	state.chainEligible = false;
-	state.chainAttributed = false;
-	state.lastActiveBeforeWarm = undefined;
-}
-
-export function beginWarmPing(state: WarmState, now: number): void {
-	state.metrics.warmAttempts += 1;
-	state.inFlight = true;
+export function beginWarmDispatch(
+	state: WarmState,
+	now: number,
+	model: Model<any> | undefined,
+): WarmDispatch | undefined {
+	if (state.cacheLastActive === undefined || state.dispatchPending || state.warmRunActive) return undefined;
+	const dispatch: WarmDispatch = {
+		id: `${now.toString(36)}-${(++state.dispatchSequence).toString(36)}`,
+		requestedAt: now,
+		cacheEpoch: state.cacheEpoch,
+		cacheLastActive: state.cacheLastActive,
+		modelKey: modelKeyOf(model),
+		model,
+	};
+	state.dispatchPending = dispatch;
 	state.lastAttemptAt = now;
-	if (!state.chainOpen) {
-		state.chainOpen = true;
-		state.lastActiveBeforeWarm = state.cacheLastActive;
-		state.chainEligible = false;
-		state.chainAttributed = false;
+	return dispatch;
+}
+
+/** Suppress this cache epoch; a late dispatch remains recognizable and cannot be retried. */
+export function expirePendingDispatch(state: WarmState, now: number): boolean {
+	const pending = state.dispatchPending;
+	if (!pending || now - pending.requestedAt < WARM_TIMEOUT_MS) return false;
+	quarantinePending(state);
+	return true;
+}
+
+export function failPendingDispatch(state: WarmState): void {
+	if (state.dispatchPending) quarantinePending(state);
+}
+
+export function confirmWarmDispatch(state: WarmState, id: string): { confirmed: boolean; abort: boolean } {
+	let dispatch: WarmDispatch | undefined;
+	let eligible = false;
+	if (state.dispatchPending?.id === id) {
+		dispatch = state.dispatchPending;
+		state.dispatchPending = undefined;
+		eligible =
+			state.enabled &&
+			dispatch.cacheEpoch === state.cacheEpoch &&
+			dispatch.modelKey === state.modelKey;
+	} else {
+		dispatch = state.staleDispatches.get(id);
+		if (dispatch) state.staleDispatches.delete(id);
 	}
+	if (!dispatch) return { confirmed: false, abort: false };
+	state.metrics.warmAttempts += 1;
+	state.externalRun = undefined;
+	if (state.warmRunActive) {
+		state.warmRunActive.interrupted = true;
+		state.warmRunActive.eligible = false;
+		if (state.pendingTurn) state.pendingTurn.origin = "warm";
+		closeChain(state);
+		return { confirmed: true, abort: true };
+	}
+	state.warmRunActive = {
+		dispatch,
+		interrupted: !eligible,
+		abortCalled: false,
+		refreshCounted: false,
+		eligible,
+	};
+	if (state.pendingTurn) state.pendingTurn.origin = "warm";
+	if (eligible && !state.chain) {
+		state.chain = {
+			counterfactualExpiry: dispatch.cacheLastActive + CACHE_TTL_MS,
+			confirmedRefresh: false,
+			attributed: false,
+			missMode: state.observedMissMode,
+		};
+	}
+	return { confirmed: true, abort: !eligible };
+}
+
+export function noteAgentStart(state: WarmState): void {
+	if (state.warmRunActive || state.dispatchPending) return;
+	state.externalRun ??= { firstStartedAt: undefined, adjudicated: false };
 }
 
 export function noteTurnStart(state: WarmState, startedAt: number): void {
-	expireStaleInFlight(state, startedAt);
-	state.pendingTurn = {
-		startedAt,
-		isWarmOrigin: state.inFlight,
-		assistantCount: 0,
-	};
+	const origin = state.warmRunActive ? "warm" : state.dispatchPending ? "unknown" : "external";
+	state.pendingTurn = { startedAt, origin, assistantCount: 0 };
+	if (origin === "external") {
+		state.externalRun ??= { firstStartedAt: startedAt, adjudicated: false };
+		state.externalRun.firstStartedAt ??= startedAt;
+	}
 }
 
-export function noteTurnEnd(state: WarmState): void {
-	state.pendingTurn = undefined;
+export function noteExternalInput(state: WarmState): boolean {
+	if (state.dispatchPending) {
+		quarantinePending(state);
+		closeChain(state);
+	}
+	if (state.warmRunActive) {
+		closeChain(state);
+		state.warmRunActive.interrupted = true;
+		state.warmRunActive.eligible = false;
+		if (!state.warmRunActive.abortCalled) {
+			state.warmRunActive.abortCalled = true;
+			return true;
+		}
+		return false;
+	}
+	state.externalRun ??= { firstStartedAt: state.pendingTurn?.startedAt, adjudicated: false };
+	if (state.pendingTurn) {
+		state.pendingTurn.origin = "external";
+		state.externalRun.firstStartedAt ??= state.pendingTurn.startedAt;
+	}
+	return false;
 }
 
-/**
- * User or other-custom traffic while a warm ping is in flight cancels refresh
- * and avoided-miss attribution. Warm spend is still charged if the assistant
- * reply is later identified as warm-origin.
- */
-export function noteInterveningTurn(state: WarmState): void {
-	const racing =
-		state.inFlight ||
-		(state.pendingTurn?.isWarmOrigin === true && state.pendingTurn.assistantCount === 0);
-	if (!racing) return;
-	state.inFlight = false;
-	closeChain(state);
+export function markWarmAbortCalled(state: WarmState): boolean {
+	const run = state.warmRunActive;
+	if (!run || run.abortCalled) return false;
+	run.abortCalled = true;
+	return true;
 }
 
 export function applyAssistantUsage(
 	state: WarmState,
-	input: {
-		now: number;
-		usage?: Partial<TokenUsage> | null;
-		model?: ModelRates | unknown;
-		startedAt?: number;
-	},
+	input: { usage?: Partial<Usage> | null; model?: Model<any>; startedAt?: number },
 ): void {
-	const usage = normalizeUsage(input.usage);
-	if (!state.pendingTurn) {
+	const rawUsage = input.usage;
+	const usage = normalizeUsage(rawUsage);
+	const observedMode = inferMissBillingMode(input.model, usage);
+	if (observedMode === "cacheWrite1h" || state.observedMissMode === null) {
+		state.observedMissMode = observedMode;
+	}
+	if (!state.pendingTurn && input.startedAt !== undefined) {
 		state.pendingTurn = {
-			startedAt: input.startedAt ?? input.now,
-			isWarmOrigin: state.inFlight,
+			startedAt: input.startedAt,
+			origin: state.warmRunActive ? "warm" : "external",
 			assistantCount: 0,
 		};
-	} else if (input.startedAt !== undefined && state.pendingTurn.assistantCount === 0) {
-		state.pendingTurn.startedAt = input.startedAt;
 	}
+	const turn = state.pendingTurn;
+	if (turn && hasCacheActivity(usage)) noteCacheActivity(state, turn.startedAt);
 
-	const pending = state.pendingTurn;
-	const isFirst = pending.assistantCount === 0;
-	if (hasCacheActivity(usage)) {
-		state.cacheLastActive = input.now;
-	}
-
-	if (pending.isWarmOrigin) {
-		addWarmSpend(state, input.model, usage);
-		if (isFirst) {
-			const refreshAttributed = state.inFlight && usage.cacheRead > 0;
-			if (refreshAttributed) {
-				state.metrics.warmRefreshes += 1;
-			}
-			if (state.inFlight && hasCacheActivity(usage)) {
-				state.chainEligible = true;
-			}
-			state.inFlight = false;
+	const run = state.warmRunActive;
+	if (run) {
+		addWarmSpend(state, run.dispatch.model ?? input.model, rawUsage ?? usage);
+		if (!run.refreshCounted && hasCacheActivity(usage)) {
+			run.refreshCounted = true;
+			state.metrics.warmRefreshes += 1;
 		}
-	} else if (isFirst) {
-		adjudicateNonWarmTurn(state, pending.startedAt, usage, input.model);
+		if (run.eligible && !run.interrupted && hasCacheActivity(usage) && state.chain) {
+			state.chain.confirmedRefresh = true;
+			const mode = inferMissBillingMode(run.dispatch.model ?? input.model, usage);
+			if (mode === "cacheWrite1h" || state.chain.missMode === null) state.chain.missMode = mode;
+		}
+	} else if (turn && turn.origin === "external" && state.externalRun && !state.externalRun.adjudicated) {
+		state.externalRun.adjudicated = adjudicateExternalRun(
+			state,
+			state.externalRun.firstStartedAt ?? turn.startedAt,
+			usage,
+			input.model,
+		);
 	}
-
-	pending.assistantCount += 1;
+	if (turn) turn.assistantCount += 1;
 }
 
-export function applyModelChange(state: WarmState, nextKey: string | undefined): void {
-	if (nextKey === state.modelKey) return;
+export function noteAgentSettled(state: WarmState): void {
+	if (!state.warmRunActive && state.externalRun) closeChain(state);
+	state.warmRunActive = undefined;
+	state.pendingTurn = undefined;
+	state.externalRun = undefined;
+}
+
+export function applyModelChange(state: WarmState, nextKey: string | undefined): boolean {
+	if (nextKey === state.modelKey) return false;
 	state.modelKey = nextKey;
-	state.cacheLastActive = undefined;
-	state.inFlight = false;
-	state.lastAttemptAt = undefined;
-	state.pendingTurn = undefined;
+	if (state.dispatchPending) quarantinePending(state);
 	closeChain(state);
+	state.cacheLastActive = undefined;
+	state.cacheEpoch += 1;
+	state.suppressedEpoch = undefined;
+	state.observedMissMode = null;
+	state.pendingTurn = undefined;
+	state.externalRun = undefined;
+	if (!state.warmRunActive) return false;
+	state.warmRunActive.interrupted = true;
+	state.warmRunActive.eligible = false;
+	return markWarmAbortCalled(state);
 }
 
-export function setEnabled(state: WarmState, enabled: boolean): void {
+export function setEnabled(state: WarmState, enabled: boolean): boolean {
+	const wasEnabled = state.enabled;
 	state.enabled = enabled;
-	if (enabled) return;
-	state.inFlight = false;
-	state.pendingTurn = undefined;
+	if (enabled) {
+		if (!wasEnabled) state.suppressedEpoch = undefined;
+		return false;
+	}
+	if (state.dispatchPending) quarantinePending(state);
 	closeChain(state);
+	state.externalRun = undefined;
+	if (!state.warmRunActive) return false;
+	state.warmRunActive.interrupted = true;
+	state.warmRunActive.eligible = false;
+	return markWarmAbortCalled(state);
 }
 
 export function resetSession(state: WarmState): void {
 	state.enabled = false;
 	state.cacheLastActive = undefined;
-	state.inFlight = false;
+	state.cacheEpoch = 0;
+	state.suppressedEpoch = undefined;
+	state.dispatchPending = undefined;
+	state.staleDispatches.clear();
+	state.warmRunActive = undefined;
 	state.lastAttemptAt = undefined;
 	state.pendingTurn = undefined;
+	state.externalRun = undefined;
+	state.chain = undefined;
+	state.observedMissMode = null;
 	state.modelKey = undefined;
-	closeChain(state);
 	state.metrics = createMetrics();
+}
+
+export function closeChain(state: WarmState): void {
+	state.chain = undefined;
 }
 
 export function modelKeyOf(model: { id?: unknown; provider?: unknown } | undefined): string | undefined {
 	if (!model) return undefined;
 	const provider = typeof model.provider === "string" ? model.provider : "";
 	const id = typeof model.id === "string" ? model.id : "";
-	if (!provider && !id) return undefined;
-	return `${provider}/${id}`;
+	return provider || id ? `${provider}/${id}` : undefined;
 }
 
 export function formatWarmFooter(state: WarmState, now: number): string | undefined {
 	if (!state.enabled) return undefined;
 	const status = computeCacheStatus(state.cacheLastActive, now);
 	const hits = state.metrics.likelyAvoidedMisses;
-	const saved = formatUsd(netUsdSaved(state.metrics));
-	const tail = `${hits} hit${hits === 1 ? "" : "s"} · ${saved}`;
+	const tail = `${hits} hit${hits === 1 ? "" : "s"} · ${formatUsd(netUsdSaved(state.metrics))}`;
 	if (status.state === "idle") return `warm on · ${tail}`;
 	if (status.state === "expired") return `warm expired · ${tail}`;
 	return `warm ${formatCountdown(status.remainingMs)} · ${tail}`;
@@ -254,36 +364,57 @@ export function formatStatusReport(state: WarmState, now: number): string {
 	return [`cache-warm: ${state.enabled ? "on" : "off"}`, cacheLine, formatMetrics(state.metrics)].join("\n");
 }
 
-function adjudicateNonWarmTurn(
-	state: WarmState,
-	startedAt: number,
-	usage: TokenUsage,
-	model: unknown,
-): void {
-	if (
-		state.chainEligible &&
-		!state.chainAttributed &&
-		state.lastActiveBeforeWarm !== undefined &&
-		startedAt > state.lastActiveBeforeWarm + CACHE_TTL_MS &&
-		usage.cacheRead > 0
-	) {
-		state.metrics.likelyAvoidedMisses += 1;
-		state.chainAttributed = true;
-		const discount = estimateGrossDiscountUsd(model, usage.cacheRead);
-		if (discount === null) {
-			state.metrics.pricingKnown = false;
-		} else {
-			state.metrics.grossDiscountUsd += discount;
-		}
-	}
-	closeChain(state);
+function quarantinePending(state: WarmState): void {
+	const pending = state.dispatchPending;
+	if (!pending) return;
+	state.dispatchPending = undefined;
+	state.suppressedEpoch = pending.cacheEpoch;
+	state.staleDispatches.set(pending.id, pending);
 }
 
-function addWarmSpend(state: WarmState, model: unknown, usage: TokenUsage): void {
-	const spend = estimateTurnUsd(model, usage);
-	if (spend === null) {
-		state.metrics.pricingKnown = false;
-		return;
+function noteCacheActivity(state: WarmState, startedAt: number): void {
+	if (state.cacheLastActive !== undefined && startedAt <= state.cacheLastActive) return;
+	state.cacheLastActive = startedAt;
+	state.cacheEpoch += 1;
+	if (state.suppressedEpoch !== undefined && state.suppressedEpoch !== state.cacheEpoch) {
+		state.suppressedEpoch = undefined;
 	}
-	state.metrics.warmSpendUsd += spend;
+}
+
+function adjudicateExternalRun(
+	state: WarmState,
+	firstStartedAt: number,
+	usage: Usage,
+	model: Model<any> | undefined,
+): boolean {
+	const chain = state.chain;
+	if (!chain || firstStartedAt <= chain.counterfactualExpiry) {
+		closeChain(state);
+		return true;
+	}
+	if (usage.cacheRead > 0) {
+		if (chain.confirmedRefresh && !chain.attributed) {
+			chain.attributed = true;
+			state.metrics.likelyAvoidedMisses += 1;
+			const gross = estimateGrossBenefitUsd(model, usage, chain.missMode);
+			if (gross === null) state.metrics.pricingKnown = false;
+			else state.metrics.grossDiscountUsd += gross;
+		}
+		closeChain(state);
+		return true;
+	}
+	const hasBillingEvidence =
+		usage.input > 0 ||
+		usage.output > 0 ||
+		usage.cacheWrite > 0 ||
+		(usage.cacheWrite1h ?? 0) > 0 ||
+		usage.totalTokens > 0;
+	if (hasBillingEvidence) closeChain(state);
+	return hasBillingEvidence;
+}
+
+function addWarmSpend(state: WarmState, model: Model<any> | undefined, usage: Partial<Usage>): void {
+	const spend = estimateTurnUsd(model, usage);
+	if (spend === null) state.metrics.pricingKnown = false;
+	else state.metrics.warmSpendUsd += spend;
 }

--- a/extensions/cache-warm/src/warm.ts
+++ b/extensions/cache-warm/src/warm.ts
@@ -1,0 +1,289 @@
+import { CACHE_TTL_MS, CACHE_WARN_MS, computeCacheStatus, formatCountdown } from "./cache.js";
+import {
+	createMetrics,
+	estimateGrossDiscountUsd,
+	estimateTurnUsd,
+	formatMetrics,
+	formatUsd,
+	hasCacheActivity,
+	netUsdSaved,
+	normalizeUsage,
+	type Metrics,
+	type ModelRates,
+	type TokenUsage,
+} from "./metrics.js";
+
+/** Custom message type injected for keep-alive pings. */
+export const ENTRY_TYPE = "cache-warm";
+
+/** Tiny constant prompt. The assistant reply still enters LLM context. */
+export const PING_CONTENT = 'Reply "." only. Do not use tools.';
+
+/** Sorts before timestamp-pi's "cache-timestamp-pi" status key. */
+export const STATUS_KEY = "cache-alive-warm";
+
+/** Bound retries after a failed or unanswered ping. */
+export const MIN_WARM_INTERVAL_MS = 15_000;
+
+/** Drop in-flight attribution if the warm assistant never arrives. */
+export const WARM_TIMEOUT_MS = 60_000;
+
+export interface PendingTurn {
+	startedAt: number;
+	isWarmOrigin: boolean;
+	assistantCount: number;
+}
+
+export interface WarmState {
+	enabled: boolean;
+	cacheLastActive: number | undefined;
+	inFlight: boolean;
+	lastAttemptAt: number | undefined;
+	/** Snapshot of cacheLastActive when the current warm chain started. */
+	lastActiveBeforeWarm: number | undefined;
+	chainOpen: boolean;
+	/** True after a completed warm turn observed cache activity. */
+	chainEligible: boolean;
+	chainAttributed: boolean;
+	pendingTurn: PendingTurn | undefined;
+	modelKey: string | undefined;
+	metrics: Metrics;
+}
+
+export interface WarmPingGate {
+	enabled: boolean;
+	now: number;
+	cacheLastActive: number | undefined;
+	inFlight: boolean;
+	idle: boolean;
+	hasPendingMessages: boolean;
+	lastAttemptAt?: number;
+	ttlMs?: number;
+	warnMs?: number;
+	minIntervalMs?: number;
+}
+
+export function createWarmState(): WarmState {
+	return {
+		enabled: false,
+		cacheLastActive: undefined,
+		inFlight: false,
+		lastAttemptAt: undefined,
+		lastActiveBeforeWarm: undefined,
+		chainOpen: false,
+		chainEligible: false,
+		chainAttributed: false,
+		pendingTurn: undefined,
+		modelKey: undefined,
+		metrics: createMetrics(),
+	};
+}
+
+/**
+ * Gate for sending a keep-alive ping. Callers must recheck idle/pending
+ * immediately before send.
+ */
+export function shouldSendWarmPing(gate: WarmPingGate): boolean {
+	if (!gate.enabled) return false;
+	if (gate.inFlight) return false;
+	if (!gate.idle) return false;
+	if (gate.hasPendingMessages) return false;
+	if (gate.cacheLastActive === undefined) return false;
+	const minInterval = gate.minIntervalMs ?? MIN_WARM_INTERVAL_MS;
+	if (gate.lastAttemptAt !== undefined && gate.now - gate.lastAttemptAt < minInterval) {
+		return false;
+	}
+	const status = computeCacheStatus(gate.cacheLastActive, gate.now, gate.ttlMs ?? CACHE_TTL_MS);
+	if (status.state !== "active") return false;
+	return status.remainingMs <= (gate.warnMs ?? CACHE_WARN_MS);
+}
+
+export function expireStaleInFlight(state: WarmState, now: number): void {
+	if (!state.inFlight || state.lastAttemptAt === undefined) return;
+	if (now - state.lastAttemptAt < WARM_TIMEOUT_MS) return;
+	state.inFlight = false;
+}
+
+export function closeChain(state: WarmState): void {
+	state.chainOpen = false;
+	state.chainEligible = false;
+	state.chainAttributed = false;
+	state.lastActiveBeforeWarm = undefined;
+}
+
+export function beginWarmPing(state: WarmState, now: number): void {
+	state.metrics.warmAttempts += 1;
+	state.inFlight = true;
+	state.lastAttemptAt = now;
+	if (!state.chainOpen) {
+		state.chainOpen = true;
+		state.lastActiveBeforeWarm = state.cacheLastActive;
+		state.chainEligible = false;
+		state.chainAttributed = false;
+	}
+}
+
+export function noteTurnStart(state: WarmState, startedAt: number): void {
+	expireStaleInFlight(state, startedAt);
+	state.pendingTurn = {
+		startedAt,
+		isWarmOrigin: state.inFlight,
+		assistantCount: 0,
+	};
+}
+
+export function noteTurnEnd(state: WarmState): void {
+	state.pendingTurn = undefined;
+}
+
+/**
+ * User or other-custom traffic while a warm ping is in flight cancels refresh
+ * and avoided-miss attribution. Warm spend is still charged if the assistant
+ * reply is later identified as warm-origin.
+ */
+export function noteInterveningTurn(state: WarmState): void {
+	const racing =
+		state.inFlight ||
+		(state.pendingTurn?.isWarmOrigin === true && state.pendingTurn.assistantCount === 0);
+	if (!racing) return;
+	state.inFlight = false;
+	closeChain(state);
+}
+
+export function applyAssistantUsage(
+	state: WarmState,
+	input: {
+		now: number;
+		usage?: Partial<TokenUsage> | null;
+		model?: ModelRates | unknown;
+		startedAt?: number;
+	},
+): void {
+	const usage = normalizeUsage(input.usage);
+	if (!state.pendingTurn) {
+		state.pendingTurn = {
+			startedAt: input.startedAt ?? input.now,
+			isWarmOrigin: state.inFlight,
+			assistantCount: 0,
+		};
+	} else if (input.startedAt !== undefined && state.pendingTurn.assistantCount === 0) {
+		state.pendingTurn.startedAt = input.startedAt;
+	}
+
+	const pending = state.pendingTurn;
+	const isFirst = pending.assistantCount === 0;
+	if (hasCacheActivity(usage)) {
+		state.cacheLastActive = input.now;
+	}
+
+	if (pending.isWarmOrigin) {
+		addWarmSpend(state, input.model, usage);
+		if (isFirst) {
+			const refreshAttributed = state.inFlight && usage.cacheRead > 0;
+			if (refreshAttributed) {
+				state.metrics.warmRefreshes += 1;
+			}
+			if (state.inFlight && hasCacheActivity(usage)) {
+				state.chainEligible = true;
+			}
+			state.inFlight = false;
+		}
+	} else if (isFirst) {
+		adjudicateNonWarmTurn(state, pending.startedAt, usage, input.model);
+	}
+
+	pending.assistantCount += 1;
+}
+
+export function applyModelChange(state: WarmState, nextKey: string | undefined): void {
+	if (nextKey === state.modelKey) return;
+	state.modelKey = nextKey;
+	state.cacheLastActive = undefined;
+	state.inFlight = false;
+	state.lastAttemptAt = undefined;
+	state.pendingTurn = undefined;
+	closeChain(state);
+}
+
+export function setEnabled(state: WarmState, enabled: boolean): void {
+	state.enabled = enabled;
+	if (enabled) return;
+	state.inFlight = false;
+	state.pendingTurn = undefined;
+	closeChain(state);
+}
+
+export function resetSession(state: WarmState): void {
+	state.enabled = false;
+	state.cacheLastActive = undefined;
+	state.inFlight = false;
+	state.lastAttemptAt = undefined;
+	state.pendingTurn = undefined;
+	state.modelKey = undefined;
+	closeChain(state);
+	state.metrics = createMetrics();
+}
+
+export function modelKeyOf(model: { id?: unknown; provider?: unknown } | undefined): string | undefined {
+	if (!model) return undefined;
+	const provider = typeof model.provider === "string" ? model.provider : "";
+	const id = typeof model.id === "string" ? model.id : "";
+	if (!provider && !id) return undefined;
+	return `${provider}/${id}`;
+}
+
+export function formatWarmFooter(state: WarmState, now: number): string | undefined {
+	if (!state.enabled) return undefined;
+	const status = computeCacheStatus(state.cacheLastActive, now);
+	const hits = state.metrics.likelyAvoidedMisses;
+	const saved = formatUsd(netUsdSaved(state.metrics));
+	const tail = `${hits} hit${hits === 1 ? "" : "s"} · ${saved}`;
+	if (status.state === "idle") return `warm on · ${tail}`;
+	if (status.state === "expired") return `warm expired · ${tail}`;
+	return `warm ${formatCountdown(status.remainingMs)} · ${tail}`;
+}
+
+export function formatStatusReport(state: WarmState, now: number): string {
+	const status = computeCacheStatus(state.cacheLastActive, now);
+	const cacheLine =
+		status.state === "idle"
+			? "cache: idle (no activity yet)"
+			: status.state === "expired"
+				? "cache: expired"
+				: `cache: ${formatCountdown(status.remainingMs)} remaining`;
+	return [`cache-warm: ${state.enabled ? "on" : "off"}`, cacheLine, formatMetrics(state.metrics)].join("\n");
+}
+
+function adjudicateNonWarmTurn(
+	state: WarmState,
+	startedAt: number,
+	usage: TokenUsage,
+	model: unknown,
+): void {
+	if (
+		state.chainEligible &&
+		!state.chainAttributed &&
+		state.lastActiveBeforeWarm !== undefined &&
+		startedAt > state.lastActiveBeforeWarm + CACHE_TTL_MS &&
+		usage.cacheRead > 0
+	) {
+		state.metrics.likelyAvoidedMisses += 1;
+		state.chainAttributed = true;
+		const discount = estimateGrossDiscountUsd(model, usage.cacheRead);
+		if (discount === null) {
+			state.metrics.pricingKnown = false;
+		} else {
+			state.metrics.grossDiscountUsd += discount;
+		}
+	}
+	closeChain(state);
+}
+
+function addWarmSpend(state: WarmState, model: unknown, usage: TokenUsage): void {
+	const spend = estimateTurnUsd(model, usage);
+	if (spend === null) {
+		state.metrics.pricingKnown = false;
+		return;
+	}
+	state.metrics.warmSpendUsd += spend;
+}

--- a/extensions/cache-warm/src/warm.ts
+++ b/extensions/cache-warm/src/warm.ts
@@ -1,5 +1,5 @@
 import type { Model, Usage } from "@earendil-works/pi-ai";
-import { CACHE_TTL_MS, CACHE_WARN_MS, computeCacheStatus, formatCountdown } from "./cache.js";
+import { CACHE_TTL_LONG_MS, CACHE_TTL_MS, CACHE_WARN_MS, computeCacheStatus, formatCountdown } from "./cache.js";
 import {
 	createMetrics,
 	estimateGrossBenefitUsd,
@@ -19,11 +19,21 @@ export const PING_CONTENT = 'Reply "." only. Do not use tools.';
 export const STATUS_KEY = "cache-alive-warm";
 export const WARM_TIMEOUT_MS = 60_000;
 
+export type RetentionKind = "short" | "long" | "mixed" | "unknown";
+
+export interface CacheRetentionState {
+	kind: RetentionKind;
+	ttlMs: number;
+	missMode: MissBillingMode | null;
+	attributionAllowed: boolean;
+}
+
 export interface WarmDispatch {
 	id: string;
 	requestedAt: number;
 	cacheEpoch: number;
 	cacheLastActive: number;
+	retention: CacheRetentionState;
 	modelKey: string | undefined;
 	model: Model<any> | undefined;
 }
@@ -52,6 +62,7 @@ interface WarmChain {
 	confirmedRefresh: boolean;
 	attributed: boolean;
 	missMode: MissBillingMode | null;
+	attributionAllowed: boolean;
 }
 
 export interface WarmState {
@@ -66,7 +77,7 @@ export interface WarmState {
 	pendingTurn: PendingTurn | undefined;
 	externalRun: ExternalRun | undefined;
 	chain: WarmChain | undefined;
-	observedMissMode: MissBillingMode | null;
+	retention: CacheRetentionState | undefined;
 	modelKey: string | undefined;
 	metrics: Metrics;
 	dispatchSequence: number;
@@ -99,7 +110,7 @@ export function createWarmState(): WarmState {
 		pendingTurn: undefined,
 		externalRun: undefined,
 		chain: undefined,
-		observedMissMode: null,
+		retention: undefined,
 		modelKey: undefined,
 		metrics: createMetrics(),
 		dispatchSequence: 0,
@@ -125,6 +136,7 @@ export function beginWarmDispatch(
 		requestedAt: now,
 		cacheEpoch: state.cacheEpoch,
 		cacheLastActive: state.cacheLastActive,
+		retention: { ...(state.retention ?? unknownRetention()) },
 		modelKey: modelKeyOf(model),
 		model,
 	};
@@ -179,10 +191,11 @@ export function confirmWarmDispatch(state: WarmState, id: string): { confirmed: 
 	if (state.pendingTurn) state.pendingTurn.origin = "warm";
 	if (eligible && !state.chain) {
 		state.chain = {
-			counterfactualExpiry: dispatch.cacheLastActive + CACHE_TTL_MS,
+			counterfactualExpiry: dispatch.cacheLastActive + dispatch.retention.ttlMs,
 			confirmedRefresh: false,
 			attributed: false,
-			missMode: state.observedMissMode,
+			missMode: dispatch.retention.missMode,
+			attributionAllowed: dispatch.retention.attributionAllowed,
 		};
 	}
 	return { confirmed: true, abort: !eligible };
@@ -217,12 +230,19 @@ export function noteExternalInput(state: WarmState): boolean {
 		}
 		return false;
 	}
-	state.externalRun ??= { firstStartedAt: state.pendingTurn?.startedAt, adjudicated: false };
-	if (state.pendingTurn) {
-		state.pendingTurn.origin = "external";
-		state.externalRun.firstStartedAt ??= state.pendingTurn.startedAt;
-	}
+	initializeExternalRun(state);
 	return false;
+}
+
+/** Transfer ownership only when Pi reaches a queued external message boundary. */
+export function noteExternalMessageStart(state: WarmState): void {
+	if (state.dispatchPending) {
+		quarantinePending(state);
+		closeChain(state);
+	}
+	const transfersWarmOwnership = state.warmRunActive !== undefined;
+	state.warmRunActive = undefined;
+	initializeExternalRun(state, transfersWarmOwnership);
 }
 
 export function markWarmAbortCalled(state: WarmState): boolean {
@@ -238,10 +258,8 @@ export function applyAssistantUsage(
 ): void {
 	const rawUsage = input.usage;
 	const usage = normalizeUsage(rawUsage);
-	const observedMode = inferMissBillingMode(input.model, usage);
-	if (observedMode === "cacheWrite1h" || state.observedMissMode === null) {
-		state.observedMissMode = observedMode;
-	}
+	const observedRetention = retentionFromWrite(input.model, usage);
+	if (observedRetention) state.retention = observedRetention;
 	if (!state.pendingTurn && input.startedAt !== undefined) {
 		state.pendingTurn = {
 			startedAt: input.startedAt,
@@ -261,8 +279,10 @@ export function applyAssistantUsage(
 		}
 		if (run.eligible && !run.interrupted && hasCacheActivity(usage) && state.chain) {
 			state.chain.confirmedRefresh = true;
-			const mode = inferMissBillingMode(run.dispatch.model ?? input.model, usage);
-			if (mode === "cacheWrite1h" || state.chain.missMode === null) state.chain.missMode = mode;
+			if (observedRetention && !observedRetention.attributionAllowed) {
+				state.chain.attributionAllowed = false;
+				state.chain.missMode = null;
+			}
 		}
 	} else if (turn && turn.origin === "external" && state.externalRun && !state.externalRun.adjudicated) {
 		state.externalRun.adjudicated = adjudicateExternalRun(
@@ -290,7 +310,7 @@ export function applyModelChange(state: WarmState, nextKey: string | undefined):
 	state.cacheLastActive = undefined;
 	state.cacheEpoch += 1;
 	state.suppressedEpoch = undefined;
-	state.observedMissMode = null;
+	state.retention = undefined;
 	state.pendingTurn = undefined;
 	state.externalRun = undefined;
 	if (!state.warmRunActive) return false;
@@ -327,7 +347,7 @@ export function resetSession(state: WarmState): void {
 	state.pendingTurn = undefined;
 	state.externalRun = undefined;
 	state.chain = undefined;
-	state.observedMissMode = null;
+	state.retention = undefined;
 	state.modelKey = undefined;
 	state.metrics = createMetrics();
 }
@@ -345,7 +365,7 @@ export function modelKeyOf(model: { id?: unknown; provider?: unknown } | undefin
 
 export function formatWarmFooter(state: WarmState, now: number): string | undefined {
 	if (!state.enabled) return undefined;
-	const status = computeCacheStatus(state.cacheLastActive, now);
+	const status = computeCacheStatus(state.cacheLastActive, now, effectiveTtl(state));
 	const hits = state.metrics.likelyAvoidedMisses;
 	const tail = `${hits} hit${hits === 1 ? "" : "s"} · ${formatUsd(netUsdSaved(state.metrics))}`;
 	if (status.state === "idle") return `warm on · ${tail}`;
@@ -354,7 +374,7 @@ export function formatWarmFooter(state: WarmState, now: number): string | undefi
 }
 
 export function formatStatusReport(state: WarmState, now: number): string {
-	const status = computeCacheStatus(state.cacheLastActive, now);
+	const status = computeCacheStatus(state.cacheLastActive, now, effectiveTtl(state));
 	const cacheLine =
 		status.state === "idle"
 			? "cache: idle (no activity yet)"
@@ -395,10 +415,14 @@ function adjudicateExternalRun(
 	if (usage.cacheRead > 0) {
 		if (chain.confirmedRefresh && !chain.attributed) {
 			chain.attributed = true;
-			state.metrics.likelyAvoidedMisses += 1;
-			const gross = estimateGrossBenefitUsd(model, usage, chain.missMode);
-			if (gross === null) state.metrics.pricingKnown = false;
-			else state.metrics.grossDiscountUsd += gross;
+			if (!chain.attributionAllowed) {
+				state.metrics.pricingKnown = false;
+			} else {
+				state.metrics.likelyAvoidedMisses += 1;
+				const gross = estimateGrossBenefitUsd(model, usage, chain.missMode);
+				if (gross === null) state.metrics.pricingKnown = false;
+				else state.metrics.grossDiscountUsd += gross;
+			}
 		}
 		closeChain(state);
 		return true;
@@ -411,6 +435,57 @@ function adjudicateExternalRun(
 		usage.totalTokens > 0;
 	if (hasBillingEvidence) closeChain(state);
 	return hasBillingEvidence;
+}
+
+function initializeExternalRun(state: WarmState, reset = false): void {
+	if (reset || !state.externalRun) {
+		state.externalRun = { firstStartedAt: state.pendingTurn?.startedAt, adjudicated: false };
+	}
+	if (state.pendingTurn) {
+		state.pendingTurn.origin = "external";
+		state.externalRun.firstStartedAt ??= state.pendingTurn.startedAt;
+	}
+}
+
+function retentionFromWrite(model: Model<any> | undefined, usage: Usage): CacheRetentionState | undefined {
+	const longWrite = usage.cacheWrite1h ?? 0;
+	if (usage.cacheWrite <= 0 && longWrite <= 0) return undefined;
+	if (longWrite > usage.cacheWrite) return unknownRetention();
+	if (longWrite === usage.cacheWrite && longWrite > 0) {
+		return {
+			kind: "long",
+			ttlMs: CACHE_TTL_LONG_MS,
+			missMode: "cacheWrite1h",
+			attributionAllowed: true,
+		};
+	}
+	if (longWrite > 0) {
+		return {
+			kind: "mixed",
+			ttlMs: CACHE_TTL_MS,
+			missMode: null,
+			attributionAllowed: false,
+		};
+	}
+	return {
+		kind: "short",
+		ttlMs: CACHE_TTL_MS,
+		missMode: inferMissBillingMode(model, usage),
+		attributionAllowed: true,
+	};
+}
+
+function unknownRetention(): CacheRetentionState {
+	return {
+		kind: "unknown",
+		ttlMs: CACHE_TTL_MS,
+		missMode: null,
+		attributionAllowed: false,
+	};
+}
+
+function effectiveTtl(state: WarmState): number {
+	return state.retention?.ttlMs ?? CACHE_TTL_MS;
 }
 
 function addWarmSpend(state: WarmState, model: Model<any> | undefined, usage: Partial<Usage>): void {

--- a/extensions/cache-warm/test/cache-warm.test.mjs
+++ b/extensions/cache-warm/test/cache-warm.test.mjs
@@ -1,20 +1,21 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import {
+import cacheWarmExtension, {
 	CACHE_TTL_MS,
-	CACHE_WARN_MS,
-	MIN_WARM_INTERVAL_MS,
+	WARM_TIMEOUT_MS,
 	applyAssistantUsage,
 	applyModelChange,
-	beginWarmPing,
-	computeCacheStatus,
+	beginWarmDispatch,
+	confirmWarmDispatch,
 	createWarmState,
-	formatCountdown,
+	estimateGrossBenefitUsd,
+	estimateTurnUsd,
+	expirePendingDispatch,
 	formatMetrics,
-	formatUsd,
-	formatWarmFooter,
-	noteInterveningTurn,
-	noteTurnEnd,
+	inferMissBillingMode,
+	noteAgentSettled,
+	noteAgentStart,
+	noteExternalInput,
 	noteTurnStart,
 	parseCacheWarmArgs,
 	resetSession,
@@ -22,524 +23,585 @@ import {
 	shouldSendWarmPing,
 } from "../dist/index.js";
 
-const RATES = {
-	cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
-};
+function model(overrides = {}) {
+	return {
+		id: "test-model",
+		name: "Test model",
+		api: "openai-responses",
+		provider: "openai",
+		baseUrl: "https://example.invalid",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 10, output: 20, cacheRead: 1, cacheWrite: 12 },
+		contextWindow: 200_000,
+		maxTokens: 8_000,
+		...overrides,
+	};
+}
 
 function usage(partial = {}) {
-	return {
+	const base = {
 		input: 0,
 		output: 0,
 		cacheRead: 0,
 		cacheWrite: 0,
-		...partial,
+		totalTokens: 0,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 	};
+	const merged = { ...base, ...partial, cost: { ...base.cost, ...(partial.cost ?? {}) } };
+	if (!partial.totalTokens) {
+		merged.totalTokens = merged.input + merged.output + merged.cacheRead + merged.cacheWrite;
+	}
+	return merged;
 }
 
-function gate(overrides = {}) {
+function seedCache(state, at, selectedModel = model(), extraUsage = {}) {
+	noteAgentStart(state);
+	noteTurnStart(state, at);
+	applyAssistantUsage(state, {
+		usage: usage({ input: 20, cacheWrite: 100, ...extraUsage }),
+		model: selectedModel,
+	});
+	noteAgentSettled(state);
+}
+
+function startWarm(state, at, selectedModel = model()) {
+	const dispatch = beginWarmDispatch(state, at, selectedModel);
+	assert.ok(dispatch);
+	noteAgentStart(state);
+	noteTurnStart(state, at + 1);
+	assert.deepEqual(confirmWarmDispatch(state, dispatch.id), { confirmed: true, abort: false });
+	return dispatch;
+}
+
+function gate(state, now, overrides = {}) {
 	return {
-		enabled: true,
-		now: 1_000_000,
-		cacheLastActive: 1_000_000 - (CACHE_TTL_MS - 30_000),
-		inFlight: false,
+		enabled: state.enabled,
+		now,
+		cacheLastActive: state.cacheLastActive,
+		cacheEpoch: state.cacheEpoch,
+		dispatchPending: state.dispatchPending !== undefined,
+		warmRunActive: state.warmRunActive !== undefined,
+		suppressedEpoch: state.suppressedEpoch,
 		idle: true,
 		hasPendingMessages: false,
 		...overrides,
 	};
 }
 
-function seedCache(state, at) {
-	applyAssistantUsage(state, {
-		now: at,
-		usage: usage({ cacheWrite: 200, input: 50 }),
-		model: RATES,
-	});
-	state.pendingTurn = undefined;
-}
-
-describe("parseCacheWarmArgs", () => {
-	it("toggles on empty input", () => {
+describe("commands and dispatch state", () => {
+	it("keeps warming off by default and parses easy toggles", () => {
+		assert.equal(createWarmState().enabled, false);
 		assert.equal(parseCacheWarmArgs(""), "toggle");
-		assert.equal(parseCacheWarmArgs("   "), "toggle");
-	});
-
-	it("parses on/off/status/metrics", () => {
 		assert.equal(parseCacheWarmArgs("on"), "on");
-		assert.equal(parseCacheWarmArgs("  OFF "), "off");
-		assert.equal(parseCacheWarmArgs("status"), "status");
-		assert.equal(parseCacheWarmArgs("metrics extra"), "metrics");
-	});
-
-	it("accepts enable/disable aliases and rejects unknown args", () => {
-		assert.equal(parseCacheWarmArgs("enable"), "on");
 		assert.equal(parseCacheWarmArgs("disable"), "off");
-		assert.equal(parseCacheWarmArgs("nope"), "unknown");
-	});
-});
-
-describe("formatCountdown", () => {
-	it("formats m:ss with padding", () => {
-		assert.equal(formatCountdown(4 * 60_000 + 32_000), "4:32");
-		assert.equal(formatCountdown(5_000), "0:05");
 	});
 
-	it("rounds up partial seconds and clamps at 0:00", () => {
-		assert.equal(formatCountdown(500), "0:01");
-		assert.equal(formatCountdown(-10_000), "0:00");
-	});
-});
-
-describe("computeCacheStatus", () => {
-	const now = Date.now();
-
-	it("is idle without cache activity", () => {
-		assert.deepEqual(computeCacheStatus(undefined, now), {
-			state: "idle",
-			label: "",
-			remainingMs: 0,
-		});
-	});
-
-	it("counts down while the cache is warm", () => {
-		const status = computeCacheStatus(now - 28_000, now);
-		assert.equal(status.state, "active");
-		assert.equal(status.label, "cache 4:32");
-		assert.equal(status.remainingMs, CACHE_TTL_MS - 28_000);
-	});
-
-	it("reports expired once the TTL elapses", () => {
-		const status = computeCacheStatus(now - CACHE_TTL_MS - 1_000, now);
-		assert.equal(status.state, "expired");
-		assert.equal(status.label, "cache expired");
-		assert.equal(status.remainingMs, 0);
-	});
-
-	it("honors a custom TTL", () => {
-		const status = computeCacheStatus(now - 90_000, now, 2 * 60_000);
-		assert.equal(status.state, "active");
-		assert.equal(status.label, "cache 0:30");
-	});
-});
-
-describe("shouldSendWarmPing", () => {
-	it("is false when disabled even if TTL is about to expire", () => {
-		assert.equal(shouldSendWarmPing(gate({ enabled: false })), false);
-	});
-
-	it("requires idle and no pending messages", () => {
-		assert.equal(shouldSendWarmPing(gate({ idle: false })), false);
-		assert.equal(shouldSendWarmPing(gate({ hasPendingMessages: true })), false);
-	});
-
-	it("blocks a second ping while one is in flight", () => {
-		assert.equal(shouldSendWarmPing(gate({ inFlight: true })), false);
-	});
-
-	it("never pings before the first cache activity", () => {
-		assert.equal(shouldSendWarmPing(gate({ cacheLastActive: undefined })), false);
-	});
-
-	it("pings only while remaining TTL is at or below the warn threshold", () => {
-		const now = 5_000_000;
-		assert.equal(
-			shouldSendWarmPing(
-				gate({
-					now,
-					cacheLastActive: now - (CACHE_TTL_MS - CACHE_WARN_MS - 1_000),
-				}),
-			),
-			false,
-		);
-		assert.equal(
-			shouldSendWarmPing(
-				gate({
-					now,
-					cacheLastActive: now - (CACHE_TTL_MS - CACHE_WARN_MS),
-				}),
-			),
-			true,
-		);
-		assert.equal(
-			shouldSendWarmPing(
-				gate({
-					now,
-					cacheLastActive: now - (CACHE_TTL_MS - 1_000),
-				}),
-			),
-			true,
-		);
-	});
-
-	it("does not ping after the cache has expired", () => {
-		const now = 5_000_000;
-		assert.equal(
-			shouldSendWarmPing(
-				gate({
-					now,
-					cacheLastActive: now - CACHE_TTL_MS,
-				}),
-			),
-			false,
-		);
-	});
-
-	it("bounds retries with a minimum interval after the last attempt", () => {
-		const now = 5_000_000;
-		assert.equal(
-			shouldSendWarmPing(
-				gate({
-					now,
-					cacheLastActive: now - (CACHE_TTL_MS - 10_000),
-					lastAttemptAt: now - MIN_WARM_INTERVAL_MS + 1,
-				}),
-			),
-			false,
-		);
-		assert.equal(
-			shouldSendWarmPing(
-				gate({
-					now,
-					cacheLastActive: now - (CACHE_TTL_MS - 10_000),
-					lastAttemptAt: now - MIN_WARM_INTERVAL_MS,
-				}),
-			),
-			true,
-		);
-	});
-});
-
-describe("savings attribution", () => {
-	it("does not count a normal-user cacheRead as an avoided miss", () => {
+	it("separates pending dispatch from confirmed attempts", () => {
 		const state = createWarmState();
-		const t0 = 0;
-		seedCache(state, t0);
-		noteTurnStart(state, t0 + 30_000);
-		applyAssistantUsage(state, {
-			now: t0 + 31_000,
-			usage: usage({ cacheRead: 8_000, input: 100, output: 50 }),
-			model: RATES,
-		});
-		assert.equal(state.metrics.likelyAvoidedMisses, 0);
-		assert.equal(state.metrics.warmRefreshes, 0);
+		const selectedModel = model();
+		state.modelKey = "openai/test-model";
+		setEnabled(state, true);
+		seedCache(state, 1_000, selectedModel);
+		const dispatch = beginWarmDispatch(state, 10_000, selectedModel);
+		assert.ok(dispatch);
 		assert.equal(state.metrics.warmAttempts, 0);
+		assert.equal(state.dispatchPending?.id, dispatch.id);
+		noteTurnStart(state, 10_001);
+		assert.equal(confirmWarmDispatch(state, dispatch.id).confirmed, true);
+		assert.equal(state.metrics.warmAttempts, 1);
+		assert.ok(state.warmRunActive);
 	});
 
-	it("counts a warm ping cacheRead as a refresh, not an avoided miss", () => {
+	it("suppresses timeout retries for the same cache epoch", () => {
 		const state = createWarmState();
-		const t0 = 0;
-		seedCache(state, t0);
-		beginWarmPing(state, t0 + CACHE_TTL_MS - 30_000);
-		noteTurnStart(state, t0 + CACHE_TTL_MS - 29_000);
-		applyAssistantUsage(state, {
-			now: t0 + CACHE_TTL_MS - 28_000,
-			usage: usage({ cacheRead: 4_000, input: 20, output: 1 }),
-			model: RATES,
-		});
+		const selectedModel = model();
+		state.modelKey = "openai/test-model";
+		setEnabled(state, true);
+		seedCache(state, 1_000, selectedModel);
+		beginWarmDispatch(state, 10_000, selectedModel);
+		assert.equal(expirePendingDispatch(state, 10_000 + WARM_TIMEOUT_MS), true);
+		assert.equal(state.metrics.warmAttempts, 0);
+		assert.equal(shouldSendWarmPing(gate(state, 10_000 + WARM_TIMEOUT_MS)), false);
+
+		noteExternalInput(state);
+		noteTurnStart(state, 20_000);
+		applyAssistantUsage(state, { usage: usage({ cacheRead: 50 }), model: selectedModel });
+		assert.equal(state.suppressedEpoch, undefined);
+	});
+
+	it("quarantines a late timed-out dispatch", () => {
+		const state = createWarmState();
+		const selectedModel = model();
+		state.modelKey = "openai/test-model";
+		setEnabled(state, true);
+		seedCache(state, 1_000, selectedModel);
+		const dispatch = beginWarmDispatch(state, 10_000, selectedModel);
+		expirePendingDispatch(state, 10_000 + WARM_TIMEOUT_MS);
+		noteTurnStart(state, 80_001);
+		assert.deepEqual(confirmWarmDispatch(state, dispatch.id), { confirmed: true, abort: true });
 		assert.equal(state.metrics.warmAttempts, 1);
+		assert.equal(state.warmRunActive?.interrupted, true);
+	});
+
+	it("retains every stale token for the session and aborts overlapping recognized starts", () => {
+		const state = createWarmState();
+		const selectedModel = model();
+		state.modelKey = "openai/test-model";
+		setEnabled(state, true);
+		seedCache(state, 1_000, selectedModel);
+		const stale = [];
+		for (let index = 0; index < 40; index += 1) {
+			const dispatch = beginWarmDispatch(state, 10_000 + index, selectedModel);
+			stale.push(dispatch);
+			expirePendingDispatch(state, 10_000 + index + WARM_TIMEOUT_MS);
+			setEnabled(state, false);
+			setEnabled(state, true);
+		}
+		assert.equal(state.staleDispatches.size, 40);
+		const active = beginWarmDispatch(state, 100_000, selectedModel);
+		noteTurnStart(state, 100_001);
+		confirmWarmDispatch(state, active.id);
+		assert.deepEqual(confirmWarmDispatch(state, stale[0].id), { confirmed: true, abort: true });
+		assert.ok(state.warmRunActive);
+		assert.equal(state.metrics.warmAttempts, 2);
+	});
+});
+
+describe("warm ownership, cache clock, and attribution", () => {
+	it("charges every continuation, refreshes once, and attributes only a later external run", () => {
+		const state = createWarmState();
+		const selectedModel = model();
+		state.modelKey = "openai/test-model";
+		setEnabled(state, true);
+		const t0 = 1_000_000;
+		seedCache(state, t0, selectedModel);
+		startWarm(state, t0 + CACHE_TTL_MS - 30_000, selectedModel);
+
+		applyAssistantUsage(state, {
+			usage: usage({ cacheRead: 1_000, cost: { cacheRead: 0.1, total: 0.1 } }),
+			model: selectedModel,
+		});
+		noteTurnStart(state, t0 + CACHE_TTL_MS + 5_000);
+		applyAssistantUsage(state, {
+			usage: usage({ cacheRead: 800, cost: { cacheRead: 0.2, total: 0.2 } }),
+			model: selectedModel,
+		});
+		assert.ok(Math.abs(state.metrics.warmSpendUsd - 0.3) < 1e-12);
 		assert.equal(state.metrics.warmRefreshes, 1);
 		assert.equal(state.metrics.likelyAvoidedMisses, 0);
-	});
 
-	it("attributes likelyAvoidedMisses once per chain after counterfactual expiry", () => {
-		const state = createWarmState();
-		const t0 = 1_000_000;
-		seedCache(state, t0);
-
-		beginWarmPing(state, t0 + CACHE_TTL_MS - 40_000);
-		noteTurnStart(state, t0 + CACHE_TTL_MS - 39_000);
-		applyAssistantUsage(state, {
-			now: t0 + CACHE_TTL_MS - 38_000,
-			usage: usage({ cacheRead: 2_000, input: 10, output: 1 }),
-			model: RATES,
-		});
-
-		beginWarmPing(state, t0 + CACHE_TTL_MS + 200_000);
-		noteTurnStart(state, t0 + CACHE_TTL_MS + 201_000);
-		applyAssistantUsage(state, {
-			now: t0 + CACHE_TTL_MS + 202_000,
-			usage: usage({ cacheRead: 2_000, input: 10, output: 1 }),
-			model: RATES,
-		});
-
-		const userStart = t0 + CACHE_TTL_MS + 250_000;
-		noteTurnStart(state, userStart);
-		applyAssistantUsage(state, {
-			now: userStart + 5_000,
-			usage: usage({ cacheRead: 50_000, input: 200, output: 80 }),
-			model: RATES,
-		});
-		assert.equal(state.metrics.likelyAvoidedMisses, 1);
-		assert.equal(state.metrics.warmRefreshes, 2);
-
-		noteTurnStart(state, userStart + 60_000);
-		applyAssistantUsage(state, {
-			now: userStart + 61_000,
-			usage: usage({ cacheRead: 40_000, input: 100, output: 20 }),
-			model: RATES,
-		});
-		assert.equal(state.metrics.likelyAvoidedMisses, 1);
-	});
-
-	it("does not count a turn that started before expiry even if it finished after", () => {
-		const state = createWarmState();
-		const t0 = 0;
-		seedCache(state, t0);
-		beginWarmPing(state, t0 + CACHE_TTL_MS - 20_000);
-		noteTurnStart(state, t0 + CACHE_TTL_MS - 19_000);
-		applyAssistantUsage(state, {
-			now: t0 + CACHE_TTL_MS - 18_000,
-			usage: usage({ cacheRead: 1_000, output: 1 }),
-			model: RATES,
-		});
-
-		const startedAt = t0 + CACHE_TTL_MS - 1_000;
-		noteTurnStart(state, startedAt);
-		applyAssistantUsage(state, {
-			now: t0 + CACHE_TTL_MS + 5_000,
-			usage: usage({ cacheRead: 9_000, input: 10 }),
-			model: RATES,
-		});
-		assert.equal(state.metrics.likelyAvoidedMisses, 0);
-	});
-
-	it("closes the chain on an ordinary turn before expiry without a hit", () => {
-		const state = createWarmState();
-		const t0 = 0;
-		seedCache(state, t0);
-		beginWarmPing(state, t0 + CACHE_TTL_MS - 30_000);
-		noteTurnStart(state, t0 + CACHE_TTL_MS - 29_000);
-		applyAssistantUsage(state, {
-			now: t0 + CACHE_TTL_MS - 28_000,
-			usage: usage({ cacheRead: 1_000 }),
-			model: RATES,
-		});
-
-		noteTurnStart(state, t0 + 60_000);
-		applyAssistantUsage(state, {
-			now: t0 + 61_000,
-			usage: usage({ cacheRead: 8_000 }),
-			model: RATES,
-		});
-		assert.equal(state.metrics.likelyAvoidedMisses, 0);
-
+		noteAgentSettled(state);
+		noteExternalInput(state);
+		noteAgentStart(state);
 		noteTurnStart(state, t0 + CACHE_TTL_MS + 10_000);
 		applyAssistantUsage(state, {
-			now: t0 + CACHE_TTL_MS + 11_000,
-			usage: usage({ cacheRead: 8_000 }),
-			model: RATES,
-		});
-		assert.equal(state.metrics.likelyAvoidedMisses, 0);
-	});
-
-	it("still attributes an avoided miss when a later user message is not an in-flight race", () => {
-		const state = createWarmState();
-		const t0 = 0;
-		seedCache(state, t0);
-		beginWarmPing(state, t0 + CACHE_TTL_MS - 20_000);
-		noteTurnStart(state, t0 + CACHE_TTL_MS - 19_000);
-		applyAssistantUsage(state, {
-			now: t0 + CACHE_TTL_MS - 18_000,
-			usage: usage({ cacheRead: 1_000 }),
-			model: RATES,
-		});
-		noteTurnEnd(state);
-		noteInterveningTurn(state);
-		noteTurnStart(state, t0 + CACHE_TTL_MS + 5_000);
-		applyAssistantUsage(state, {
-			now: t0 + CACHE_TTL_MS + 6_000,
-			usage: usage({ cacheRead: 9_000 }),
-			model: RATES,
+			usage: usage({ cacheRead: 5_000, output: 5 }),
+			model: selectedModel,
 		});
 		assert.equal(state.metrics.likelyAvoidedMisses, 1);
 	});
 
-	it("does not treat an intervening user turn as a warm refresh or avoided miss", () => {
+	it("preserves the first external request start across continuations", () => {
 		const state = createWarmState();
+		const selectedModel = model();
+		state.modelKey = "openai/test-model";
+		setEnabled(state, true);
 		const t0 = 0;
-		seedCache(state, t0);
-		beginWarmPing(state, t0 + CACHE_TTL_MS - 20_000);
-		noteTurnStart(state, t0 + CACHE_TTL_MS - 19_000);
-		noteInterveningTurn(state);
-		applyAssistantUsage(state, {
-			now: t0 + CACHE_TTL_MS + 5_000,
-			usage: usage({ cacheRead: 12_000, input: 80, output: 20 }),
-			model: RATES,
-		});
-		assert.equal(state.metrics.warmRefreshes, 0);
-		assert.equal(state.metrics.likelyAvoidedMisses, 0);
-		assert.equal(state.metrics.warmAttempts, 1);
-		assert.ok(state.metrics.warmSpendUsd > 0);
-	});
+		seedCache(state, t0, selectedModel);
+		startWarm(state, CACHE_TTL_MS - 20_000, selectedModel);
+		applyAssistantUsage(state, { usage: usage({ cacheRead: 100 }), model: selectedModel });
+		noteAgentSettled(state);
 
-	it("does not count an avoided miss without a confirmed warm refresh", () => {
-		const state = createWarmState();
-		const t0 = 0;
-		seedCache(state, t0);
-		beginWarmPing(state, t0 + CACHE_TTL_MS - 20_000);
-		noteTurnStart(state, t0 + CACHE_TTL_MS - 19_000);
-		applyAssistantUsage(state, {
-			now: t0 + CACHE_TTL_MS - 18_000,
-			usage: usage({ input: 20, output: 1 }),
-			model: RATES,
-		});
-
-		noteTurnStart(state, t0 + CACHE_TTL_MS + 10_000);
-		applyAssistantUsage(state, {
-			now: t0 + CACHE_TTL_MS + 11_000,
-			usage: usage({ cacheRead: 9_000 }),
-			model: RATES,
-		});
-		assert.equal(state.metrics.warmRefreshes, 0);
+		noteExternalInput(state);
+		noteAgentStart(state);
+		noteTurnStart(state, CACHE_TTL_MS - 1);
+		applyAssistantUsage(state, { usage: usage({ output: 1 }), model: selectedModel });
+		noteTurnStart(state, CACHE_TTL_MS + 20_000);
+		applyAssistantUsage(state, { usage: usage({ cacheRead: 5_000 }), model: selectedModel });
 		assert.equal(state.metrics.likelyAvoidedMisses, 0);
 	});
 
-	it("does not count a hit at exact counterfactual expiry", () => {
+	it("anchors cache activity to turn_start despite a long response", () => {
 		const state = createWarmState();
-		const t0 = 0;
-		seedCache(state, t0);
-		beginWarmPing(state, t0 + CACHE_TTL_MS - 20_000);
-		noteTurnStart(state, t0 + CACHE_TTL_MS - 19_000);
+		noteAgentStart(state);
+		noteTurnStart(state, 10_000);
 		applyAssistantUsage(state, {
-			now: t0 + CACHE_TTL_MS - 18_000,
 			usage: usage({ cacheRead: 1_000 }),
-			model: RATES,
+			model: model(),
 		});
-
-		noteTurnStart(state, t0 + CACHE_TTL_MS);
-		applyAssistantUsage(state, {
-			now: t0 + CACHE_TTL_MS + 1_000,
-			usage: usage({ cacheRead: 9_000 }),
-			model: RATES,
-		});
-		assert.equal(state.metrics.likelyAvoidedMisses, 0);
+		assert.equal(state.cacheLastActive, 10_000);
 	});
 
-	it("reports N/A when model rates are missing", () => {
+	it("does not let old stale tombstones hide a later external avoided miss", () => {
 		const state = createWarmState();
-		const t0 = 0;
-		seedCache(state, t0);
-		beginWarmPing(state, t0 + CACHE_TTL_MS - 20_000);
-		noteTurnStart(state, t0 + CACHE_TTL_MS - 19_000);
-		applyAssistantUsage(state, {
-			now: t0 + CACHE_TTL_MS - 18_000,
-			usage: usage({ cacheRead: 1_000, output: 1 }),
-		});
-		noteTurnStart(state, t0 + CACHE_TTL_MS + 5_000);
-		applyAssistantUsage(state, {
-			now: t0 + CACHE_TTL_MS + 6_000,
-			usage: usage({ cacheRead: 8_000 }),
-		});
-		assert.equal(state.metrics.likelyAvoidedMisses, 1);
-		assert.match(formatMetrics(state.metrics), /estimated net USD saved: N\/A/);
-		assert.equal(formatUsd(null), "N/A");
-	});
-
-	it("allows negative net savings when warm spend exceeds the discount", () => {
-		const state = createWarmState();
-		const t0 = 0;
-		seedCache(state, t0);
-		beginWarmPing(state, t0 + CACHE_TTL_MS - 20_000);
-		noteTurnStart(state, t0 + CACHE_TTL_MS - 19_000);
-		applyAssistantUsage(state, {
-			now: t0 + CACHE_TTL_MS - 18_000,
-			usage: usage({ input: 10_000, output: 2_000, cacheRead: 100 }),
-			model: RATES,
-		});
-		noteTurnStart(state, t0 + CACHE_TTL_MS + 5_000);
-		applyAssistantUsage(state, {
-			now: t0 + CACHE_TTL_MS + 6_000,
-			usage: usage({ cacheRead: 100, input: 10 }),
-			model: RATES,
-		});
-		assert.equal(state.metrics.likelyAvoidedMisses, 1);
-		assert.match(formatMetrics(state.metrics), /estimated net USD saved: -\$/);
-	});
-
-	it("does not double-count assistant messages in the same non-warm turn", () => {
-		const state = createWarmState();
-		const t0 = 0;
-		seedCache(state, t0);
-		beginWarmPing(state, t0 + CACHE_TTL_MS - 20_000);
-		noteTurnStart(state, t0 + CACHE_TTL_MS - 19_000);
-		applyAssistantUsage(state, {
-			now: t0 + CACHE_TTL_MS - 18_000,
-			usage: usage({ cacheRead: 1_000 }),
-			model: RATES,
-		});
-
-		noteTurnStart(state, t0 + CACHE_TTL_MS + 5_000);
-		applyAssistantUsage(state, {
-			now: t0 + CACHE_TTL_MS + 6_000,
-			usage: usage({ cacheRead: 8_000 }),
-			model: RATES,
-		});
-		applyAssistantUsage(state, {
-			now: t0 + CACHE_TTL_MS + 7_000,
-			usage: usage({ cacheRead: 8_000 }),
-			model: RATES,
-		});
-		assert.equal(state.metrics.likelyAvoidedMisses, 1);
-	});
-});
-
-describe("session and model resets", () => {
-	it("clears the chain on model/provider change", () => {
-		const state = createWarmState();
-		const t0 = 0;
-		seedCache(state, t0);
-		state.modelKey = "anthropic/claude";
-		beginWarmPing(state, t0 + CACHE_TTL_MS - 20_000);
-		noteTurnStart(state, t0 + CACHE_TTL_MS - 19_000);
-		applyAssistantUsage(state, {
-			now: t0 + CACHE_TTL_MS - 18_000,
-			usage: usage({ cacheRead: 1_000 }),
-			model: RATES,
-		});
-		applyModelChange(state, "openai/gpt");
-		assert.equal(state.cacheLastActive, undefined);
-		assert.equal(state.inFlight, false);
-		noteTurnStart(state, t0 + CACHE_TTL_MS + 10_000);
-		applyAssistantUsage(state, {
-			now: t0 + CACHE_TTL_MS + 11_000,
-			usage: usage({ cacheRead: 9_000 }),
-			model: RATES,
-		});
-		assert.equal(state.metrics.likelyAvoidedMisses, 0);
-	});
-
-	it("invalidates an open chain on disable without wiping metrics", () => {
-		const state = createWarmState();
-		const t0 = 0;
-		seedCache(state, t0);
-		beginWarmPing(state, t0 + CACHE_TTL_MS - 20_000);
-		noteTurnStart(state, t0 + CACHE_TTL_MS - 19_000);
-		applyAssistantUsage(state, {
-			now: t0 + CACHE_TTL_MS - 18_000,
-			usage: usage({ cacheRead: 1_000 }),
-			model: RATES,
-		});
+		const selectedModel = model();
+		state.modelKey = "openai/test-model";
+		setEnabled(state, true);
+		seedCache(state, 0, selectedModel);
+		beginWarmDispatch(state, 1_000, selectedModel);
+		expirePendingDispatch(state, 1_000 + WARM_TIMEOUT_MS);
 		setEnabled(state, false);
-		assert.equal(state.enabled, false);
-		assert.equal(state.metrics.warmAttempts, 1);
-		noteTurnStart(state, t0 + CACHE_TTL_MS + 10_000);
-		applyAssistantUsage(state, {
-			now: t0 + CACHE_TTL_MS + 11_000,
-			usage: usage({ cacheRead: 9_000 }),
-			model: RATES,
-		});
-		assert.equal(state.metrics.likelyAvoidedMisses, 0);
+		setEnabled(state, true);
+		startWarm(state, CACHE_TTL_MS - 20_000, selectedModel);
+		applyAssistantUsage(state, { usage: usage({ cacheRead: 100 }), model: selectedModel });
+		noteAgentSettled(state);
+		noteExternalInput(state);
+		noteAgentStart(state);
+		noteTurnStart(state, CACHE_TTL_MS + 1);
+		applyAssistantUsage(state, { usage: usage({ cacheRead: 1_000 }), model: selectedModel });
+		assert.equal(state.metrics.likelyAvoidedMisses, 1);
 	});
 
-	it("resets enabled, lastActive, in-flight, and metrics on session shutdown", () => {
+	it("waits through usage-less retries but keeps first-request eligibility fixed", () => {
+		const selectedModel = model();
+		for (const [firstStart, expected] of [
+			[CACHE_TTL_MS + 1, 1],
+			[CACHE_TTL_MS - 1, 0],
+		]) {
+			const state = createWarmState();
+			state.modelKey = "openai/test-model";
+			setEnabled(state, true);
+			seedCache(state, 0, selectedModel);
+			startWarm(state, CACHE_TTL_MS - 20_000, selectedModel);
+			applyAssistantUsage(state, { usage: usage({ cacheRead: 100 }), model: selectedModel });
+			noteAgentSettled(state);
+			noteExternalInput(state);
+			noteAgentStart(state);
+			noteTurnStart(state, firstStart);
+			applyAssistantUsage(state, { usage: usage(), model: selectedModel });
+			noteTurnStart(state, CACHE_TTL_MS + 10_000);
+			applyAssistantUsage(state, { usage: usage({ cacheRead: 1_000 }), model: selectedModel });
+			assert.equal(state.metrics.likelyAvoidedMisses, expected);
+		}
+	});
+
+	it("falls back to Pi-native pricing when warm usage has no valid reported cost", () => {
 		const state = createWarmState();
-		state.enabled = true;
-		seedCache(state, 0);
-		beginWarmPing(state, CACHE_TTL_MS - 20_000);
-		resetSession(state);
-		assert.equal(state.enabled, false);
-		assert.equal(state.cacheLastActive, undefined);
-		assert.equal(state.inFlight, false);
-		assert.equal(state.metrics.warmAttempts, 0);
-		assert.equal(formatWarmFooter(state, Date.now()), undefined);
+		const selectedModel = model();
+		state.modelKey = "openai/test-model";
+		setEnabled(state, true);
+		seedCache(state, 0, selectedModel);
+		startWarm(state, 1_000, selectedModel);
+		applyAssistantUsage(state, {
+			usage: { input: 1_000, output: 0, cacheRead: 100, cacheWrite: 0, totalTokens: 1_100 },
+			model: selectedModel,
+		});
+		assert.ok(Math.abs(state.metrics.warmSpendUsd - 0.0101) < 1e-12);
+	});
+
+	it("interrupts an active run without clearing ownership before settlement", () => {
+		const state = createWarmState();
+		const selectedModel = model();
+		state.modelKey = "openai/test-model";
+		setEnabled(state, true);
+		seedCache(state, 0, selectedModel);
+		startWarm(state, CACHE_TTL_MS - 10_000, selectedModel);
+		assert.equal(noteExternalInput(state), true);
+		assert.ok(state.warmRunActive);
+		assert.equal(noteExternalInput(state), false);
+		applyAssistantUsage(state, {
+			usage: usage({ cacheRead: 100, cost: { cacheRead: 0.05, total: 0.05 } }),
+			model: selectedModel,
+		});
+		assert.equal(state.metrics.warmSpendUsd, 0.05);
+		noteAgentSettled(state);
+		assert.equal(state.warmRunActive, undefined);
+		assert.equal(state.metrics.likelyAvoidedMisses, 0);
 	});
 });
+
+describe("Pi-native pricing", () => {
+	it("honors tiered rates and preserves cacheWrite1h pricing", () => {
+		const selectedModel = model({
+			cost: {
+				input: 10,
+				output: 20,
+				cacheRead: 1,
+				cacheWrite: 12,
+				tiers: [{ inputTokensAbove: 100, input: 20, output: 40, cacheRead: 2, cacheWrite: 24 }],
+			},
+		});
+		const full = usage({ cacheWrite: 150, cacheWrite1h: 150 });
+		assert.equal(estimateTurnUsd(selectedModel, { ...full, cost: undefined }), 0.006);
+		assert.equal(estimateTurnUsd(selectedModel, { input: 1_000, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 1_000 }), 0.02);
+		assert.equal(
+			estimateTurnUsd(selectedModel, usage({ input: 1_000, cost: { input: 0, total: 0.5 } })),
+			0.02,
+		);
+		assert.equal(estimateTurnUsd(selectedModel, { ...full, cacheWrite1h: 151, cost: undefined }), null);
+		assert.equal(
+			estimateTurnUsd(selectedModel, usage({ cacheWrite: 150, cacheWrite1h: 151, cost: { cacheWrite: 1, total: 1 } })),
+			null,
+		);
+	});
+
+	it("calculates known input, 5-minute write, and 1-hour write counterfactuals", () => {
+		const selectedModel = model();
+		const actual = usage({ cacheRead: 1_000 });
+		assert.ok(Math.abs(estimateGrossBenefitUsd(selectedModel, actual, "input") - 0.009) < 1e-12);
+		assert.ok(Math.abs(estimateGrossBenefitUsd(selectedModel, actual, "cacheWrite") - 0.011) < 1e-12);
+		assert.ok(Math.abs(estimateGrossBenefitUsd(selectedModel, actual, "cacheWrite1h") - 0.019) < 1e-12);
+	});
+
+	it("infers only defensible provider modes and reports unknown pricing as N/A", () => {
+		assert.equal(inferMissBillingMode(model(), usage()), "input");
+		assert.equal(
+			inferMissBillingMode(model({ api: "anthropic-messages", provider: "anthropic" }), usage()),
+			"cacheWrite",
+		);
+		assert.equal(
+			inferMissBillingMode(
+				model({ api: "anthropic-messages", provider: "anthropic" }),
+				usage({ cacheWrite: 10, cacheWrite1h: 10 }),
+			),
+			"cacheWrite1h",
+		);
+		assert.equal(inferMissBillingMode(model({ api: "mystery-api", provider: "proxy" }), usage()), null);
+		assert.equal(inferMissBillingMode(model({ provider: "proxy" }), usage()), null);
+		assert.equal(estimateGrossBenefitUsd(model(), usage({ cacheRead: 1_000 }), null), null);
+		const metrics = createWarmState().metrics;
+		metrics.pricingKnown = false;
+		assert.match(formatMetrics(metrics), /N\/A/);
+	});
+});
+
+describe("reset safety", () => {
+	it("disables pending and active runs without prematurely dropping an active guard", () => {
+		const state = createWarmState();
+		const selectedModel = model();
+		state.modelKey = "openai/test-model";
+		setEnabled(state, true);
+		seedCache(state, 0, selectedModel);
+		beginWarmDispatch(state, 1_000, selectedModel);
+		assert.equal(setEnabled(state, false), false);
+		assert.equal(state.dispatchPending, undefined);
+		setEnabled(state, true);
+		const dispatch = beginWarmDispatch(state, 2_000, selectedModel);
+		noteTurnStart(state, 2_001);
+		confirmWarmDispatch(state, dispatch.id);
+		assert.equal(setEnabled(state, false), true);
+		assert.ok(state.warmRunActive);
+		noteAgentSettled(state);
+		assert.equal(state.warmRunActive, undefined);
+	});
+
+	it("aborts and drains on model change, while shutdown hard-resets", () => {
+		const state = createWarmState();
+		const selectedModel = model();
+		state.modelKey = "openai/test-model";
+		setEnabled(state, true);
+		seedCache(state, 0, selectedModel);
+		startWarm(state, 1_000, selectedModel);
+		assert.equal(applyModelChange(state, "anthropic/other"), true);
+		assert.ok(state.warmRunActive);
+		assert.equal(state.cacheLastActive, undefined);
+		resetSession(state);
+		assert.equal(state.warmRunActive, undefined);
+		assert.equal(state.dispatchPending, undefined);
+		assert.equal(state.enabled, false);
+	});
+
+	it("quarantines pending work on model change and clears pending work on shutdown", () => {
+		const state = createWarmState();
+		const selectedModel = model();
+		state.modelKey = "openai/test-model";
+		setEnabled(state, true);
+		seedCache(state, 0, selectedModel);
+		const pending = beginWarmDispatch(state, 1_000, selectedModel);
+		assert.equal(applyModelChange(state, "anthropic/other"), false);
+		assert.equal(state.dispatchPending, undefined);
+		assert.ok(state.staleDispatches.has(pending.id));
+		state.cacheLastActive = 2_000;
+		beginWarmDispatch(state, 3_000, selectedModel);
+		resetSession(state);
+		assert.equal(state.dispatchPending, undefined);
+		assert.equal(state.staleDispatches.size, 0);
+	});
+});
+
+describe("extension event wiring", { concurrency: false }, () => {
+	it("blocks tools from confirmed warm start through interruption and settlement", async () => {
+		const harness = createHarness();
+		await harness.startAndEnable();
+		await harness.seed(1_000);
+		harness.tickAt(1_000 + CACHE_TTL_MS - 30_000);
+		assert.equal(harness.sent.length, 1);
+		assert.match(await harness.metrics(), /attempts: 0/);
+		assert.equal(await harness.emit("tool_call", toolEvent()), undefined);
+
+		await harness.emit("agent_start", { type: "agent_start" });
+		await harness.emit("turn_start", { type: "turn_start", turnIndex: 0, timestamp: 271_001 });
+		await harness.emit("message_start", { type: "message_start", message: harness.sent[0] });
+		assert.match(await harness.metrics(), /attempts: 1/);
+		assert.deepEqual(await harness.emit("tool_call", toolEvent()), {
+			block: true,
+			reason: "cache-warm hidden turns cannot call tools",
+			terminate: true,
+		});
+
+		await harness.emit("input", { type: "input", text: "real work", source: "interactive" });
+		assert.equal(harness.abortCount, 1);
+		assert.equal((await harness.emit("tool_call", toolEvent())).block, true);
+		await harness.emit("agent_settled", { type: "agent_settled" });
+		assert.equal(await harness.emit("tool_call", toolEvent()), undefined);
+		harness.restore();
+	});
+
+	it("does not retry an unconfirmed dispatch in the same epoch", async () => {
+		const harness = createHarness();
+		await harness.startAndEnable();
+		await harness.seed(1_000);
+		const first = 1_000 + CACHE_TTL_MS - 30_000;
+		harness.tickAt(first);
+		assert.equal(harness.sent.length, 1);
+		harness.tickAt(first + WARM_TIMEOUT_MS);
+		harness.tickAt(first + WARM_TIMEOUT_MS + 10_000);
+		assert.equal(harness.sent.length, 1);
+		assert.match(await harness.metrics(), /attempts: 0/);
+		harness.restore();
+	});
+
+	it("does not retry a synchronously failed send in the same epoch", async () => {
+		const harness = createHarness({ sendThrows: true });
+		await harness.startAndEnable();
+		await harness.seed(1_000);
+		const first = 1_000 + CACHE_TTL_MS - 30_000;
+		harness.tickAt(first);
+		harness.tickAt(first + 10_000);
+		assert.equal(harness.sendCalls, 1);
+		assert.match(await harness.metrics(), /attempts: 0/);
+		harness.restore();
+	});
+
+	it("keeps active tool blocking on disable/model change and clears on shutdown", async () => {
+		const harness = createHarness();
+		await harness.startAndEnable();
+		await harness.seed(1_000);
+		harness.tickAt(1_000 + CACHE_TTL_MS - 30_000);
+		await harness.emit("agent_start", { type: "agent_start" });
+		await harness.emit("turn_start", { type: "turn_start", turnIndex: 0, timestamp: 271_001 });
+		await harness.emit("message_start", { type: "message_start", message: harness.sent[0] });
+		await harness.command("off");
+		assert.equal(harness.abortCount, 1);
+		assert.equal((await harness.emit("tool_call", toolEvent())).block, true);
+		await harness.emit("model_select", {
+			type: "model_select",
+			model: model({ id: "other" }),
+			previousModel: harness.ctx.model,
+			source: "set",
+		});
+		assert.equal(harness.abortCount, 1);
+		await harness.emit("session_shutdown", { type: "session_shutdown", reason: "quit" });
+		assert.equal(await harness.emit("tool_call", toolEvent()), undefined);
+		harness.restore();
+	});
+});
+
+function toolEvent() {
+	return { type: "tool_call", toolName: "bash", toolCallId: "tool-1", input: { command: "touch bad" } };
+}
+
+function createHarness(options = {}) {
+	const handlers = new Map();
+	let commandHandler;
+	let timerCallback;
+	let now = 0;
+	const originalSetInterval = globalThis.setInterval;
+	const originalClearInterval = globalThis.clearInterval;
+	const originalDateNow = Date.now;
+	globalThis.setInterval = (callback) => {
+		timerCallback = callback;
+		return { fake: true };
+	};
+	globalThis.clearInterval = () => {};
+	Date.now = () => now;
+	const sent = [];
+	const notices = [];
+	const selectedModel = model();
+	let abortCount = 0;
+	let sendCalls = 0;
+	const ctx = {
+		model: selectedModel,
+		hasUI: true,
+		isIdle: () => true,
+		hasPendingMessages: () => false,
+		abort: () => {
+			abortCount += 1;
+		},
+		ui: {
+			setStatus: () => {},
+			notify: (message) => notices.push(message),
+		},
+	};
+	const pi = {
+		on(name, handler) {
+			const list = handlers.get(name) ?? [];
+			list.push(handler);
+			handlers.set(name, list);
+		},
+		registerCommand(_name, definition) {
+			commandHandler = definition.handler;
+		},
+		sendMessage(message) {
+			sendCalls += 1;
+			if (options.sendThrows) throw new Error("synthetic send failure");
+			sent.push({ role: "custom", ...message });
+		},
+	};
+	cacheWarmExtension(pi);
+
+	async function emit(name, event) {
+		let result;
+		for (const handler of handlers.get(name) ?? []) {
+			const next = await handler(event, ctx);
+			if (next !== undefined) result = next;
+		}
+		return result;
+	}
+
+	return {
+		ctx,
+		sent,
+		get abortCount() {
+			return abortCount;
+		},
+		get sendCalls() {
+			return sendCalls;
+		},
+		async startAndEnable() {
+			await emit("session_start", { type: "session_start", reason: "startup" });
+			await commandHandler("on", ctx);
+		},
+		async command(args) {
+			await commandHandler(args, ctx);
+		},
+		async seed(at) {
+			await emit("input", { type: "input", text: "hello", source: "interactive" });
+			await emit("before_agent_start", { type: "before_agent_start", prompt: "hello" });
+			await emit("agent_start", { type: "agent_start" });
+			await emit("turn_start", { type: "turn_start", turnIndex: 0, timestamp: at });
+			await emit("message_start", { type: "message_start", message: { role: "user" } });
+			await emit("message_end", {
+				type: "message_end",
+				message: { role: "assistant", usage: usage({ cacheWrite: 100 }) },
+			});
+			await emit("agent_settled", { type: "agent_settled" });
+		},
+		tickAt(value) {
+			now = value;
+			assert.ok(timerCallback);
+			timerCallback();
+		},
+		async metrics() {
+			await commandHandler("metrics", ctx);
+			return notices.at(-1);
+		},
+		emit,
+		restore() {
+			globalThis.setInterval = originalSetInterval;
+			globalThis.clearInterval = originalClearInterval;
+			Date.now = originalDateNow;
+		},
+	};
+}

--- a/extensions/cache-warm/test/cache-warm.test.mjs
+++ b/extensions/cache-warm/test/cache-warm.test.mjs
@@ -1,0 +1,545 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+	CACHE_TTL_MS,
+	CACHE_WARN_MS,
+	MIN_WARM_INTERVAL_MS,
+	applyAssistantUsage,
+	applyModelChange,
+	beginWarmPing,
+	computeCacheStatus,
+	createWarmState,
+	formatCountdown,
+	formatMetrics,
+	formatUsd,
+	formatWarmFooter,
+	noteInterveningTurn,
+	noteTurnEnd,
+	noteTurnStart,
+	parseCacheWarmArgs,
+	resetSession,
+	setEnabled,
+	shouldSendWarmPing,
+} from "../dist/index.js";
+
+const RATES = {
+	cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+};
+
+function usage(partial = {}) {
+	return {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		...partial,
+	};
+}
+
+function gate(overrides = {}) {
+	return {
+		enabled: true,
+		now: 1_000_000,
+		cacheLastActive: 1_000_000 - (CACHE_TTL_MS - 30_000),
+		inFlight: false,
+		idle: true,
+		hasPendingMessages: false,
+		...overrides,
+	};
+}
+
+function seedCache(state, at) {
+	applyAssistantUsage(state, {
+		now: at,
+		usage: usage({ cacheWrite: 200, input: 50 }),
+		model: RATES,
+	});
+	state.pendingTurn = undefined;
+}
+
+describe("parseCacheWarmArgs", () => {
+	it("toggles on empty input", () => {
+		assert.equal(parseCacheWarmArgs(""), "toggle");
+		assert.equal(parseCacheWarmArgs("   "), "toggle");
+	});
+
+	it("parses on/off/status/metrics", () => {
+		assert.equal(parseCacheWarmArgs("on"), "on");
+		assert.equal(parseCacheWarmArgs("  OFF "), "off");
+		assert.equal(parseCacheWarmArgs("status"), "status");
+		assert.equal(parseCacheWarmArgs("metrics extra"), "metrics");
+	});
+
+	it("accepts enable/disable aliases and rejects unknown args", () => {
+		assert.equal(parseCacheWarmArgs("enable"), "on");
+		assert.equal(parseCacheWarmArgs("disable"), "off");
+		assert.equal(parseCacheWarmArgs("nope"), "unknown");
+	});
+});
+
+describe("formatCountdown", () => {
+	it("formats m:ss with padding", () => {
+		assert.equal(formatCountdown(4 * 60_000 + 32_000), "4:32");
+		assert.equal(formatCountdown(5_000), "0:05");
+	});
+
+	it("rounds up partial seconds and clamps at 0:00", () => {
+		assert.equal(formatCountdown(500), "0:01");
+		assert.equal(formatCountdown(-10_000), "0:00");
+	});
+});
+
+describe("computeCacheStatus", () => {
+	const now = Date.now();
+
+	it("is idle without cache activity", () => {
+		assert.deepEqual(computeCacheStatus(undefined, now), {
+			state: "idle",
+			label: "",
+			remainingMs: 0,
+		});
+	});
+
+	it("counts down while the cache is warm", () => {
+		const status = computeCacheStatus(now - 28_000, now);
+		assert.equal(status.state, "active");
+		assert.equal(status.label, "cache 4:32");
+		assert.equal(status.remainingMs, CACHE_TTL_MS - 28_000);
+	});
+
+	it("reports expired once the TTL elapses", () => {
+		const status = computeCacheStatus(now - CACHE_TTL_MS - 1_000, now);
+		assert.equal(status.state, "expired");
+		assert.equal(status.label, "cache expired");
+		assert.equal(status.remainingMs, 0);
+	});
+
+	it("honors a custom TTL", () => {
+		const status = computeCacheStatus(now - 90_000, now, 2 * 60_000);
+		assert.equal(status.state, "active");
+		assert.equal(status.label, "cache 0:30");
+	});
+});
+
+describe("shouldSendWarmPing", () => {
+	it("is false when disabled even if TTL is about to expire", () => {
+		assert.equal(shouldSendWarmPing(gate({ enabled: false })), false);
+	});
+
+	it("requires idle and no pending messages", () => {
+		assert.equal(shouldSendWarmPing(gate({ idle: false })), false);
+		assert.equal(shouldSendWarmPing(gate({ hasPendingMessages: true })), false);
+	});
+
+	it("blocks a second ping while one is in flight", () => {
+		assert.equal(shouldSendWarmPing(gate({ inFlight: true })), false);
+	});
+
+	it("never pings before the first cache activity", () => {
+		assert.equal(shouldSendWarmPing(gate({ cacheLastActive: undefined })), false);
+	});
+
+	it("pings only while remaining TTL is at or below the warn threshold", () => {
+		const now = 5_000_000;
+		assert.equal(
+			shouldSendWarmPing(
+				gate({
+					now,
+					cacheLastActive: now - (CACHE_TTL_MS - CACHE_WARN_MS - 1_000),
+				}),
+			),
+			false,
+		);
+		assert.equal(
+			shouldSendWarmPing(
+				gate({
+					now,
+					cacheLastActive: now - (CACHE_TTL_MS - CACHE_WARN_MS),
+				}),
+			),
+			true,
+		);
+		assert.equal(
+			shouldSendWarmPing(
+				gate({
+					now,
+					cacheLastActive: now - (CACHE_TTL_MS - 1_000),
+				}),
+			),
+			true,
+		);
+	});
+
+	it("does not ping after the cache has expired", () => {
+		const now = 5_000_000;
+		assert.equal(
+			shouldSendWarmPing(
+				gate({
+					now,
+					cacheLastActive: now - CACHE_TTL_MS,
+				}),
+			),
+			false,
+		);
+	});
+
+	it("bounds retries with a minimum interval after the last attempt", () => {
+		const now = 5_000_000;
+		assert.equal(
+			shouldSendWarmPing(
+				gate({
+					now,
+					cacheLastActive: now - (CACHE_TTL_MS - 10_000),
+					lastAttemptAt: now - MIN_WARM_INTERVAL_MS + 1,
+				}),
+			),
+			false,
+		);
+		assert.equal(
+			shouldSendWarmPing(
+				gate({
+					now,
+					cacheLastActive: now - (CACHE_TTL_MS - 10_000),
+					lastAttemptAt: now - MIN_WARM_INTERVAL_MS,
+				}),
+			),
+			true,
+		);
+	});
+});
+
+describe("savings attribution", () => {
+	it("does not count a normal-user cacheRead as an avoided miss", () => {
+		const state = createWarmState();
+		const t0 = 0;
+		seedCache(state, t0);
+		noteTurnStart(state, t0 + 30_000);
+		applyAssistantUsage(state, {
+			now: t0 + 31_000,
+			usage: usage({ cacheRead: 8_000, input: 100, output: 50 }),
+			model: RATES,
+		});
+		assert.equal(state.metrics.likelyAvoidedMisses, 0);
+		assert.equal(state.metrics.warmRefreshes, 0);
+		assert.equal(state.metrics.warmAttempts, 0);
+	});
+
+	it("counts a warm ping cacheRead as a refresh, not an avoided miss", () => {
+		const state = createWarmState();
+		const t0 = 0;
+		seedCache(state, t0);
+		beginWarmPing(state, t0 + CACHE_TTL_MS - 30_000);
+		noteTurnStart(state, t0 + CACHE_TTL_MS - 29_000);
+		applyAssistantUsage(state, {
+			now: t0 + CACHE_TTL_MS - 28_000,
+			usage: usage({ cacheRead: 4_000, input: 20, output: 1 }),
+			model: RATES,
+		});
+		assert.equal(state.metrics.warmAttempts, 1);
+		assert.equal(state.metrics.warmRefreshes, 1);
+		assert.equal(state.metrics.likelyAvoidedMisses, 0);
+	});
+
+	it("attributes likelyAvoidedMisses once per chain after counterfactual expiry", () => {
+		const state = createWarmState();
+		const t0 = 1_000_000;
+		seedCache(state, t0);
+
+		beginWarmPing(state, t0 + CACHE_TTL_MS - 40_000);
+		noteTurnStart(state, t0 + CACHE_TTL_MS - 39_000);
+		applyAssistantUsage(state, {
+			now: t0 + CACHE_TTL_MS - 38_000,
+			usage: usage({ cacheRead: 2_000, input: 10, output: 1 }),
+			model: RATES,
+		});
+
+		beginWarmPing(state, t0 + CACHE_TTL_MS + 200_000);
+		noteTurnStart(state, t0 + CACHE_TTL_MS + 201_000);
+		applyAssistantUsage(state, {
+			now: t0 + CACHE_TTL_MS + 202_000,
+			usage: usage({ cacheRead: 2_000, input: 10, output: 1 }),
+			model: RATES,
+		});
+
+		const userStart = t0 + CACHE_TTL_MS + 250_000;
+		noteTurnStart(state, userStart);
+		applyAssistantUsage(state, {
+			now: userStart + 5_000,
+			usage: usage({ cacheRead: 50_000, input: 200, output: 80 }),
+			model: RATES,
+		});
+		assert.equal(state.metrics.likelyAvoidedMisses, 1);
+		assert.equal(state.metrics.warmRefreshes, 2);
+
+		noteTurnStart(state, userStart + 60_000);
+		applyAssistantUsage(state, {
+			now: userStart + 61_000,
+			usage: usage({ cacheRead: 40_000, input: 100, output: 20 }),
+			model: RATES,
+		});
+		assert.equal(state.metrics.likelyAvoidedMisses, 1);
+	});
+
+	it("does not count a turn that started before expiry even if it finished after", () => {
+		const state = createWarmState();
+		const t0 = 0;
+		seedCache(state, t0);
+		beginWarmPing(state, t0 + CACHE_TTL_MS - 20_000);
+		noteTurnStart(state, t0 + CACHE_TTL_MS - 19_000);
+		applyAssistantUsage(state, {
+			now: t0 + CACHE_TTL_MS - 18_000,
+			usage: usage({ cacheRead: 1_000, output: 1 }),
+			model: RATES,
+		});
+
+		const startedAt = t0 + CACHE_TTL_MS - 1_000;
+		noteTurnStart(state, startedAt);
+		applyAssistantUsage(state, {
+			now: t0 + CACHE_TTL_MS + 5_000,
+			usage: usage({ cacheRead: 9_000, input: 10 }),
+			model: RATES,
+		});
+		assert.equal(state.metrics.likelyAvoidedMisses, 0);
+	});
+
+	it("closes the chain on an ordinary turn before expiry without a hit", () => {
+		const state = createWarmState();
+		const t0 = 0;
+		seedCache(state, t0);
+		beginWarmPing(state, t0 + CACHE_TTL_MS - 30_000);
+		noteTurnStart(state, t0 + CACHE_TTL_MS - 29_000);
+		applyAssistantUsage(state, {
+			now: t0 + CACHE_TTL_MS - 28_000,
+			usage: usage({ cacheRead: 1_000 }),
+			model: RATES,
+		});
+
+		noteTurnStart(state, t0 + 60_000);
+		applyAssistantUsage(state, {
+			now: t0 + 61_000,
+			usage: usage({ cacheRead: 8_000 }),
+			model: RATES,
+		});
+		assert.equal(state.metrics.likelyAvoidedMisses, 0);
+
+		noteTurnStart(state, t0 + CACHE_TTL_MS + 10_000);
+		applyAssistantUsage(state, {
+			now: t0 + CACHE_TTL_MS + 11_000,
+			usage: usage({ cacheRead: 8_000 }),
+			model: RATES,
+		});
+		assert.equal(state.metrics.likelyAvoidedMisses, 0);
+	});
+
+	it("still attributes an avoided miss when a later user message is not an in-flight race", () => {
+		const state = createWarmState();
+		const t0 = 0;
+		seedCache(state, t0);
+		beginWarmPing(state, t0 + CACHE_TTL_MS - 20_000);
+		noteTurnStart(state, t0 + CACHE_TTL_MS - 19_000);
+		applyAssistantUsage(state, {
+			now: t0 + CACHE_TTL_MS - 18_000,
+			usage: usage({ cacheRead: 1_000 }),
+			model: RATES,
+		});
+		noteTurnEnd(state);
+		noteInterveningTurn(state);
+		noteTurnStart(state, t0 + CACHE_TTL_MS + 5_000);
+		applyAssistantUsage(state, {
+			now: t0 + CACHE_TTL_MS + 6_000,
+			usage: usage({ cacheRead: 9_000 }),
+			model: RATES,
+		});
+		assert.equal(state.metrics.likelyAvoidedMisses, 1);
+	});
+
+	it("does not treat an intervening user turn as a warm refresh or avoided miss", () => {
+		const state = createWarmState();
+		const t0 = 0;
+		seedCache(state, t0);
+		beginWarmPing(state, t0 + CACHE_TTL_MS - 20_000);
+		noteTurnStart(state, t0 + CACHE_TTL_MS - 19_000);
+		noteInterveningTurn(state);
+		applyAssistantUsage(state, {
+			now: t0 + CACHE_TTL_MS + 5_000,
+			usage: usage({ cacheRead: 12_000, input: 80, output: 20 }),
+			model: RATES,
+		});
+		assert.equal(state.metrics.warmRefreshes, 0);
+		assert.equal(state.metrics.likelyAvoidedMisses, 0);
+		assert.equal(state.metrics.warmAttempts, 1);
+		assert.ok(state.metrics.warmSpendUsd > 0);
+	});
+
+	it("does not count an avoided miss without a confirmed warm refresh", () => {
+		const state = createWarmState();
+		const t0 = 0;
+		seedCache(state, t0);
+		beginWarmPing(state, t0 + CACHE_TTL_MS - 20_000);
+		noteTurnStart(state, t0 + CACHE_TTL_MS - 19_000);
+		applyAssistantUsage(state, {
+			now: t0 + CACHE_TTL_MS - 18_000,
+			usage: usage({ input: 20, output: 1 }),
+			model: RATES,
+		});
+
+		noteTurnStart(state, t0 + CACHE_TTL_MS + 10_000);
+		applyAssistantUsage(state, {
+			now: t0 + CACHE_TTL_MS + 11_000,
+			usage: usage({ cacheRead: 9_000 }),
+			model: RATES,
+		});
+		assert.equal(state.metrics.warmRefreshes, 0);
+		assert.equal(state.metrics.likelyAvoidedMisses, 0);
+	});
+
+	it("does not count a hit at exact counterfactual expiry", () => {
+		const state = createWarmState();
+		const t0 = 0;
+		seedCache(state, t0);
+		beginWarmPing(state, t0 + CACHE_TTL_MS - 20_000);
+		noteTurnStart(state, t0 + CACHE_TTL_MS - 19_000);
+		applyAssistantUsage(state, {
+			now: t0 + CACHE_TTL_MS - 18_000,
+			usage: usage({ cacheRead: 1_000 }),
+			model: RATES,
+		});
+
+		noteTurnStart(state, t0 + CACHE_TTL_MS);
+		applyAssistantUsage(state, {
+			now: t0 + CACHE_TTL_MS + 1_000,
+			usage: usage({ cacheRead: 9_000 }),
+			model: RATES,
+		});
+		assert.equal(state.metrics.likelyAvoidedMisses, 0);
+	});
+
+	it("reports N/A when model rates are missing", () => {
+		const state = createWarmState();
+		const t0 = 0;
+		seedCache(state, t0);
+		beginWarmPing(state, t0 + CACHE_TTL_MS - 20_000);
+		noteTurnStart(state, t0 + CACHE_TTL_MS - 19_000);
+		applyAssistantUsage(state, {
+			now: t0 + CACHE_TTL_MS - 18_000,
+			usage: usage({ cacheRead: 1_000, output: 1 }),
+		});
+		noteTurnStart(state, t0 + CACHE_TTL_MS + 5_000);
+		applyAssistantUsage(state, {
+			now: t0 + CACHE_TTL_MS + 6_000,
+			usage: usage({ cacheRead: 8_000 }),
+		});
+		assert.equal(state.metrics.likelyAvoidedMisses, 1);
+		assert.match(formatMetrics(state.metrics), /estimated net USD saved: N\/A/);
+		assert.equal(formatUsd(null), "N/A");
+	});
+
+	it("allows negative net savings when warm spend exceeds the discount", () => {
+		const state = createWarmState();
+		const t0 = 0;
+		seedCache(state, t0);
+		beginWarmPing(state, t0 + CACHE_TTL_MS - 20_000);
+		noteTurnStart(state, t0 + CACHE_TTL_MS - 19_000);
+		applyAssistantUsage(state, {
+			now: t0 + CACHE_TTL_MS - 18_000,
+			usage: usage({ input: 10_000, output: 2_000, cacheRead: 100 }),
+			model: RATES,
+		});
+		noteTurnStart(state, t0 + CACHE_TTL_MS + 5_000);
+		applyAssistantUsage(state, {
+			now: t0 + CACHE_TTL_MS + 6_000,
+			usage: usage({ cacheRead: 100, input: 10 }),
+			model: RATES,
+		});
+		assert.equal(state.metrics.likelyAvoidedMisses, 1);
+		assert.match(formatMetrics(state.metrics), /estimated net USD saved: -\$/);
+	});
+
+	it("does not double-count assistant messages in the same non-warm turn", () => {
+		const state = createWarmState();
+		const t0 = 0;
+		seedCache(state, t0);
+		beginWarmPing(state, t0 + CACHE_TTL_MS - 20_000);
+		noteTurnStart(state, t0 + CACHE_TTL_MS - 19_000);
+		applyAssistantUsage(state, {
+			now: t0 + CACHE_TTL_MS - 18_000,
+			usage: usage({ cacheRead: 1_000 }),
+			model: RATES,
+		});
+
+		noteTurnStart(state, t0 + CACHE_TTL_MS + 5_000);
+		applyAssistantUsage(state, {
+			now: t0 + CACHE_TTL_MS + 6_000,
+			usage: usage({ cacheRead: 8_000 }),
+			model: RATES,
+		});
+		applyAssistantUsage(state, {
+			now: t0 + CACHE_TTL_MS + 7_000,
+			usage: usage({ cacheRead: 8_000 }),
+			model: RATES,
+		});
+		assert.equal(state.metrics.likelyAvoidedMisses, 1);
+	});
+});
+
+describe("session and model resets", () => {
+	it("clears the chain on model/provider change", () => {
+		const state = createWarmState();
+		const t0 = 0;
+		seedCache(state, t0);
+		state.modelKey = "anthropic/claude";
+		beginWarmPing(state, t0 + CACHE_TTL_MS - 20_000);
+		noteTurnStart(state, t0 + CACHE_TTL_MS - 19_000);
+		applyAssistantUsage(state, {
+			now: t0 + CACHE_TTL_MS - 18_000,
+			usage: usage({ cacheRead: 1_000 }),
+			model: RATES,
+		});
+		applyModelChange(state, "openai/gpt");
+		assert.equal(state.cacheLastActive, undefined);
+		assert.equal(state.inFlight, false);
+		noteTurnStart(state, t0 + CACHE_TTL_MS + 10_000);
+		applyAssistantUsage(state, {
+			now: t0 + CACHE_TTL_MS + 11_000,
+			usage: usage({ cacheRead: 9_000 }),
+			model: RATES,
+		});
+		assert.equal(state.metrics.likelyAvoidedMisses, 0);
+	});
+
+	it("invalidates an open chain on disable without wiping metrics", () => {
+		const state = createWarmState();
+		const t0 = 0;
+		seedCache(state, t0);
+		beginWarmPing(state, t0 + CACHE_TTL_MS - 20_000);
+		noteTurnStart(state, t0 + CACHE_TTL_MS - 19_000);
+		applyAssistantUsage(state, {
+			now: t0 + CACHE_TTL_MS - 18_000,
+			usage: usage({ cacheRead: 1_000 }),
+			model: RATES,
+		});
+		setEnabled(state, false);
+		assert.equal(state.enabled, false);
+		assert.equal(state.metrics.warmAttempts, 1);
+		noteTurnStart(state, t0 + CACHE_TTL_MS + 10_000);
+		applyAssistantUsage(state, {
+			now: t0 + CACHE_TTL_MS + 11_000,
+			usage: usage({ cacheRead: 9_000 }),
+			model: RATES,
+		});
+		assert.equal(state.metrics.likelyAvoidedMisses, 0);
+	});
+
+	it("resets enabled, lastActive, in-flight, and metrics on session shutdown", () => {
+		const state = createWarmState();
+		state.enabled = true;
+		seedCache(state, 0);
+		beginWarmPing(state, CACHE_TTL_MS - 20_000);
+		resetSession(state);
+		assert.equal(state.enabled, false);
+		assert.equal(state.cacheLastActive, undefined);
+		assert.equal(state.inFlight, false);
+		assert.equal(state.metrics.warmAttempts, 0);
+		assert.equal(formatWarmFooter(state, Date.now()), undefined);
+	});
+});

--- a/extensions/cache-warm/test/cache-warm.test.mjs
+++ b/extensions/cache-warm/test/cache-warm.test.mjs
@@ -1,6 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import cacheWarmExtension, {
+	CACHE_TTL_LONG_MS,
 	CACHE_TTL_MS,
 	WARM_TIMEOUT_MS,
 	applyAssistantUsage,
@@ -85,6 +86,7 @@ function gate(state, now, overrides = {}) {
 		suppressedEpoch: state.suppressedEpoch,
 		idle: true,
 		hasPendingMessages: false,
+		ttlMs: state.retention?.ttlMs,
 		...overrides,
 	};
 }
@@ -311,6 +313,94 @@ describe("warm ownership, cache clock, and attribution", () => {
 	});
 });
 
+describe("cache retention", () => {
+	const anthropicModel = () =>
+		model({ api: "anthropic-messages", provider: "anthropic", cost: { input: 10, output: 20, cacheRead: 1, cacheWrite: 12 } });
+
+	it("uses the short Anthropic TTL and five-minute miss mode", () => {
+		const state = createWarmState();
+		const selectedModel = anthropicModel();
+		state.modelKey = "anthropic/test-model";
+		setEnabled(state, true);
+		seedCache(state, 1_000, selectedModel);
+		assert.deepEqual(state.retention, {
+			kind: "short",
+			ttlMs: CACHE_TTL_MS,
+			missMode: "cacheWrite",
+			attributionAllowed: true,
+		});
+		assert.equal(shouldSendWarmPing(gate(state, 1_000 + CACHE_TTL_MS - 30_000)), true);
+	});
+
+	it("keeps full one-hour writes warm for one hour and snapshots that expiry", () => {
+		const state = createWarmState();
+		const selectedModel = anthropicModel();
+		state.modelKey = "anthropic/test-model";
+		setEnabled(state, true);
+		seedCache(state, 1_000, selectedModel, { cacheWrite1h: 100 });
+		assert.equal(state.retention?.kind, "long");
+		assert.equal(state.retention?.ttlMs, CACHE_TTL_LONG_MS);
+		assert.equal(shouldSendWarmPing(gate(state, 1_000 + CACHE_TTL_MS - 30_000)), false);
+		assert.equal(shouldSendWarmPing(gate(state, 1_000 + CACHE_TTL_LONG_MS - 30_000)), true);
+
+		const dispatch = beginWarmDispatch(state, 1_000 + CACHE_TTL_LONG_MS - 30_000, selectedModel);
+		assert.ok(dispatch);
+		noteTurnStart(state, 1_000 + CACHE_TTL_LONG_MS - 29_999);
+		confirmWarmDispatch(state, dispatch.id);
+		assert.equal(state.chain?.counterfactualExpiry, 1_000 + CACHE_TTL_LONG_MS);
+		assert.equal(state.chain?.missMode, "cacheWrite1h");
+
+		applyAssistantUsage(state, { usage: usage({ cacheRead: 100 }), model: selectedModel });
+		assert.equal(state.retention?.kind, "long", "read-only activity retains known retention");
+		applyModelChange(state, "anthropic/other");
+		assert.equal(state.retention, undefined);
+	});
+
+	it("warms mixed writes conservatively without claiming a miss or savings", () => {
+		const state = createWarmState();
+		const selectedModel = anthropicModel();
+		state.modelKey = "anthropic/test-model";
+		setEnabled(state, true);
+		seedCache(state, 0, selectedModel, { cacheWrite1h: 40 });
+		assert.deepEqual(state.retention, {
+			kind: "mixed",
+			ttlMs: CACHE_TTL_MS,
+			missMode: null,
+			attributionAllowed: false,
+		});
+		assert.equal(shouldSendWarmPing(gate(state, CACHE_TTL_MS - 30_000)), true);
+		startWarm(state, CACHE_TTL_MS - 20_000, selectedModel);
+		applyAssistantUsage(state, { usage: usage({ cacheRead: 100 }), model: selectedModel });
+		noteAgentSettled(state);
+		noteExternalInput(state);
+		noteAgentStart(state);
+		noteTurnStart(state, CACHE_TTL_MS + 1);
+		applyAssistantUsage(state, { usage: usage({ cacheRead: 1_000 }), model: selectedModel });
+		assert.equal(state.metrics.likelyAvoidedMisses, 0);
+		assert.match(formatMetrics(state.metrics), /N\/A/);
+	});
+
+	it("makes mixed retention discovered by the warm turn sticky for attribution", () => {
+		const state = createWarmState();
+		const selectedModel = anthropicModel();
+		state.modelKey = "anthropic/test-model";
+		setEnabled(state, true);
+		seedCache(state, 0, selectedModel);
+		startWarm(state, CACHE_TTL_MS - 20_000, selectedModel);
+		applyAssistantUsage(state, {
+			usage: usage({ cacheWrite: 100, cacheWrite1h: 40 }),
+			model: selectedModel,
+		});
+		noteAgentSettled(state);
+		noteExternalInput(state);
+		noteAgentStart(state);
+		noteTurnStart(state, CACHE_TTL_MS + 1);
+		applyAssistantUsage(state, { usage: usage({ cacheRead: 1_000 }), model: selectedModel });
+		assert.equal(state.metrics.likelyAvoidedMisses, 0);
+		assert.match(formatMetrics(state.metrics), /N\/A/);
+	});
+});
+
 describe("Pi-native pricing", () => {
 	it("honors tiered rates and preserves cacheWrite1h pricing", () => {
 		const selectedModel = model({
@@ -338,10 +428,43 @@ describe("Pi-native pricing", () => {
 
 	it("calculates known input, 5-minute write, and 1-hour write counterfactuals", () => {
 		const selectedModel = model();
-		const actual = usage({ cacheRead: 1_000 });
+		const actual = usage({ cacheRead: 1_000, cost: { cacheRead: 0.001, total: 0.001 } });
 		assert.ok(Math.abs(estimateGrossBenefitUsd(selectedModel, actual, "input") - 0.009) < 1e-12);
 		assert.ok(Math.abs(estimateGrossBenefitUsd(selectedModel, actual, "cacheWrite") - 0.011) < 1e-12);
 		assert.ok(Math.abs(estimateGrossBenefitUsd(selectedModel, actual, "cacheWrite1h") - 0.019) < 1e-12);
+	});
+
+	it("preserves observed OpenAI flex and priority service-tier multipliers", () => {
+		for (const [id, multiplier, expected] of [
+			["gpt-5", 0.5, 0.0045],
+			["gpt-5", 2, 0.018],
+			["gpt-5.5", 2.5, 0.0225],
+		]) {
+			const actual = usage({
+				cacheRead: 1_000,
+				cost: { cacheRead: 0.001 * multiplier, total: 0.001 * multiplier },
+			});
+			assert.ok(Math.abs(estimateGrossBenefitUsd(model({ id }), actual, "input") - expected) < 1e-12);
+		}
+	});
+
+	it("returns N/A when a service-tier multiplier cannot be inferred safely", () => {
+		assert.equal(
+			estimateGrossBenefitUsd(
+				model(),
+				usage({ cacheRead: 1_000, cost: { input: 0.001, cacheRead: 0, total: 0.001 } }),
+				"input",
+			),
+			null,
+		);
+		assert.equal(
+			estimateGrossBenefitUsd(
+				model({ cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 } }),
+				usage({ cacheRead: 1_000 }),
+				"input",
+			),
+			null,
+		);
 	});
 
 	it("infers only defensible provider modes and reports unknown pricing as N/A", () => {
@@ -421,7 +544,7 @@ describe("reset safety", () => {
 });
 
 describe("extension event wiring", { concurrency: false }, () => {
-	it("blocks tools from confirmed warm start through interruption and settlement", async () => {
+	it("hands off an interrupted warm run at Pi's queued user boundary", async () => {
 		const harness = createHarness();
 		await harness.startAndEnable();
 		await harness.seed(1_000);
@@ -434,17 +557,28 @@ describe("extension event wiring", { concurrency: false }, () => {
 		await harness.emit("turn_start", { type: "turn_start", turnIndex: 0, timestamp: 271_001 });
 		await harness.emit("message_start", { type: "message_start", message: harness.sent[0] });
 		assert.match(await harness.metrics(), /attempts: 1/);
+		await harness.emit("input", { type: "input", text: "real work", source: "interactive" });
+		assert.equal(harness.abortCount, 1);
 		assert.deepEqual(await harness.emit("tool_call", toolEvent()), {
 			block: true,
 			reason: "cache-warm hidden turns cannot call tools",
 			terminate: true,
 		});
+		await harness.emit("message_end", {
+			type: "message_end",
+			message: { role: "assistant", usage: usage({ cacheRead: 100, cost: { cacheRead: 0.05, total: 0.05 } }) },
+		});
 
-		await harness.emit("input", { type: "input", text: "real work", source: "interactive" });
-		assert.equal(harness.abortCount, 1);
-		assert.equal((await harness.emit("tool_call", toolEvent())).block, true);
-		await harness.emit("agent_settled", { type: "agent_settled" });
+		// Pi 0.84.2 emits turn_start before draining the queued user message.
+		await harness.emit("turn_start", { type: "turn_start", turnIndex: 1, timestamp: 280_000 });
+		await harness.emit("message_start", { type: "message_start", message: { role: "user" } });
 		assert.equal(await harness.emit("tool_call", toolEvent()), undefined);
+		await harness.emit("message_end", {
+			type: "message_end",
+			message: { role: "assistant", usage: usage({ output: 1, cost: { output: 0.4, total: 0.4 } }) },
+		});
+		await harness.emit("agent_settled", { type: "agent_settled" });
+		assert.match(await harness.metrics(), /estimated net USD saved: -\$0\.050/);
 		harness.restore();
 	});
 

--- a/extensions/cache-warm/test/cache-warm.test.mjs
+++ b/extensions/cache-warm/test/cache-warm.test.mjs
@@ -448,6 +448,65 @@ describe("Pi-native pricing", () => {
 		}
 	});
 
+	it("preserves the observed Codex flex service-tier multiplier", () => {
+		const actual = usage({ cacheRead: 1_000, cost: { cacheRead: 0.0005, total: 0.0005 } });
+		assert.ok(
+			Math.abs(
+				estimateGrossBenefitUsd(
+					model({ api: "openai-codex-responses", provider: "openai-codex", id: "gpt-5" }),
+					actual,
+					"input",
+				) - 0.0045,
+			) < 1e-12,
+		);
+	});
+
+	it("preserves the observed Codex ordinary priority service-tier multiplier", () => {
+		const actual = usage({ cacheRead: 1_000, cost: { cacheRead: 0.002, total: 0.002 } });
+		assert.ok(
+			Math.abs(
+				estimateGrossBenefitUsd(
+					model({ api: "openai-codex-responses", provider: "openai-codex", id: "gpt-5" }),
+					actual,
+					"input",
+				) - 0.018,
+			) < 1e-12,
+		);
+	});
+
+	it("preserves the observed Codex GPT-5.5 2.5x service-tier multiplier", () => {
+		const actual = usage({ cacheRead: 1_000, cost: { cacheRead: 0.0025, total: 0.0025 } });
+		assert.ok(
+			Math.abs(
+				estimateGrossBenefitUsd(
+					model({ api: "openai-codex-responses", provider: "openai-codex", id: "gpt-5.5" }),
+					actual,
+					"input",
+				) - 0.0225,
+			) < 1e-12,
+		);
+	});
+
+	it("returns N/A for missing or invalid Codex service-tier multiplier evidence", () => {
+		const selectedModel = model({ api: "openai-codex-responses", provider: "openai-codex" });
+		assert.equal(
+			estimateGrossBenefitUsd(
+				selectedModel,
+				{ ...usage({ cacheRead: 1_000 }), cost: undefined },
+				"input",
+			),
+			null,
+		);
+		assert.equal(
+			estimateGrossBenefitUsd(
+				selectedModel,
+				usage({ cacheRead: 1_000, cost: { input: 0.001, cacheRead: 0, total: 0.001 } }),
+				"input",
+			),
+			null,
+		);
+	});
+
 	it("returns N/A when a service-tier multiplier cannot be inferred safely", () => {
 		assert.equal(
 			estimateGrossBenefitUsd(

--- a/extensions/cache-warm/tsconfig.json
+++ b/extensions/cache-warm/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/extensions/timestamp-pi/README.md
+++ b/extensions/timestamp-pi/README.md
@@ -7,7 +7,7 @@ Show a timestamp under every message in Pi's chat, plus a prompt-cache countdown
 - **Per-message timestamps with context** — a dim line like `⏱ HH:MM:SS (2m ago) · user message` appears directly under each message, labeled as `user message`, `ai response`, or `tool call`
 - **Cache miss countdown** — a footer status element shows `⏳ cache 4:32`, counting down the 5-minute prompt-cache TTL after each response; turns green while warm, yellow under 1 minute, red (`cache expired`) once the next request will be a cache miss
 
-Timestamps are stored as custom session entries: they persist across reloads and are rendered TUI-only — they are never sent to the LLM.
+Timestamps are stored as custom session entries: they persist across reloads and are rendered TUI-only — they are never sent to the LLM. For paid keep-alive turns that refresh the prompt cache, use [cache-warm](../cache-warm/README.md) instead; timestamp-pi does not send warming traffic.
 
 ## Features
 

--- a/scripts/publish-npm-extensions.sh
+++ b/scripts/publish-npm-extensions.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 OTP="${1:-${NPM_OTP:-}}"
 
-EXTENSIONS=(9router-pi advisor-pi agy-pi claude-code-pi grok-pi model-debugger opencode-pi statusline-pi subagents-pi timestamp-pi)
+EXTENSIONS=(9router-pi advisor-pi agy-pi cache-warm claude-code-pi grok-pi model-debugger opencode-pi statusline-pi subagents-pi timestamp-pi)
 
 echo "===== packaging check ====="
 node "$ROOT/scripts/check-packaging.mjs"


### PR DESCRIPTION
Closes #51

## Summary

Adds a separate `cache-warm` Pi extension that keeps an observed prompt cache warm with guarded, explicitly enabled keep-alive turns. It reports warm attempts, confirmed refreshes, likely avoided misses, and estimated net USD saved while remaining off by default.

## Approach

Option 2 — Ship a separate `extensions/cache-warm` package using a hidden `pi.sendMessage(..., { triggerTurn: true })` only when Pi is idle, no messages are pending, cache activity has been observed, and the cache is close to its heuristic expiry. Keep timestamp-pi TUI-only and copy its small TTL helpers rather than coupling the packages.

## Decision Record

- **Root cause:** Prompt-cache freshness was only displayed by timestamp-pi; no extension could refresh the live session cache before idle expiry or attribute the resulting cache benefit.
- **Options considered:** Option 1 — extend timestamp-pi with warming; Option 2 — separate cache-warm package with guarded session keep-alives; Option 3 — separate package plus shared TTL library, persisted metrics, and configurable TTL
- **Options rejected:** Option 1 — paid session traffic must remain independently togglable from timestamp-pi's TUI-only behavior; Option 3 — shared-library extraction, persistence, and TTL configuration exceed the issue scope and add regression surface
- **Selected option:** Option 2 — Ship separate `extensions/cache-warm` with sendMessage keep-alive
- **Residual risk:** The five-minute TTL is a provider heuristic, keep-alives are billed model turns that enter context, and savings are estimates rather than invoice values; the extension therefore defaults off and reports unknown pricing as `N/A`.

Analyzed at: `feat/51-add-cache-warm-extension-to-keep` @ `ef3fbbb` (2026-08-22)

## Changes

| File | Change |
|------|--------|
| `extensions/cache-warm/src/` | Add guarded keep-alive lifecycle, attribution state machine, commands, and cost metrics |
| `extensions/cache-warm/test/cache-warm.test.mjs` | Add 31 unit tests for TTL gates, attribution, pricing, and resets |
| `extensions/cache-warm/package.json` | Add an npm-ready Pi extension package |
| `extensions/cache-warm/README.md` | Document opt-in behavior, commands, metrics, and limitations |
| `README.md` | Add cache-warm to the extension catalog and usage documentation |
| `docs/DEVELOPMENT.md` | Document package architecture and implementation flow |
| `docs/DECISIONS.md` | Record the separate-package decision |
| `CHANGELOG.md` | Add the feature under Unreleased |
| `extensions/timestamp-pi/README.md` | Cross-link cache-warm while keeping timestamp-pi TUI-only |
| `scripts/publish-npm-extensions.sh` | Include cache-warm in the explicit publish list |

## Test Results

- Unit tests: 31 passed
- Integration tests: skipped — no integration harness for Pi session turns
- E2e tests: skipped — no existing e2e framework
- Build: passed
- Packaging check: passed
- `npm pack --dry-run`: passed (7 shipped files)
- QA cycles: 1

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Cache-warm can be easily enabled and disabled | pass | `/cache-warm on`, `off`, and toggle handling in `extensions/cache-warm/src/index.ts`; parser tests in `cache-warm.test.mjs` |
| Metrics report how many times warming avoided a cache miss | pass | `likelyAvoidedMisses` counterfactual-expiry attribution in `extensions/cache-warm/src/warm.ts`; savings-attribution tests |
| Metrics estimate total cost saved by avoiding cache misses | pass | gross cache discount minus warm-turn spend in `extensions/cache-warm/src/metrics.ts`; missing-rate and negative-net tests |
| Record and follow the separate-vs-timestamp-pi decision | pass | `docs/DECISIONS.md` records a separate package; implementation lives under `extensions/cache-warm` with no timestamp-pi runtime dependency |

<!-- gitissue:qa v1 head=efb51ab453a305842169e4519046f63695adafd9 profile=full cycles=1 review=clean ui=none -->
