### PR TITLE
feat(extensions): add harness prerequisite checks (#53)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Harness environment checks**: `agy-pi`, `opencode-pi`, and `grok-pi` now verify their required external CLI at session start and warn with install guidance naming the missing harness; missing-binary stream failures in agy-pi report actionable setup steps instead of "No response from agy.", opencode-pi flags a missing CLI even when the `OPENCODE_PI_MODELS` fast path skipped discovery, and grok-pi distinguishes an uninstalled Grok CLI from a missing `grok login`, with a combined `Ready:` line in `/grok-pi status` (#53).
 - **cache-warm**: Opt-in prompt-cache keep-alive extension (`/cache-warm on`, `off`, `status`, `metrics`) with avoided-miss and estimated net USD-saved metrics. Separate package from timestamp-pi; default off so install/session start never bills a warm turn (#51).
 - **9router-pi**: Dynamic `9router` provider discovery from the local OpenAI-compatible `/v1/models` endpoint, with manual refresh and offline fallback support.
 

--- a/extensions/agy-pi/README.md
+++ b/extensions/agy-pi/README.md
@@ -18,6 +18,11 @@ Registers an `agy` provider in Pi that exposes all models available through the 
   ```
 - agy configured with your API keys (Google, Anthropic, OpenAI, etc.)
 
+At session start the extension probes `agy --version`. If the agy CLI is
+missing or unusable, Pi shows a warning telling you exactly which harness is
+missing and how to install it; when the probe succeeds, models register as
+usual. Set `AGY_PI_BIN` to point the probe at a non-`PATH` binary.
+
 ## Configuration
 
 | Environment Variable | Description |

--- a/extensions/agy-pi/package.json
+++ b/extensions/agy-pi/package.json
@@ -10,6 +10,7 @@
   ],
   "scripts": {
     "build": "tsc",
+    "test": "node --test test/*.test.mjs",
     "prepublishOnly": "npm run build"
   },
   "pi": {

--- a/extensions/agy-pi/src/index.ts
+++ b/extensions/agy-pi/src/index.ts
@@ -21,6 +21,13 @@ const AGENT_ID = "pi-model";
 const DEFAULT_CONTEXT_WINDOW = 1_048_576;
 const DEFAULT_MAX_TOKENS = 8_192;
 const STDERR_LIMIT = 20_000;
+const STATUS_TIMEOUT_MS = 10_000;
+
+export type CliStatus = {
+  ok: boolean;
+  summary: string;
+  detail?: string;
+};
 // Conservative argv budget for the `-p <prompt>` value (macOS caps a single
 // arg at ~256KB and total argv at ~1MB).
 const MAX_ARGV_PROMPT_BYTES = 100_000;
@@ -65,8 +72,18 @@ let registeredModels: AgyModelInfo[] = [];
 let lastDiscoveryTime: number | undefined;
 let lastDiscoveryError: string | undefined;
 
-function agyBin(): string {
+export function agyBin(): string {
   return process.env.AGY_PI_BIN?.trim() || "agy";
+}
+
+/** Build the install/setup instructions shown when the agy CLI is unusable. */
+export function setupGuidance(error: string): string {
+  return [
+    "agy-pi could not use the local agy CLI.",
+    `Reason: ${error}`,
+    "Install agy (`pip install agy-cli` or `pipx install agy-cli`), ensure `agy --version` works on PATH, then reload Pi.",
+    "Set AGY_PI_BIN to override the executable path.",
+  ].join(" ");
 }
 
 function configuredModels(): string[] | undefined {
@@ -184,6 +201,29 @@ async function runCapture(
   });
 }
 
+/** Probe the agy CLI with `agy --version` to detect a missing/broken install. */
+export async function checkAgyStatus(): Promise<CliStatus> {
+  try {
+    const result = await runCapture(["--version"], STATUS_TIMEOUT_MS);
+    if (result.code !== 0) {
+      const detail =
+        result.stderr.trim() ||
+        result.stdout.trim() ||
+        `agy --version exited with code ${result.code}`;
+      return { ok: false, summary: "agy CLI is unusable", detail };
+    }
+    const version =
+      result.stdout.trim() || result.stderr.trim() || "agy is available";
+    return { ok: true, summary: version };
+  } catch (error) {
+    return {
+      ok: false,
+      summary: "agy CLI is unavailable",
+      detail: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
 export async function discoverModels(opts?: {
   forceDiscovery?: boolean;
 }): Promise<{
@@ -274,7 +314,7 @@ function buildPrompt(context: Context): string {
 }
 
 /** Stream agy output via `agy --print --model <id>` */
-function streamAgy(
+export function streamAgy(
   model: Model<Api>,
   context: Context,
   options?: SimpleStreamOptions,
@@ -351,10 +391,20 @@ function streamAgy(
         stderr += chunk;
       });
 
+      let spawnError: Error | undefined;
       await new Promise<void>((resolve) => {
         child.on("close", () => resolve());
-        child.on("error", () => resolve());
+        child.on("error", (error) => {
+          spawnError = error;
+          resolve();
+        });
       });
+
+      if (spawnError) {
+        throw new Error(
+          setupGuidance(`failed to launch ${agyBin()}: ${spawnError.message}`),
+        );
+      }
 
       // Clean output
       const content = stdout.trim();
@@ -499,6 +549,14 @@ export default function agyPiExtension(pi: ExtensionAPI) {
   );
 
   pi.on("session_start", async (_event: any, ctx: any) => {
+    const cliStatus = await checkAgyStatus();
+    if (!cliStatus.ok) {
+      ctx.ui.notify(
+        `agy-pi: ${setupGuidance(cliStatus.detail ?? cliStatus.summary)}`,
+        "warning",
+      );
+      return;
+    }
     ctx.ui.notify(
       `agy-pi: registered ${registeredModels.length} model(s). Use /model and pick ${PROVIDER_ID}.`,
       "info",

--- a/extensions/agy-pi/test/helpers.test.mjs
+++ b/extensions/agy-pi/test/helpers.test.mjs
@@ -1,0 +1,137 @@
+import assert from "node:assert/strict";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const extRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const {
+	agyBin,
+	checkAgyStatus,
+	setupGuidance,
+	streamAgy,
+} = await import(`file://${join(extRoot, "src/index.ts")}`);
+
+// process.env values are coerced to strings, so `process.env.X = undefined`
+// sets it to the literal string "undefined" instead of clearing it. Restore
+// via delete when the original value was unset.
+function restoreEnv(key, value) {
+	if (value === undefined) delete process.env[key];
+	else process.env[key] = value;
+}
+
+function withFakeAgy(script, run) {
+	const dir = mkdtempSync(join(tmpdir(), "agy-pi-fake-bin-"));
+	const binPath = join(dir, "agy-fake.js");
+	writeFileSync(binPath, `#!/usr/bin/env node\n${script}`, "utf8");
+	chmodSync(binPath, 0o755);
+
+	const previousBin = process.env.AGY_PI_BIN;
+	process.env.AGY_PI_BIN = binPath;
+	return Promise.resolve()
+		.then(run)
+		.finally(() => {
+			restoreEnv("AGY_PI_BIN", previousBin);
+			rmSync(dir, { recursive: true, force: true });
+		});
+}
+
+function missingBin() {
+	return join(tmpdir(), `agy-pi-missing-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+}
+
+function fakeModel() {
+	return {
+		id: "gemini-3.6-flash-high",
+		name: "Gemini 3.6 Flash",
+		api: "agy-runner",
+		provider: "agy",
+		baseUrl: "",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 1_048_576,
+		maxTokens: 8_192,
+	};
+}
+
+async function collectEvents(stream) {
+	const events = [];
+	for await (const event of stream) events.push(event);
+	return events;
+}
+
+test("agyBin resolves the default binary and honors AGY_PI_BIN", () => {
+	const previousBin = process.env.AGY_PI_BIN;
+	try {
+		delete process.env.AGY_PI_BIN;
+		assert.equal(agyBin(), "agy");
+		process.env.AGY_PI_BIN = "/usr/local/bin/agy-custom";
+		assert.equal(agyBin(), "/usr/local/bin/agy-custom");
+	} finally {
+		restoreEnv("AGY_PI_BIN", previousBin);
+	}
+});
+
+test("setupGuidance names agy, the install command, and reload step", () => {
+	const guidance = setupGuidance("spawn agy ENOENT");
+	assert.match(guidance, /agy-pi could not use the local agy CLI/);
+	assert.match(guidance, /Reason: spawn agy ENOENT/);
+	assert.match(guidance, /pip install agy-cli/);
+	assert.match(guidance, /agy --version/);
+	assert.match(guidance, /reload Pi/);
+});
+
+test("checkAgyStatus reports ok for a working binary", async () => {
+	await withFakeAgy(`process.stdout.write("agy 1.2.3\\n");`, async () => {
+		const status = await checkAgyStatus();
+		assert.equal(status.ok, true);
+		assert.equal(status.summary, "agy 1.2.3");
+	});
+});
+
+test("checkAgyStatus reports unavailable when the binary is missing", async () => {
+	const previousBin = process.env.AGY_PI_BIN;
+	process.env.AGY_PI_BIN = missingBin();
+	try {
+		const status = await checkAgyStatus();
+		assert.equal(status.ok, false);
+		assert.equal(status.summary, "agy CLI is unavailable");
+		assert.ok(status.detail);
+	} finally {
+		restoreEnv("AGY_PI_BIN", previousBin);
+	}
+});
+
+test("checkAgyStatus reports unusable when --version exits nonzero", async () => {
+	await withFakeAgy(`process.stderr.write("boom\\n"); process.exit(3);`, async () => {
+		const status = await checkAgyStatus();
+		assert.equal(status.ok, false);
+		assert.equal(status.summary, "agy CLI is unusable");
+		assert.equal(status.detail, "boom");
+	});
+});
+
+test("streamAgy emits actionable setup guidance instead of a bare empty response when the binary is missing", async () => {
+	const previousBin = process.env.AGY_PI_BIN;
+	process.env.AGY_PI_BIN = missingBin();
+	try {
+		const events = await collectEvents(
+			streamAgy(fakeModel(), { messages: [{ role: "user", content: "hi", timestamp: 1 }] }),
+		);
+
+		assert.deepEqual(
+			events.map((event) => event.type),
+			["start", "error"],
+		);
+		const error = events.at(-1);
+		if (error?.type !== "error") return;
+		const text = error.error.content.find((block) => block.type === "text")?.text ?? "";
+		assert.match(text, /agy-pi could not use the local agy CLI/);
+		assert.match(text, /failed to launch/);
+		assert.ok(!text.includes("No response from agy."));
+	} finally {
+		restoreEnv("AGY_PI_BIN", previousBin);
+	}
+});

--- a/extensions/grok-pi/README.md
+++ b/extensions/grok-pi/README.md
@@ -25,6 +25,13 @@ Models are read from `~/.grok/models_cache.json` when present; otherwise the ext
 2. **Grok CLI** installed and on your `PATH` (`grok --version`).
 3. Network access to `https://cli-chat-proxy.grok.com` and `https://auth.x.ai`.
 
+At session start the extension checks both prerequisites and tells you which
+one is missing: a warning naming the **Grok CLI install** (with
+https://x.ai/grok) when `~/.grok` does not exist, or a warning to run
+**`grok login`** when only auth is missing. `/grok-pi status` shows a combined
+`Ready:` line reflecting both checks. When everything is present, models
+register normally.
+
 ## Install
 
 Published on npm: [`grok-pi`](https://www.npmjs.com/package/grok-pi). Use **Pi's package manager** (`pi install`), not `npm install` alone.
@@ -114,7 +121,8 @@ On session start you should see an info notification that `grok-cli` was registe
 
 | Symptom | What to do |
 |---------|------------|
-| `grok-pi: no ~/.grok/auth.json` | Run `grok login`, then `/reload` |
+| `grok-pi: Grok CLI not found (~/.grok missing)` | Install Grok CLI (https://x.ai/grok), then `/reload` |
+| `grok-pi: Grok CLI is installed but ~/.grok/auth.json is missing` | Run `grok login`, then `/reload` |
 | Proxy says CLI version outdated | Update Grok: `grok update` or reinstall Grok CLI |
 | `grok-api-key: ... run grok login` | Re-authenticate with `grok login` |
 | Models missing in Pi | `/reload`, then `pi --list-models grok` |

--- a/extensions/grok-pi/src/harness.ts
+++ b/extensions/grok-pi/src/harness.ts
@@ -1,0 +1,37 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+export type GrokHarnessState = {
+	installed: boolean;
+	authPresent: boolean;
+};
+
+export function grokAuthPathIn(grokHome: string): string {
+	return join(grokHome, "auth.json");
+}
+
+export function grokHarnessStateIn(grokHome: string): GrokHarnessState {
+	return {
+		installed:
+			existsSync(grokAuthPathIn(grokHome)) ||
+			existsSync(join(grokHome, "bin", "grok")),
+		authPresent: existsSync(grokAuthPathIn(grokHome)),
+	};
+}
+
+/** Guidance shown at session start when no Grok CLI install is detected. */
+export function grokInstallGuidance(): string {
+	return "grok-pi: Grok CLI not found (~/.grok missing). Install Grok CLI (https://x.ai/grok), run `grok login`, then `/reload` or restart Pi.";
+}
+
+/** Guidance shown at session start when the CLI is installed but auth is missing. */
+export function grokAuthGuidance(): string {
+	return "grok-pi: Grok CLI is installed but ~/.grok/auth.json is missing. Run `grok login`, then `/reload` or restart Pi.";
+}
+
+/** Combined bin+auth readiness label for /grok-pi status. */
+export function grokReadinessLabel(state: GrokHarnessState): string {
+	if (!state.installed) return "no (install Grok CLI)";
+	if (!state.authPresent) return "no (run `grok login`)";
+	return "yes";
+}

--- a/extensions/grok-pi/src/index.ts
+++ b/extensions/grok-pi/src/index.ts
@@ -12,6 +12,7 @@ import {
 	modelsFromCache,
 	supportedThinkingLevels,
 } from "./models.js";
+import { grokHarnessStateIn, grokReadinessLabel, grokInstallGuidance, grokAuthGuidance } from "./harness.js";
 import { formatUsageCard } from "./usage.js";
 
 const PROVIDER_ID = "grok-cli";
@@ -38,14 +39,6 @@ function readJson<T>(path: string): T | null {
 	}
 }
 
-function grokInstalled(): boolean {
-	return existsSync(AUTH_PATH) || existsSync(join(GROK_HOME, "bin", "grok"));
-}
-
-function authPresent(): boolean {
-	return existsSync(AUTH_PATH);
-}
-
 function readCachedModels(): GrokModelInfo[] {
 	return modelsFromCache(readJson<GrokModelsCache>(MODELS_CACHE_PATH));
 }
@@ -69,12 +62,14 @@ function registerGrokProvider(pi: ExtensionAPI) {
 
 function statusLines(): string[] {
 	const lines: string[] = [];
+	const harness = grokHarnessStateIn(GROK_HOME);
 	lines.push(`Provider: ${PROVIDER_ID}`);
 	lines.push(`Proxy: ${PROXY_BASE}`);
 	lines.push(`Grok home: ${GROK_HOME}`);
-	lines.push(`Grok CLI installed: ${grokInstalled() ? "yes" : "no"}`);
-	lines.push(`Auth file present: ${authPresent() ? "yes" : "no"}`);
-	if (authPresent()) {
+	lines.push(`Grok CLI installed: ${harness.installed ? "yes" : "no"}`);
+	lines.push(`Auth file present: ${harness.authPresent ? "yes" : "no"}`);
+	lines.push(`Ready: ${grokReadinessLabel(harness)}`);
+	if (harness.authPresent) {
 		lines.push(`Auth path: ${AUTH_PATH}`);
 	}
 	lines.push(`Models cache: ${existsSync(MODELS_CACHE_PATH) ? MODELS_CACHE_PATH : "missing (using bundled defaults)"}`);
@@ -119,11 +114,13 @@ export default function grokPiExtension(pi: ExtensionAPI) {
 	registerGrokProvider(pi);
 
 	pi.on("session_start", async (_event, ctx) => {
-		if (!authPresent()) {
-			ctx.ui.notify(
-				"grok-pi: no ~/.grok/auth.json yet. Run `grok login`, then `/reload` or restart Pi.",
-				"warning",
-			);
+		const harness = grokHarnessStateIn(GROK_HOME);
+		if (!harness.installed) {
+			ctx.ui.notify(grokInstallGuidance(), "warning");
+			return;
+		}
+		if (!harness.authPresent) {
+			ctx.ui.notify(grokAuthGuidance(), "warning");
 			return;
 		}
 		ctx.ui.notify(
@@ -177,6 +174,7 @@ export default function grokPiExtension(pi: ExtensionAPI) {
 
 			if (sub === "help") {
 				ctx.ui.notify("Usage: /grok-pi [status|models|test|usage|help]", "info");
+				ctx.ui.notify("Install the Grok CLI first: https://x.ai/grok", "info");
 				ctx.ui.notify("Authenticate first with: grok login", "info");
 				ctx.ui.notify("Thinking: Shift+Tab, /settings, or --thinking <low|medium|high|xhigh>", "info");
 				return;

--- a/extensions/grok-pi/test/harness-checks.test.mjs
+++ b/extensions/grok-pi/test/harness-checks.test.mjs
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const extRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const {
+	grokAuthGuidance,
+	grokAuthPathIn,
+	grokHarnessStateIn,
+	grokInstallGuidance,
+	grokReadinessLabel,
+} = await import(`file://${join(extRoot, "src/harness.ts")}`);
+
+function tempGrokHome() {
+	return mkdtempSync(join(tmpdir(), "grok-pi-harness-"));
+}
+
+test("grokHarnessStateIn reports nothing installed in an empty home", () => {
+	const grokHome = tempGrokHome();
+	try {
+		assert.deepEqual(grokHarnessStateIn(grokHome), {
+			installed: false,
+			authPresent: false,
+		});
+		assert.equal(grokReadinessLabel(grokHarnessStateIn(grokHome)), "no (install Grok CLI)");
+	} finally {
+		rmSync(grokHome, { recursive: true, force: true });
+	}
+});
+
+test("grokHarnessStateIn reports ready when auth.json exists", () => {
+	const grokHome = tempGrokHome();
+	try {
+		writeFileSync(grokAuthPathIn(grokHome), "{}", "utf8");
+		const state = grokHarnessStateIn(grokHome);
+		assert.deepEqual(state, { installed: true, authPresent: true });
+		assert.equal(grokReadinessLabel(state), "yes");
+	} finally {
+		rmSync(grokHome, { recursive: true, force: true });
+	}
+});
+
+test("grokHarnessStateIn distinguishes a CLI install without login", () => {
+	const grokHome = tempGrokHome();
+	try {
+		mkdirSync(join(grokHome, "bin"), { recursive: true });
+		writeFileSync(join(grokHome, "bin", "grok"), "#!/bin/sh\n", "utf8");
+		const state = grokHarnessStateIn(grokHome);
+		assert.deepEqual(state, { installed: true, authPresent: false });
+		assert.equal(grokReadinessLabel(state), "no (run `grok login`)");
+	} finally {
+		rmSync(grokHome, { recursive: true, force: true });
+	}
+});
+
+test("install guidance names the Grok CLI and the install URL", () => {
+	const guidance = grokInstallGuidance();
+	assert.match(guidance, /Grok CLI not found/);
+	assert.match(guidance, /https:\/\/x\.ai\/grok/);
+	assert.match(guidance, /`grok login`/);
+});
+
+test("auth guidance distinguishes a missing login from a missing install", () => {
+	const guidance = grokAuthGuidance();
+	assert.match(guidance, /installed but ~/);
+	assert.match(guidance, /~\/.grok\/auth\.json is missing/);
+	assert.match(guidance, /`grok login`/);
+});

--- a/extensions/opencode-pi/README.md
+++ b/extensions/opencode-pi/README.md
@@ -27,6 +27,12 @@ opencode models opencode --verbose
 
 No OpenCode login is required for the bundled free OpenCode models.
 
+At session start the extension probes `opencode --version`. If the OpenCode
+CLI is missing, Pi shows a warning naming the missing harness and the install
+steps (https://opencode.ai). When `OPENCODE_PI_MODELS` is set, discovery is
+skipped for speed — so a missing binary is only caught by this probe, and the
+warning says so explicitly. When the probe succeeds, models register as usual.
+
 ## Install
 
 Published on npm: [`opencode-pi`](https://www.npmjs.com/package/opencode-pi). Use **Pi's package manager** (`pi install`), not `npm install` alone.

--- a/extensions/opencode-pi/src/index.test.ts
+++ b/extensions/opencode-pi/src/index.test.ts
@@ -1111,3 +1111,125 @@ process.stdout.write([
     rmSync(dir, { recursive: true, force: true });
   }
 });
+
+type RecordedNotification = { message: string; level?: string };
+
+type NotifyCtx = { ui: { notify: (msg: string, level?: string) => void } };
+
+function sessionStartRecorder() {
+  let handler:
+    | ((event: unknown, ctx: unknown) => Promise<void>)
+    | undefined;
+  const extension = {
+    registerProvider() {},
+    on(event: string, registered: (event: unknown, ctx: unknown) => Promise<void>) {
+      if (event === "session_start") handler = registered;
+    },
+    registerCommand() {},
+  };
+  return {
+    extension: extension as unknown as ExtensionAPI,
+    async run(ctx: NotifyCtx) {
+      if (!handler) throw new Error("session_start handler not registered");
+      await handler({}, ctx);
+    },
+  };
+}
+
+function recordingCtx(): {
+  notifications: RecordedNotification[];
+  ui: { notify: (msg: string, level?: string) => void };
+} {
+  const notifications: RecordedNotification[] = [];
+  return {
+    notifications,
+    ui: {
+      notify(message: string, level?: string) {
+        notifications.push({ message, level });
+      },
+    },
+  };
+}
+
+test("session_start warns with setup guidance when the opencode binary is missing", async () => {
+  const previousModels = process.env.OPENCODE_PI_MODELS;
+  delete process.env.OPENCODE_PI_MODELS;
+  const previousBin = process.env.OPENCODE_PI_BIN;
+  process.env.OPENCODE_PI_BIN = join(tmpdir(), "opencode-pi-does-not-exist");
+
+  try {
+    const recorder = sessionStartRecorder();
+    await opencodePiExtension(recorder.extension);
+
+    const ctx = recordingCtx();
+    await recorder.run(ctx);
+
+    const warnings = ctx.notifications.filter((n) => n.level === "warning");
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0]!.message, /could not use the local OpenCode CLI/);
+    assert.match(warnings[0]!.message, /Reason:/);
+    assert.match(warnings[0]!.message, /Install OpenCode/);
+    assert.equal(
+      ctx.notifications.some((n) => n.level === "info"),
+      false,
+    );
+  } finally {
+    restoreEnv("OPENCODE_PI_BIN", previousBin);
+    restoreEnv("OPENCODE_PI_MODELS", previousModels);
+  }
+});
+
+test("session_start flags the OPENCODE_PI_MODELS fast path when the binary is missing", async () => {
+  const previousModels = process.env.OPENCODE_PI_MODELS;
+  process.env.OPENCODE_PI_MODELS = "custom-model-a";
+  const previousBin = process.env.OPENCODE_PI_BIN;
+  process.env.OPENCODE_PI_BIN = join(tmpdir(), "opencode-pi-does-not-exist");
+
+  try {
+    const recorder = sessionStartRecorder();
+    await opencodePiExtension(recorder.extension);
+
+    const ctx = recordingCtx();
+    await recorder.run(ctx);
+
+    const warnings = ctx.notifications.filter((n) => n.level === "warning");
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0]!.message, /OPENCODE_PI_MODELS skipped discovery/);
+    assert.match(warnings[0]!.message, /could not use the local OpenCode CLI/);
+  } finally {
+    restoreEnv("OPENCODE_PI_BIN", previousBin);
+    restoreEnv("OPENCODE_PI_MODELS", previousModels);
+  }
+});
+
+test("session_start produces no warning when opencode answers --version", async () => {
+  const previousModels = process.env.OPENCODE_PI_MODELS;
+  delete process.env.OPENCODE_PI_MODELS;
+
+  try {
+    const recorder = sessionStartRecorder();
+    await withFakeOpenCode(
+      `if (process.argv.includes("--version")) {
+  process.stdout.write("opencode 9.9.9\\n");
+  process.exit(0);
+}
+process.stdout.write([
+  "opencode/one-free",
+  JSON.stringify({ capabilities: {} }),
+].join("\\n"));`,
+      () => opencodePiExtension(recorder.extension),
+    );
+
+    const ctx = recordingCtx();
+    await recorder.run(ctx);
+
+    assert.deepEqual(
+      ctx.notifications.filter((n) => n.level === "warning"),
+      [],
+    );
+    const info = ctx.notifications.find((n) => n.level === "info");
+    assert.match(info?.message ?? "", /registered \d+ OpenCode CLI model\(s\)/);
+  } finally {
+    restoreEnv("OPENCODE_PI_MODELS", previousModels);
+  }
+});

--- a/extensions/opencode-pi/src/index.ts
+++ b/extensions/opencode-pi/src/index.ts
@@ -29,7 +29,14 @@ const AGENT_ID = "pi-model";
 const DEFAULT_CONTEXT_WINDOW = 128_000;
 const DEFAULT_MAX_TOKENS = 16_384;
 const DISCOVERY_TIMEOUT_MS = 8_000;
+const STATUS_TIMEOUT_MS = 10_000;
 const STDERR_LIMIT = 20_000;
+
+export type CliStatus = {
+  ok: boolean;
+  summary: string;
+  detail?: string;
+};
 
 const DEFAULT_FREE_MODELS = [
   "opencode/deepseek-v4-flash-free",
@@ -278,6 +285,39 @@ function runCapture(
       child.stdin!.end(input);
     }
   });
+}
+
+/** Build the install/setup instructions shown when the opencode CLI is unusable. */
+export function setupGuidance(error: string): string {
+  return [
+    "opencode-pi could not use the local OpenCode CLI.",
+    `Reason: ${error}`,
+    "Install OpenCode (https://opencode.ai), ensure `opencode --version` works on PATH, then reload Pi.",
+    "Set OPENCODE_PI_BIN to override the executable path.",
+  ].join(" ");
+}
+
+/** Probe the OpenCode CLI with `opencode --version` to detect a missing/broken install. */
+export async function checkCliStatus(): Promise<CliStatus> {
+  try {
+    const result = await runCapture(["--version"], undefined, STATUS_TIMEOUT_MS);
+    if (result.code !== 0) {
+      const detail =
+        result.stderr.trim() ||
+        result.stdout.trim() ||
+        `opencode --version exited with code ${result.code}`;
+      return { ok: false, summary: "OpenCode CLI is unusable", detail };
+    }
+    const version =
+      result.stdout.trim() || result.stderr.trim() || "OpenCode CLI is available";
+    return { ok: true, summary: version };
+  } catch (error) {
+    return {
+      ok: false,
+      summary: "OpenCode CLI is unavailable",
+      detail: error instanceof Error ? error.message : String(error),
+    };
+  }
 }
 
 export async function discoverModels(opts?: {
@@ -1436,6 +1476,18 @@ export default async function opencodePiExtension(pi: ExtensionAPI) {
   registerApiHandler();
 
   pi.on("session_start", async (_event: any, ctx: any) => {
+    const cliStatus = await checkCliStatus();
+    if (!cliStatus.ok) {
+      const fastPathConfigured = Boolean(configuredModels()?.length);
+      const fastPathNote = fastPathConfigured
+        ? "OPENCODE_PI_MODELS skipped discovery, so this was not detected at startup. "
+        : "";
+      ctx.ui.notify(
+        `opencode-pi: ${fastPathNote}${setupGuidance(cliStatus.detail ?? cliStatus.summary)}`,
+        "warning",
+      );
+      return;
+    }
     ctx.ui.notify(
       `opencode-pi: registered ${registeredModels.length} OpenCode CLI model(s). Use /model and pick ${PROVIDER_ID}.`,
       "info",


### PR DESCRIPTION
Closes #53

## Summary

Extensions that bridge external CLI harnesses now verify their prerequisite is installed before use: each of `agy-pi`, `opencode-pi`, and `grok-pi` checks its harness at session start and, when something is missing, tells the user exactly which harness is absent and what to install. `claude-code-pi` already implemented this pattern and is intentionally untouched.

## Approach

Option 2 — Balanced approach. Replicate the proven `checkCliStatus()`/`setupGuidance()` pattern from `claude-code-pi` into the other three extensions (spawn `<bin> --version` with a 10s timeout via each package's existing `runCapture`, or a filesystem state check for grok-pi's proxy-based design), surface actionable `ctx.ui.notify(..., 'warning')` messages at `session_start`, add unit tests per package (including agy-pi's first test suite), README prerequisites sections, and a CHANGELOG entry.

## Decision Record

- **Root cause:** Only `claude-code-pi` probed its external CLI at startup; `agy-pi` had no check at all (and swallowed spawn errors as "No response from agy."), `opencode-pi` warned only on generic discovery-fallback errors (and its `OPENCODE_PI_MODELS` fast path skipped spawning opencode entirely), and `grok-pi` surfaced only auth state — never "Grok CLI not installed".
- **Options considered:** Option 1 — Minimal fix (replicate checks only); Option 2 — Balanced approach (checks + tests + docs); Option 3 — Comprehensive refactor (shared harness-check utility + stream-level ENOENT guards)
- **Options rejected:** Option 1 — ships new check logic with no automated tests or docs; Option 3 — shared-module packaging friction cuts against independently publishable per-extension packages (AGENTS.md) and refactors a proven reference implementation for duplication a fifth harness bridge would justify
- **Selected option:** Option 2 — Balanced approach
- **Residual risk:** ~40-line checker duplicated across three packages (consistent with repo copy-don't-couple precedent); no live Pi TUI notification test (requires running host)
- **Pi availability note:** extensions execute inside Pi by construction, so "verify Pi is available" reduces to documenting that requirement in each README

Analyzed at: `feat/53-add-harness-environment-checks-to @ 32ee642` (2026-08-23)

## Changes

| File | Change |
|------|--------|
| `extensions/agy-pi/src/index.ts` | `checkAgyStatus()` probes `agy --version`; exported pure helpers (`setupGuidance()`, `agyBin()`, `streamAgy()`); session_start warning; stream spawn failures now emit guidance-bearing errors instead of bare "No response from agy." |
| `extensions/opencode-pi/src/index.ts` | Exported `checkCliStatus()` + `setupGuidance()`; session_start warns on missing CLI, explicitly calling out the `OPENCODE_PI_MODELS` fast path that skipped discovery |
| `extensions/grok-pi/src/harness.ts` | New pure helpers: `grokHarnessStateIn()`, `grokInstallGuidance()`, `grokAuthGuidance()`, `grokReadinessLabel()` |
| `extensions/grok-pi/src/index.ts` | session_start distinguishes "Grok CLI not found" from "installed but not logged in"; `/grok-pi status` gains combined Ready line |
| `extensions/agy-pi/test/helpers.test.mjs` | First agy-pi suite: bin resolution, guidance text, probe ok/nonzero-exit/missing-bin, stream-failure diagnostic |
| `extensions/agy-pi/package.json` | Added `test` script |
| `extensions/opencode-pi/src/index.test.ts` | 3 new session_start cases (missing-binary warning, fast-path-with-missing-bin, ok path silent) |
| `extensions/grok-pi/test/harness-checks.test.mjs` | Temp-dir `~/.grok` fixture tests: readiness states + guidance text |
| `extensions/{agy-pi,opencode-pi,grok-pi}/README.md` | Prerequisites sections |
| `CHANGELOG.md` | Unreleased → Added entry |

## Test Results

- Unit tests: 52 passed (agy 6/6 · grok 17/17 · opencode 49/49 including pre-existing suites)
- Integration tests: skipped — no framework in this repo
- E2e tests: skipped — no framework in this repo
- Build: passed (`npm run build` clean in all three touched packages)
- QA cycles: 1

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Extensions related to Grok, Agy, Claude Code, and OpenCode check that Pi and their required external harness are installed before use | pass | `session_start` probes in agy-pi/opencode-pi/grok-pi `src/index.ts`; claude-code-pi pre-existing (`checkCliStatus()`); Pi-as-host documented in READMEs |
| The checks cover every extension that depends on one of these external harnesses | pass | Repo inventory confirms exactly four harness-dependent extensions of eleven; all four covered |
| When a required prerequisite is missing, the user is clearly told which harness is missing and what must be installed | pass | Warning texts name harness + install step (`pip install agy-cli`, https://opencode.ai, https://x.ai/grok + `grok login`) — asserted in `test/helpers.test.mjs`, `src/index.test.ts`, `test/harness-checks.test.mjs` |
| When all required prerequisites are installed, the extensions continue to work normally | pass | Ok-path tests produce zero extra warnings and preserve original info notifications verbatim |

<!-- gitissue:qa v1 head=f56a7c9528464e28bc5f9a54d28fbfac24ba3972 profile=full cycles=1 review=clean ui=none -->
