### PR TITLE
feat(cache-warm): enable keep-alive by default (#55)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Harness environment checks**: `agy-pi`, `opencode-pi`, and `grok-pi` now verify their required external CLI at session start and warn with install guidance naming the missing harness; missing-binary stream failures in agy-pi report actionable setup steps instead of "No response from agy.", opencode-pi flags a missing CLI even when the `OPENCODE_PI_MODELS` fast path skipped discovery, and grok-pi distinguishes an uninstalled Grok CLI from a missing `grok login`, with a combined `Ready:` line in `/grok-pi status` (#53).
-- **cache-warm**: Opt-in prompt-cache keep-alive extension (`/cache-warm on`, `off`, `status`, `metrics`) with avoided-miss and estimated net USD-saved metrics. Separate package from timestamp-pi; default off so install/session start never bills a warm turn (#51).
+- **cache-warm**: Prompt-cache keep-alive extension (`/cache-warm on`, `off`, `status`, `metrics`, `duration`) with avoided-miss and estimated net USD-saved metrics. Separate package from timestamp-pi; enabled by default, disable with `/cache-warm off`. Idle keep-alive auto-stops after 30 minutes (configurable via `/cache-warm duration` or `CACHE_WARM_DURATION`); `/cache-warm on` clears a suppressed epoch (#51, #55).
 - **9router-pi**: Dynamic `9router` provider discovery from the local OpenAI-compatible `/v1/models` endpoint, with manual refresh and offline fallback support.
-
-### Changed
-
-- **cache-warm**: Keep-alive is now enabled by default on new sessions; `/cache-warm off`, `/cache-warm on`, and `/cache-warm` still disable, re-enable, and toggle it (#55).
 
 ## [0.2.0] — 2026-08-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **cache-warm**: Opt-in prompt-cache keep-alive extension (`/cache-warm on`, `off`, `status`, `metrics`) with avoided-miss and estimated net USD-saved metrics. Separate package from timestamp-pi; default off so install/session start never bills a warm turn (#51).
 - **9router-pi**: Dynamic `9router` provider discovery from the local OpenAI-compatible `/v1/models` endpoint, with manual refresh and offline fallback support.
 
+### Changed
+
+- **cache-warm**: Keep-alive is now enabled by default on new sessions; `/cache-warm off`, `/cache-warm on`, and `/cache-warm` still disable, re-enable, and toggle it (#55).
+
 ## [0.2.0] — 2026-08-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Find what you need, copy the install command, reload Pi (`/reload`).
 | Extension | What you get | Install |
 |---|---|---|
 | [advisor-pi](extensions/advisor-pi/README.md) | `advisor` tool: strategic guidance from a stronger model | `pi install npm:advisor-pi` |
-| [cache-warm](extensions/cache-warm/README.md) | Opt-in keep-alive pings that avoid prompt-cache misses | `pi install npm:cache-warm` |
+| [cache-warm](extensions/cache-warm/README.md) | Keep-alive pings that avoid prompt-cache misses (on by default) | `pi install npm:cache-warm` |
 | [model-debugger](extensions/model-debugger/README.md) | Log all model requests/responses for provider debugging | `pi install npm:model-debugger` |
 
 ### Skill & themes
@@ -365,9 +365,9 @@ pi install npm:timestamp-pi   # or: pi -e ./extensions/timestamp-pi
 
 ![Cache-warm footer counting down, before and after a warm ping](assets/cache-warm.png)
 
-Keeps the prompt cache alive with opt-in hidden keep-alive turns.
-Default is **off**: install and `session_start` never bill a warm turn. Enable
-with `/cache-warm on`. Pings use `pi.sendMessage()` (not `sendUserMessage` /
+Keeps the prompt cache alive with hidden keep-alive turns.
+Default is **on**: new sessions start the keep-alive timer without `/cache-warm on`.
+Disable with `/cache-warm off`. Pings use `pi.sendMessage()` (not `sendUserMessage` /
 `completeSimple`) and only fire when the session is idle, nothing is queued,
 cache activity has already been seen, and remaining TTL is under 60 seconds
 (`extensions/cache-warm/src/index.ts`). The 5-minute TTL is an Anthropic

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Find what you need, copy the install command, reload Pi (`/reload`).
 | Extension | What you get | Install |
 |---|---|---|
 | [advisor-pi](extensions/advisor-pi/README.md) | `advisor` tool: strategic guidance from a stronger model | `pi install npm:advisor-pi` |
-| [cache-warm](extensions/cache-warm/README.md) | Keep-alive pings that avoid prompt-cache misses (on by default) | `pi install npm:cache-warm` |
+| [cache-warm](extensions/cache-warm/README.md) | Keep-alive pings that avoid prompt-cache misses (on by default, 30m idle auto-stop) | `pi install npm:cache-warm` |
 | [model-debugger](extensions/model-debugger/README.md) | Log all model requests/responses for provider debugging | `pi install npm:model-debugger` |
 
 ### Skill & themes
@@ -367,7 +367,8 @@ pi install npm:timestamp-pi   # or: pi -e ./extensions/timestamp-pi
 
 Keeps the prompt cache alive with hidden keep-alive turns.
 Default is **on**: new sessions start the keep-alive timer without `/cache-warm on`.
-Disable with `/cache-warm off`. Pings use `pi.sendMessage()` (not `sendUserMessage` /
+Disable with `/cache-warm off`. Keep-alive auto-stops after 30 minutes idle
+(configurable: `/cache-warm duration 1h` or `CACHE_WARM_DURATION`). Pings use `pi.sendMessage()` (not `sendUserMessage` /
 `completeSimple`) and only fire when the session is idle, nothing is queued,
 cache activity has already been seen, and remaining TTL is under 60 seconds
 (`extensions/cache-warm/src/index.ts`). The 5-minute TTL is an Anthropic
@@ -380,7 +381,7 @@ pi install npm:cache-warm   # or: pi -e ./extensions/cache-warm
 ```
 
 **Commands:** `/cache-warm on`, `/cache-warm off`, `/cache-warm` (toggle),
-`/cache-warm status`, `/cache-warm metrics`
+`/cache-warm duration [30m|1h|forever]`, `/cache-warm status`, `/cache-warm metrics`
 
 </details>
 

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -14,3 +14,8 @@ Append-only log of documentation ambiguities resolved with the user.
 - Q: Should prompt-cache keep-alive ship by extending timestamp-pi, or as a separate `cache-warm` package?
 - A: Separate `extensions/cache-warm` npm package. timestamp-pi stays TUI-only (timestamps never reach the LLM). Warming is paid session traffic and must be independently togglable (default off). Countdown helpers (`CACHE_TTL_MS`, `computeCacheStatus`) are copied (~20 lines) rather than extracted into a shared library; no runtime imports from timestamp-pi or statusline-pi.
 - Source: issue #51
+
+## 2026-08-24
+- Q: Should cache-warm keep-alive start enabled, and should idle warming be unbounded?
+- A: Default on for new sessions (#55). Auto-stop after 30 minutes idle (from last user turn or enable) so a forgotten session does not bill overnight. `/cache-warm duration 1h` / `CACHE_WARM_DURATION` sets the window; `forever` disables auto-stop. `/cache-warm on` also clears a suppressed epoch while already enabled.
+- Source: issue #55 / PR #56 review; follow-up idle auto-stop

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -330,9 +330,10 @@ session entries, so history survives reloads and never reaches the LLM.
 ### cache-warm
 
 `cache-warm` is a separate keep-alive extension (not part of timestamp-pi).
-Default is off: `/cache-warm on` starts a timer that may `pi.sendMessage()` a
+Default is on: `session_start` starts a timer that may `pi.sendMessage()` a
 hidden ping when remaining TTL is under 60s, the session is idle, and cache
 activity has already been observed (`extensions/cache-warm/src/index.ts`).
+`/cache-warm off` stops the timer.
 Metrics (`attempts`, `refreshes`, `likelyAvoidedMisses`, estimated net USD)
 live in `src/warm.ts` / `src/metrics.ts`; cost math is copied from
 statusline-pi rather than imported. The 5-minute TTL is an Anthropic heuristic.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -330,9 +330,13 @@ session entries, so history survives reloads and never reaches the LLM.
 ### cache-warm
 
 `cache-warm` is a separate keep-alive extension (not part of timestamp-pi).
-Default is on: `session_start` starts a timer that may `pi.sendMessage()` a
-hidden ping when remaining TTL is under 60s, the session is idle, and cache
-activity has already been observed (`extensions/cache-warm/src/index.ts`).
+Default is on: `session_start` starts a 1s tick timer (`unref`'d so it cannot
+hold the process open) that may `pi.sendMessage()` a hidden ping when remaining
+TTL is under 60s, the session is idle, and cache activity has already been
+observed (`extensions/cache-warm/src/index.ts`). Idle keep-alive auto-stops after
+30 minutes (from last user turn or enable); `/cache-warm duration 1h` or
+`CACHE_WARM_DURATION` changes that window (`forever` disables auto-stop).
+`/cache-warm on` clears a suppressed epoch even when already enabled.
 `/cache-warm off` stops the timer.
 Metrics (`attempts`, `refreshes`, `likelyAvoidedMisses`, estimated net USD)
 live in `src/warm.ts` / `src/metrics.ts`; cost math is copied from

--- a/extensions/cache-warm/README.md
+++ b/extensions/cache-warm/README.md
@@ -1,8 +1,8 @@
 # cache-warm
 
-Opt-in keep-alive for Pi's prompt cache. When enabled, the extension sends a tiny hidden turn before the cache TTL expires so a later user message is more likely to hit cache instead of paying for a miss.
+Keep-alive for Pi's prompt cache. When enabled, the extension sends a tiny hidden turn before the cache TTL expires so a later user message is more likely to hit cache instead of paying for a miss.
 
-**Default is off.** Installing the extension or starting a session never bills a warm turn. Enable it with `/cache-warm on`.
+**Default is on.** New sessions start keep-alive without `/cache-warm on`. Disable it with `/cache-warm off`.
 
 ![Cache-warm footer counting down, before and after a warm ping](../../assets/cache-warm.png)
 
@@ -56,7 +56,7 @@ Or install it persistently:
 pi install -l ./extensions/cache-warm
 ```
 
-Then run `/reload` in Pi (or restart it). Warming stays **off** until `/cache-warm on`.
+Then run `/reload` in Pi (or restart it). Keep-alive is **on** by default; use `/cache-warm off` to disable.
 
 ## Development
 

--- a/extensions/cache-warm/README.md
+++ b/extensions/cache-warm/README.md
@@ -2,7 +2,7 @@
 
 Keep-alive for Pi's prompt cache. When enabled, the extension sends a tiny hidden turn before the cache TTL expires so a later user message is more likely to hit cache instead of paying for a miss.
 
-**Default is on.** New sessions start keep-alive without `/cache-warm on`. Disable it with `/cache-warm off`.
+**Default is on.** New sessions start keep-alive without `/cache-warm on`. Disable it with `/cache-warm off`. Keep-alive auto-stops after **30 minutes idle** (from the last user turn or `/cache-warm on`). Set any duration with `/cache-warm duration 1h` (or `30m`, `2h`, `forever`).
 
 ![Cache-warm footer counting down, before and after a warm ping](../../assets/cache-warm.png)
 
@@ -10,12 +10,12 @@ This is a separate package from [timestamp-pi](../timestamp-pi/README.md). times
 
 ## What it does
 
-- **Keep-alive pings** — when the remaining prompt-cache TTL drops under 60 seconds, and the session is idle with no queued messages, `cache-warm` injects a `display: false` custom message (`Reply "." only. Do not use tools.`) via `sendMessage`. Observed full one-hour Anthropic writes use a one-hour TTL; short and mixed writes schedule conservatively at five minutes.
+- **Keep-alive pings** — when the remaining prompt-cache TTL drops under 60 seconds, and the session is idle with no queued messages, `cache-warm` injects a `display: false` custom message (`Reply "." only. Do not use tools.`) via `sendMessage`. Observed full one-hour Anthropic writes use a one-hour TTL; short and mixed writes schedule conservatively at five minutes. After 30 minutes with no user turn (configurable), keep-alive turns itself off so a forgotten session does not bill overnight.
 - **Tool isolation** — once the hidden turn is confirmed, every hidden tool call is forcibly blocked, including retries, continuations, and interrupted work. If Pi drains queued user or foreign custom work before `agent_settled`, the guard is released at that message boundary so the external turn can use tools normally. The extension never changes the global active-tool list.
 - **Easy toggle** — `/cache-warm on`, `/cache-warm off`, or `/cache-warm` to toggle
 - **Honest metrics** — attempts, successful refreshes, likely avoided misses, and estimated net USD saved
 
-The five-minute fallback is an Anthropic heuristic, not a universal provider guarantee. Cache reads without new write evidence retain the most recent observed retention for the model/session. An unconfirmed dispatch is never retried within the same cache-activity epoch because a late first dispatch could otherwise create duplicate billed turns.
+The five-minute fallback is an Anthropic heuristic, not a universal provider guarantee. Cache reads without new write evidence retain the most recent observed retention for the model/session. An unconfirmed dispatch is never retried within the same cache-activity epoch because a late first dispatch could otherwise create duplicate billed turns. `/cache-warm on` clears that suppression even when keep-alive is already enabled.
 
 Pings enter the LLM context. The assistant reply cannot be guaranteed invisible.
 
@@ -24,9 +24,11 @@ Pings enter the LLM context. The assistant reply cannot be guaranteed invisible.
 | Command | Description |
 |---------|-------------|
 | `/cache-warm` | Toggle keep-alive on/off |
-| `/cache-warm on` | Enable warming |
+| `/cache-warm on` | Enable warming (restarts the idle window) |
 | `/cache-warm off` | Disable warming |
-| `/cache-warm status` | Enabled state, cache countdown, and metrics |
+| `/cache-warm duration` | Show the idle auto-stop limit |
+| `/cache-warm duration 30m` | Set the idle auto-stop (`1h`, `2h`, `90`, `forever`; bare numbers are minutes) |
+| `/cache-warm status` | Enabled state, idle limit, cache countdown, and metrics |
 | `/cache-warm metrics` | Attempts, refreshes, likely avoided misses, estimated net USD saved |
 
 ## Metrics
@@ -56,7 +58,7 @@ Or install it persistently:
 pi install -l ./extensions/cache-warm
 ```
 
-Then run `/reload` in Pi (or restart it). Keep-alive is **on** by default; use `/cache-warm off` to disable.
+Then run `/reload` in Pi (or restart it). Keep-alive is **on** by default and auto-stops after 30 minutes idle; use `/cache-warm off` to disable, or `/cache-warm duration 2h` (or `CACHE_WARM_DURATION=2h`) for a longer window.
 
 ## Development
 

--- a/extensions/cache-warm/package.json
+++ b/extensions/cache-warm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cache-warm",
   "version": "0.1.0",
-  "description": "Opt-in prompt-cache keep-alive for Pi with avoided-miss and USD-saved metrics",
+  "description": "Prompt-cache keep-alive for Pi with avoided-miss and USD-saved metrics (enabled by default)",
   "type": "module",
   "main": "./src/index.ts",
   "files": [

--- a/extensions/cache-warm/src/command.ts
+++ b/extensions/cache-warm/src/command.ts
@@ -1,22 +1,82 @@
-export type CacheWarmAction = "on" | "off" | "status" | "metrics" | "toggle" | "unknown";
+export type CacheWarmAction = "on" | "off" | "status" | "metrics" | "toggle" | "duration" | "unknown";
+
+export interface ParsedCacheWarmArgs {
+	action: CacheWarmAction;
+	/** Set when action is "duration" and a value was given. 0 means no idle auto-stop. */
+	durationMs?: number;
+	error?: string;
+}
+
+const FOREVER_TOKENS = new Set(["forever", "unlimited", "infinite", "none"]);
+
+/** Parse a duration such as `30m`, `1h`, `1h30m`, `90` (minutes), or `forever`. */
+export function parseDurationMs(raw: string): number | undefined {
+	const token = raw.trim().toLowerCase();
+	if (!token) return undefined;
+	if (FOREVER_TOKENS.has(token)) return 0;
+	if (/^\d+$/.test(token)) {
+		const minutes = Number(token);
+		return minutes > 0 ? minutes * 60_000 : undefined;
+	}
+	const match = token.match(/^(?:(\d+)\s*h)?\s*(?:(\d+)\s*m)?\s*(?:(\d+)\s*s)?$/);
+	if (!match || !(match[1] || match[2] || match[3])) return undefined;
+	const ms =
+		Number(match[1] ?? 0) * 3_600_000 + Number(match[2] ?? 0) * 60_000 + Number(match[3] ?? 0) * 1_000;
+	return ms > 0 ? ms : undefined;
+}
+
+export function formatDurationMs(ms: number): string {
+	if (ms === 0) return "forever";
+	const totalSeconds = Math.round(ms / 1000);
+	const hours = Math.floor(totalSeconds / 3600);
+	const minutes = Math.floor((totalSeconds % 3600) / 60);
+	const seconds = totalSeconds % 60;
+	let out = "";
+	if (hours) out += `${hours}h`;
+	if (minutes) out += `${minutes}m`;
+	if (seconds || !out) out += `${seconds}s`;
+	return out;
+}
 
 /** Parse `/cache-warm` args. Empty input toggles. */
-export function parseCacheWarmArgs(args: string): CacheWarmAction {
-	const token = args.trim().split(/\s+/).filter(Boolean)[0]?.toLowerCase() ?? "";
-	switch (token) {
+export function parseCacheWarmArgs(args: string): ParsedCacheWarmArgs {
+	const tokens = args.trim().split(/\s+/).filter(Boolean);
+	const first = tokens[0]?.toLowerCase() ?? "";
+	switch (first) {
 		case "":
-			return "toggle";
+			return { action: "toggle" };
 		case "on":
 		case "enable":
-			return "on";
+			return { action: "on" };
 		case "off":
 		case "disable":
-			return "off";
+			return { action: "off" };
 		case "status":
-			return "status";
+			return { action: "status" };
 		case "metrics":
-			return "metrics";
-		default:
-			return "unknown";
+			return { action: "metrics" };
+		case "duration":
+		case "for": {
+			if (tokens.length === 1) return { action: "duration" };
+			const rest = tokens.slice(1).join(" ");
+			const durationMs = parseDurationMs(rest);
+			if (durationMs === undefined) {
+				return {
+					action: "unknown",
+					error: `Invalid duration "${rest}". Try 30m, 1h, 2h, or forever.`,
+				};
+			}
+			return { action: "duration", durationMs };
+		}
+		default: {
+			if (tokens.length === 1) {
+				const durationMs = parseDurationMs(first);
+				if (durationMs !== undefined) return { action: "duration", durationMs };
+			}
+			return {
+				action: "unknown",
+				error: "Usage: /cache-warm [on|off|status|metrics|duration [30m|1h|forever]]",
+			};
+		}
 	}
 }

--- a/extensions/cache-warm/src/index.ts
+++ b/extensions/cache-warm/src/index.ts
@@ -91,6 +91,7 @@ export default function cacheWarmExtension(pi: ExtensionAPI) {
 	pi.on("session_start", async (_event, ctx) => {
 		mountedCtx = ctx;
 		applyModelChange(state, modelKeyOf(ctx.model));
+		if (state.enabled) startTimer();
 		syncStatus(ctx);
 	});
 

--- a/extensions/cache-warm/src/index.ts
+++ b/extensions/cache-warm/src/index.ts
@@ -1,6 +1,6 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { Model, Usage } from "@earendil-works/pi-ai";
-import { parseCacheWarmArgs } from "./command.js";
+import { formatDurationMs, parseCacheWarmArgs } from "./command.js";
 import { formatMetrics } from "./metrics.js";
 import {
 	applyAssistantUsage,
@@ -13,6 +13,7 @@ import {
 	failPendingDispatch,
 	formatStatusReport,
 	formatWarmFooter,
+	isActiveWindowOpen,
 	markWarmAbortCalled,
 	modelKeyOf,
 	noteAgentSettled,
@@ -20,16 +21,18 @@ import {
 	noteExternalInput,
 	noteExternalMessageStart,
 	noteTurnStart,
+	noteUserActivity,
 	PING_CONTENT,
 	resetSession,
+	setActiveMs,
 	setEnabled,
 	shouldSendWarmPing,
 	STATUS_KEY,
 } from "./warm.js";
 
 export { CACHE_TTL_LONG_MS, CACHE_TTL_MS, CACHE_WARN_MS, computeCacheStatus, formatCountdown } from "./cache.js";
-export { parseCacheWarmArgs } from "./command.js";
-export type { CacheWarmAction } from "./command.js";
+export { formatDurationMs, parseCacheWarmArgs, parseDurationMs } from "./command.js";
+export type { CacheWarmAction, ParsedCacheWarmArgs } from "./command.js";
 export {
 	cloneUsage,
 	createMetrics,
@@ -53,8 +56,10 @@ export {
 	ENTRY_TYPE,
 	expirePendingDispatch,
 	failPendingDispatch,
+	DEFAULT_ACTIVE_MS,
 	formatStatusReport,
 	formatWarmFooter,
+	isActiveWindowOpen,
 	markWarmAbortCalled,
 	modelKeyOf,
 	noteAgentSettled,
@@ -62,8 +67,11 @@ export {
 	noteExternalInput,
 	noteExternalMessageStart,
 	noteTurnStart,
+	noteUserActivity,
 	PING_CONTENT,
+	remainingActiveMs,
 	resetSession,
+	setActiveMs,
 	setEnabled,
 	shouldSendWarmPing,
 	STATUS_KEY,
@@ -91,6 +99,7 @@ export default function cacheWarmExtension(pi: ExtensionAPI) {
 	pi.on("session_start", async (_event, ctx) => {
 		mountedCtx = ctx;
 		applyModelChange(state, modelKeyOf(ctx.model));
+		noteUserActivity(state, Date.now());
 		if (state.enabled) startTimer();
 		syncStatus(ctx);
 	});
@@ -167,8 +176,8 @@ export default function cacheWarmExtension(pi: ExtensionAPI) {
 		description: "Enable, disable, or show prompt-cache keep-alive status and savings",
 		handler: async (args, ctx) => {
 			mountedCtx = ctx;
-			const action = parseCacheWarmArgs(args);
-			switch (action) {
+			const parsed = parseCacheWarmArgs(args);
+			switch (parsed.action) {
 				case "on":
 				enable(ctx);
 				notify(ctx, "cache-warm enabled", "info");
@@ -192,14 +201,37 @@ export default function cacheWarmExtension(pi: ExtensionAPI) {
 				case "metrics":
 				notify(ctx, formatMetrics(state.metrics), "info");
 				return;
+				case "duration":
+				if (parsed.durationMs === undefined) {
+					notify(
+						ctx,
+						`cache-warm idle limit: ${formatDurationMs(state.activeMs)}`,
+						"info",
+					);
+					return;
+				}
+				setActiveMs(state, parsed.durationMs);
+				syncStatus(ctx);
+				notify(
+					ctx,
+					parsed.durationMs === 0
+						? "cache-warm idle limit set to forever"
+						: `cache-warm idle limit set to ${formatDurationMs(parsed.durationMs)}`,
+					"info",
+				);
+				return;
 				default:
-				notify(ctx, "Usage: /cache-warm [on|off|status|metrics]", "warning");
+				notify(
+					ctx,
+					parsed.error ?? "Usage: /cache-warm [on|off|status|metrics|duration [30m|1h|forever]]",
+					"warning",
+				);
 			}
 		},
 	});
 
 	function enable(ctx: ExtensionContext): void {
-		setEnabled(state, true);
+		setEnabled(state, true, Date.now());
 		mountedCtx = ctx;
 		startTimer();
 		syncStatus(ctx);
@@ -216,6 +248,7 @@ export default function cacheWarmExtension(pi: ExtensionAPI) {
 		timer = setInterval(() => {
 			if (mountedCtx) tick(mountedCtx);
 		}, TICK_MS);
+		timer.unref?.();
 	}
 
 	function stopTimer(): void {
@@ -227,8 +260,18 @@ export default function cacheWarmExtension(pi: ExtensionAPI) {
 	function tick(ctx: ExtensionContext): void {
 		const now = Date.now();
 		expirePendingDispatch(state, now);
-		const idle = ctx.isIdle();
-		const hasPendingMessages = ctx.hasPendingMessages();
+		if (
+			state.enabled &&
+			!isActiveWindowOpen(now, state.activeMs, state.lastUserActivityAt)
+		) {
+			disable(ctx);
+			notify(
+				ctx,
+				`cache-warm stopped after ${formatDurationMs(state.activeMs)} idle`,
+				"info",
+			);
+			return;
+		}
 		if (
 			shouldSendWarmPing({
 				enabled: state.enabled,
@@ -238,15 +281,12 @@ export default function cacheWarmExtension(pi: ExtensionAPI) {
 				dispatchPending: state.dispatchPending !== undefined,
 				warmRunActive: state.warmRunActive !== undefined,
 				suppressedEpoch: state.suppressedEpoch,
-				idle,
-				hasPendingMessages,
+				activeMs: state.activeMs,
+				lastUserActivityAt: state.lastUserActivityAt,
+				idle: ctx.isIdle(),
+				hasPendingMessages: ctx.hasPendingMessages(),
 				ttlMs: state.retention?.ttlMs,
-			}) &&
-			ctx.isIdle() &&
-			!ctx.hasPendingMessages() &&
-			state.enabled &&
-			!state.dispatchPending &&
-			!state.warmRunActive
+			})
 		) {
 			const dispatch = beginWarmDispatch(state, now, ctx.model as Model<any> | undefined);
 			if (dispatch) {

--- a/extensions/cache-warm/src/warm.ts
+++ b/extensions/cache-warm/src/warm.ts
@@ -99,7 +99,7 @@ export interface WarmPingGate {
 
 export function createWarmState(): WarmState {
 	return {
-		enabled: false,
+		enabled: true,
 		cacheLastActive: undefined,
 		cacheEpoch: 0,
 		suppressedEpoch: undefined,
@@ -336,7 +336,7 @@ export function setEnabled(state: WarmState, enabled: boolean): boolean {
 }
 
 export function resetSession(state: WarmState): void {
-	state.enabled = false;
+	state.enabled = true;
 	state.cacheLastActive = undefined;
 	state.cacheEpoch = 0;
 	state.suppressedEpoch = undefined;

--- a/extensions/cache-warm/src/warm.ts
+++ b/extensions/cache-warm/src/warm.ts
@@ -1,5 +1,6 @@
 import type { Model, Usage } from "@earendil-works/pi-ai";
 import { CACHE_TTL_LONG_MS, CACHE_TTL_MS, CACHE_WARN_MS, computeCacheStatus, formatCountdown } from "./cache.js";
+import { formatDurationMs, parseDurationMs } from "./command.js";
 import {
 	createMetrics,
 	estimateGrossBenefitUsd,
@@ -18,6 +19,8 @@ export const ENTRY_TYPE = "cache-warm";
 export const PING_CONTENT = 'Reply "." only. Do not use tools.';
 export const STATUS_KEY = "cache-alive-warm";
 export const WARM_TIMEOUT_MS = 60_000;
+/** Default idle window after last user activity before keep-alive auto-stops. */
+export const DEFAULT_ACTIVE_MS = 30 * 60 * 1000;
 
 export type RetentionKind = "short" | "long" | "mixed" | "unknown";
 
@@ -81,6 +84,9 @@ export interface WarmState {
 	modelKey: string | undefined;
 	metrics: Metrics;
 	dispatchSequence: number;
+	/** Idle window in ms. 0 means never auto-stop. */
+	activeMs: number;
+	lastUserActivityAt: number | undefined;
 }
 
 export interface WarmPingGate {
@@ -95,6 +101,8 @@ export interface WarmPingGate {
 	hasPendingMessages: boolean;
 	ttlMs?: number;
 	warnMs?: number;
+	activeMs?: number;
+	lastUserActivityAt?: number;
 }
 
 export function createWarmState(): WarmState {
@@ -114,6 +122,8 @@ export function createWarmState(): WarmState {
 		modelKey: undefined,
 		metrics: createMetrics(),
 		dispatchSequence: 0,
+		activeMs: resolveActiveMs(),
+		lastUserActivityAt: undefined,
 	};
 }
 
@@ -121,6 +131,7 @@ export function shouldSendWarmPing(gate: WarmPingGate): boolean {
 	if (!gate.enabled || gate.dispatchPending || gate.warmRunActive) return false;
 	if (!gate.idle || gate.hasPendingMessages || gate.cacheLastActive === undefined) return false;
 	if (gate.suppressedEpoch === gate.cacheEpoch) return false;
+	if (!isActiveWindowOpen(gate.now, gate.activeMs ?? 0, gate.lastUserActivityAt)) return false;
 	const status = computeCacheStatus(gate.cacheLastActive, gate.now, gate.ttlMs ?? CACHE_TTL_MS);
 	return status.state === "active" && status.remainingMs <= (gate.warnMs ?? CACHE_WARN_MS);
 }
@@ -215,7 +226,8 @@ export function noteTurnStart(state: WarmState, startedAt: number): void {
 	}
 }
 
-export function noteExternalInput(state: WarmState): boolean {
+export function noteExternalInput(state: WarmState, now = Date.now()): boolean {
+	state.lastUserActivityAt = now;
 	if (state.dispatchPending) {
 		quarantinePending(state);
 		closeChain(state);
@@ -235,7 +247,8 @@ export function noteExternalInput(state: WarmState): boolean {
 }
 
 /** Transfer ownership only when Pi reaches a queued external message boundary. */
-export function noteExternalMessageStart(state: WarmState): void {
+export function noteExternalMessageStart(state: WarmState, now = Date.now()): void {
+	state.lastUserActivityAt = now;
 	if (state.dispatchPending) {
 		quarantinePending(state);
 		closeChain(state);
@@ -319,11 +332,11 @@ export function applyModelChange(state: WarmState, nextKey: string | undefined):
 	return markWarmAbortCalled(state);
 }
 
-export function setEnabled(state: WarmState, enabled: boolean): boolean {
-	const wasEnabled = state.enabled;
+export function setEnabled(state: WarmState, enabled: boolean, now?: number): boolean {
 	state.enabled = enabled;
 	if (enabled) {
-		if (!wasEnabled) state.suppressedEpoch = undefined;
+		state.suppressedEpoch = undefined;
+		if (now !== undefined) state.lastUserActivityAt = now;
 		return false;
 	}
 	if (state.dispatchPending) quarantinePending(state);
@@ -350,6 +363,7 @@ export function resetSession(state: WarmState): void {
 	state.retention = undefined;
 	state.modelKey = undefined;
 	state.metrics = createMetrics();
+	state.lastUserActivityAt = undefined;
 }
 
 export function closeChain(state: WarmState): void {
@@ -381,7 +395,45 @@ export function formatStatusReport(state: WarmState, now: number): string {
 			: status.state === "expired"
 				? "cache: expired"
 				: `cache: ${formatCountdown(status.remainingMs)} remaining`;
-	return [`cache-warm: ${state.enabled ? "on" : "off"}`, cacheLine, formatMetrics(state.metrics)].join("\n");
+	const enabledLine = `cache-warm: ${state.enabled ? "on" : "off"}`;
+	return [enabledLine, formatIdleLimit(state, now), cacheLine, formatMetrics(state.metrics)].join("\n");
+}
+
+export function isActiveWindowOpen(
+	now: number,
+	activeMs: number,
+	lastUserActivityAt: number | undefined,
+): boolean {
+	if (!activeMs) return true;
+	if (lastUserActivityAt === undefined) return true;
+	return now - lastUserActivityAt < activeMs;
+}
+
+export function remainingActiveMs(state: WarmState, now: number): number | undefined {
+	if (!state.activeMs) return undefined;
+	if (state.lastUserActivityAt === undefined) return state.activeMs;
+	return Math.max(0, state.activeMs - (now - state.lastUserActivityAt));
+}
+
+export function setActiveMs(state: WarmState, activeMs: number): void {
+	state.activeMs = activeMs;
+}
+
+export function noteUserActivity(state: WarmState, now: number): void {
+	state.lastUserActivityAt = now;
+}
+
+function resolveActiveMs(): number {
+	return parseDurationMs(process.env.CACHE_WARM_DURATION ?? "") ?? DEFAULT_ACTIVE_MS;
+}
+
+function formatIdleLimit(state: WarmState, now: number): string {
+	if (!state.activeMs) return "idle limit: forever";
+	const left = remainingActiveMs(state, now) ?? state.activeMs;
+	if (!state.enabled || state.lastUserActivityAt === undefined) {
+		return `idle limit: ${formatDurationMs(state.activeMs)}`;
+	}
+	return `idle limit: ${formatCountdown(left)} of ${formatDurationMs(state.activeMs)} remaining`;
 }
 
 function quarantinePending(state: WarmState): void {

--- a/extensions/cache-warm/test/cache-warm.test.mjs
+++ b/extensions/cache-warm/test/cache-warm.test.mjs
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import cacheWarmExtension, {
 	CACHE_TTL_LONG_MS,
 	CACHE_TTL_MS,
+	DEFAULT_ACTIVE_MS,
 	WARM_TIMEOUT_MS,
 	applyAssistantUsage,
 	applyModelChange,
@@ -12,14 +13,18 @@ import cacheWarmExtension, {
 	estimateGrossBenefitUsd,
 	estimateTurnUsd,
 	expirePendingDispatch,
+	failPendingDispatch,
 	formatMetrics,
+	formatStatusReport,
 	inferMissBillingMode,
 	noteAgentSettled,
 	noteAgentStart,
 	noteExternalInput,
 	noteTurnStart,
 	parseCacheWarmArgs,
+	parseDurationMs,
 	resetSession,
+	setActiveMs,
 	setEnabled,
 	shouldSendWarmPing,
 } from "../dist/index.js";
@@ -84,6 +89,8 @@ function gate(state, now, overrides = {}) {
 		dispatchPending: state.dispatchPending !== undefined,
 		warmRunActive: state.warmRunActive !== undefined,
 		suppressedEpoch: state.suppressedEpoch,
+		activeMs: state.activeMs,
+		lastUserActivityAt: state.lastUserActivityAt,
 		idle: true,
 		hasPendingMessages: false,
 		ttlMs: state.retention?.ttlMs,
@@ -94,9 +101,17 @@ function gate(state, now, overrides = {}) {
 describe("commands and dispatch state", () => {
 	it("keeps warming on by default and parses easy toggles", () => {
 		assert.equal(createWarmState().enabled, true);
-		assert.equal(parseCacheWarmArgs(""), "toggle");
-		assert.equal(parseCacheWarmArgs("on"), "on");
-		assert.equal(parseCacheWarmArgs("disable"), "off");
+		assert.equal(createWarmState().activeMs, DEFAULT_ACTIVE_MS);
+		assert.equal(parseCacheWarmArgs("").action, "toggle");
+		assert.equal(parseCacheWarmArgs("on").action, "on");
+		assert.equal(parseCacheWarmArgs("disable").action, "off");
+		assert.equal(parseDurationMs("30m"), DEFAULT_ACTIVE_MS);
+		assert.equal(parseDurationMs("1h"), 60 * 60 * 1000);
+		assert.equal(parseDurationMs("2h"), 2 * 60 * 60 * 1000);
+		assert.equal(parseDurationMs("90"), 90 * 60 * 1000);
+		assert.equal(parseDurationMs("forever"), 0);
+		assert.deepEqual(parseCacheWarmArgs("duration 1h"), { action: "duration", durationMs: 60 * 60 * 1000 });
+		assert.deepEqual(parseCacheWarmArgs("30m"), { action: "duration", durationMs: DEFAULT_ACTIVE_MS });
 	});
 
 	it("separates pending dispatch from confirmed attempts", () => {
@@ -167,6 +182,38 @@ describe("commands and dispatch state", () => {
 		assert.deepEqual(confirmWarmDispatch(state, stale[0].id), { confirmed: true, abort: true });
 		assert.ok(state.warmRunActive);
 		assert.equal(state.metrics.warmAttempts, 2);
+	});
+
+	it("clears a suppressed epoch when /cache-warm on is issued while already enabled", () => {
+		const state = createWarmState();
+		const selectedModel = model();
+		state.modelKey = "openai/test-model";
+		seedCache(state, 1_000, selectedModel);
+		const pingAt = 1_000 + CACHE_TTL_MS - 30_000;
+		beginWarmDispatch(state, pingAt, selectedModel);
+		failPendingDispatch(state);
+		assert.equal(shouldSendWarmPing(gate(state, pingAt)), false);
+		assert.equal(setEnabled(state, true), false);
+		assert.equal(state.suppressedEpoch, undefined);
+		assert.equal(shouldSendWarmPing(gate(state, pingAt)), true);
+	});
+
+	it("stops warming after the idle duration and resumes on a user turn", () => {
+		const state = createWarmState();
+		const selectedModel = model();
+		state.modelKey = "openai/test-model";
+		const pingAt = 1_000 + CACHE_TTL_MS - 30_000;
+		seedCache(state, 1_000, selectedModel);
+		setActiveMs(state, 10 * 60_000);
+		noteExternalInput(state, 1_000);
+		assert.equal(shouldSendWarmPing(gate(state, pingAt)), true);
+
+		setActiveMs(state, 60_000);
+		assert.equal(shouldSendWarmPing(gate(state, pingAt)), false);
+		assert.match(formatStatusReport(state, pingAt), /idle limit: 0:00 of 1m remaining/);
+
+		noteExternalInput(state, pingAt);
+		assert.equal(shouldSendWarmPing(gate(state, pingAt)), true);
 	});
 });
 
@@ -607,6 +654,7 @@ describe("extension event wiring", { concurrency: false }, () => {
 		const harness = createHarness();
 		await harness.start();
 		assert.match(await harness.status(), /cache-warm: on/);
+		assert.equal(harness.unrefCalls, 1);
 		await harness.seed(1_000);
 		harness.tickAt(1_000 + CACHE_TTL_MS - 30_000);
 		assert.equal(harness.sent.length, 1);
@@ -715,6 +763,34 @@ describe("extension event wiring", { concurrency: false }, () => {
 		harness.restore();
 	});
 
+	it("auto-stops keep-alive after the configured idle duration", async () => {
+		const harness = createHarness();
+		await harness.start();
+		await harness.command("duration 1m");
+		assert.match(harness.notices.at(-1), /idle limit set to 1m/);
+		await harness.seed(1_000);
+		harness.tickAt(1_000 + 61_000);
+		assert.match(await harness.status(), /cache-warm: off/);
+		harness.tickAt(1_000 + CACHE_TTL_MS - 30_000);
+		assert.equal(harness.sent.length, 0);
+		harness.restore();
+	});
+
+	it("retries a failed send after /cache-warm on while already enabled", async () => {
+		const harness = createHarness({ sendThrows: true });
+		await harness.start();
+		await harness.seed(1_000);
+		const first = 1_000 + CACHE_TTL_MS - 30_000;
+		harness.tickAt(first);
+		assert.equal(harness.sendCalls, 1);
+		harness.tickAt(first + 10_000);
+		assert.equal(harness.sendCalls, 1);
+		await harness.command("on");
+		harness.tickAt(first + 11_000);
+		assert.equal(harness.sendCalls, 2);
+		harness.restore();
+	});
+
 	it("keeps active tool blocking on disable/model change and clears on shutdown", async () => {
 		const harness = createHarness();
 		await harness.startAndEnable();
@@ -748,12 +824,18 @@ function createHarness(options = {}) {
 	let commandHandler;
 	let timerCallback;
 	let now = 0;
+	let unrefCalls = 0;
 	const originalSetInterval = globalThis.setInterval;
 	const originalClearInterval = globalThis.clearInterval;
 	const originalDateNow = Date.now;
 	globalThis.setInterval = (callback) => {
 		timerCallback = callback;
-		return { fake: true };
+		return {
+			fake: true,
+			unref() {
+				unrefCalls += 1;
+			},
+		};
 	};
 	globalThis.clearInterval = () => {};
 	Date.now = () => now;
@@ -804,11 +886,15 @@ function createHarness(options = {}) {
 	return {
 		ctx,
 		sent,
+		notices,
 		get abortCount() {
 			return abortCount;
 		},
 		get sendCalls() {
 			return sendCalls;
+		},
+		get unrefCalls() {
+			return unrefCalls;
 		},
 		async start() {
 			await emit("session_start", { type: "session_start", reason: "startup" });

--- a/extensions/cache-warm/test/cache-warm.test.mjs
+++ b/extensions/cache-warm/test/cache-warm.test.mjs
@@ -92,8 +92,8 @@ function gate(state, now, overrides = {}) {
 }
 
 describe("commands and dispatch state", () => {
-	it("keeps warming off by default and parses easy toggles", () => {
-		assert.equal(createWarmState().enabled, false);
+	it("keeps warming on by default and parses easy toggles", () => {
+		assert.equal(createWarmState().enabled, true);
 		assert.equal(parseCacheWarmArgs(""), "toggle");
 		assert.equal(parseCacheWarmArgs("on"), "on");
 		assert.equal(parseCacheWarmArgs("disable"), "off");
@@ -581,7 +581,7 @@ describe("reset safety", () => {
 		resetSession(state);
 		assert.equal(state.warmRunActive, undefined);
 		assert.equal(state.dispatchPending, undefined);
-		assert.equal(state.enabled, false);
+		assert.equal(state.enabled, true);
 	});
 
 	it("quarantines pending work on model change and clears pending work on shutdown", () => {
@@ -603,6 +603,54 @@ describe("reset safety", () => {
 });
 
 describe("extension event wiring", { concurrency: false }, () => {
+	it("starts the keep-alive timer on session_start without an explicit enable", async () => {
+		const harness = createHarness();
+		await harness.start();
+		assert.match(await harness.status(), /cache-warm: on/);
+		await harness.seed(1_000);
+		harness.tickAt(1_000 + CACHE_TTL_MS - 30_000);
+		assert.equal(harness.sent.length, 1);
+		harness.restore();
+	});
+
+	it("lets /cache-warm off, on, and empty-args toggle keep-alive", async () => {
+		const harness = createHarness();
+		await harness.start();
+		assert.match(await harness.status(), /cache-warm: on/);
+
+		await harness.command("off");
+		assert.match(await harness.status(), /cache-warm: off/);
+
+		await harness.command("");
+		assert.match(await harness.status(), /cache-warm: on/);
+
+		await harness.command("");
+		assert.match(await harness.status(), /cache-warm: off/);
+
+		await harness.seed(1_000);
+		harness.tickAt(1_000 + CACHE_TTL_MS - 30_000);
+		assert.equal(harness.sent.length, 0);
+
+		await harness.command("on");
+		assert.match(await harness.status(), /cache-warm: on/);
+		harness.tickAt(1_000 + CACHE_TTL_MS - 29_000);
+		assert.equal(harness.sent.length, 1);
+		harness.restore();
+	});
+
+	it("restores keep-alive after session_shutdown in the same process", async () => {
+		const harness = createHarness();
+		await harness.start();
+		await harness.command("off");
+		await harness.emit("session_shutdown", { type: "session_shutdown", reason: "quit" });
+		await harness.start();
+		assert.match(await harness.status(), /cache-warm: on/);
+		await harness.seed(1_000);
+		harness.tickAt(1_000 + CACHE_TTL_MS - 30_000);
+		assert.equal(harness.sent.length, 1);
+		harness.restore();
+	});
+
 	it("hands off an interrupted warm run at Pi's queued user boundary", async () => {
 		const harness = createHarness();
 		await harness.startAndEnable();
@@ -762,6 +810,9 @@ function createHarness(options = {}) {
 		get sendCalls() {
 			return sendCalls;
 		},
+		async start() {
+			await emit("session_start", { type: "session_start", reason: "startup" });
+		},
 		async startAndEnable() {
 			await emit("session_start", { type: "session_start", reason: "startup" });
 			await commandHandler("on", ctx);
@@ -788,6 +839,10 @@ function createHarness(options = {}) {
 		},
 		async metrics() {
 			await commandHandler("metrics", ctx);
+			return notices.at(-1);
+		},
+		async status() {
+			await commandHandler("status", ctx);
 			return notices.at(-1);
 		},
 		emit,


### PR DESCRIPTION
Closes #55

## Summary

Cache-warm keep-alive now starts enabled on new sessions, so installing the extension or opening a session no longer requires `/cache-warm on` before the tick timer can fire. Users can still turn it off, back on, or toggle it, and status plus docs describe the new default.

## Approach

Default-on keep-alive — flip the factory and session-reset `enabled` flag to true, and start the tick timer from `session_start` when keep-alive is enabled. Command paths (`on` / `off` / toggle / status) stay unchanged. Enabled state remains in-memory only.

## Decision Record

- **Root cause:** Keep-alive defaulted off in two places: `createWarmState()` and `resetSession()` set `enabled: false`, and `session_start` never started the tick timer (`startTimer()` ran only from `enable()`, which required `/cache-warm on`).
- **Options considered:** Option 1 — Default-on keep-alive
- **Options rejected:** n/a — trivial change, direct plan (light profile)
- **Selected option:** Option 1 — Default-on keep-alive
- **Residual risk:** Enabled state is still in-memory only, so `/cache-warm off` does not persist across process restarts (same as before). New sessions still do not bill immediately: pings require idle session, no queued messages, observed cache activity, and remaining TTL under 60s.
- **Effort profile:** light — fast path (pre-work Effort S); synthesis skipped, QA capped at 1 cycle

Analyzed at: `refactor/55-enable-cache-warm-extension-by @ 304d712` (2026-08-23)

## Changes

| File | Change |
|------|--------|
| `extensions/cache-warm/src/warm.ts` | Factory and `resetSession()` default `enabled` to true |
| `extensions/cache-warm/src/index.ts` | `session_start` starts the tick timer when enabled |
| `extensions/cache-warm/test/cache-warm.test.mjs` | Default-on, session-start ping, off/on/toggle, same-process restart |
| `extensions/cache-warm/README.md` | Document default-on and `/cache-warm off` |
| `extensions/cache-warm/package.json` | Description no longer says opt-in |
| `README.md` | Catalog and details: keep-alive on by default |
| `docs/DEVELOPMENT.md` | `session_start` starts the timer; off stops it |
| `CHANGELOG.md` | Unreleased **Changed** entry for #55 |

## Test Results

- Unit tests: 35 passed (`extensions/cache-warm` `npm test`: tsc + node --test)
- Integration tests: skipped — covered by the extension harness in the same suite
- E2e tests: skipped — no e2e framework
- Build: passed
- QA cycles: 1

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Cache-warm keep-alive is active by default on new sessions without requiring `/cache-warm on`. | pass | `createWarmState()`/`resetSession()` set `enabled: true`; `session_start` calls `startTimer()`; test `starts the keep-alive timer on session_start without an explicit enable` |
| Users can still disable, re-enable, and toggle keep-alive via `/cache-warm off`, `/cache-warm on`, and `/cache-warm` toggle. | pass | Command handler unchanged; test `lets /cache-warm off, on, and empty-args toggle keep-alive` |
| Status and documentation reflect the enabled-by-default behavior (e.g., README and `/cache-warm status` output). | pass | Status reports `cache-warm: on` after `session_start`; README, DEVELOPMENT.md, CHANGELOG, package description updated |

<!-- gitissue:qa v1 head=304d71281536f90c7fb1edda45cb56fc99143554 profile=light cycles=1 review=clean ui=none -->
