### PR TITLE
docs: CLI-bridge ToS analysis and grok-pi 1.4.0

### DIFF
--- a/extensions/agy-pi/README.md
+++ b/extensions/agy-pi/README.md
@@ -69,6 +69,25 @@ pi -e ./extensions/agy-pi
 
 Reload Pi (`/reload`) after installing.
 
+## Terms of service analysis
+
+This extension uses the **subprocess-delegation pattern**: every model turn spawns the real `agy` CLI binary (`agy --model <id> -p <prompt>`); it never reads OAuth tokens or session credentials itself, and never talks to any model backend over HTTP directly.
+
+Checked against Google's actual published terms for Antigravity (the product behind the `agy` CLI):
+
+| Provision | Source | How this extension relates |
+|---|---|---|
+| "Using third party software, tools, or services to access the Service … is a breach of this Agreement" | [Google Antigravity Additional Terms of Service](https://antigravity.google/terms), §6 — explicitly citing "using OpenClaw with Antigravity OAuth" as a breach | ⚠️ **Nuanced.** The extension itself is third-party software, but it does *not* use Antigravity OAuth tokens outside the CLI — it invokes the official `agy` binary, so authentication and all API access stay inside Google's own client. This is materially different from the OpenClaw example Google names. Still, Pi driving `agy` headlessly per turn is automated use of the Service through a wrapper, and Google's clause is written broadly enough that enforcement discretion is Google's. |
+| Interaction data recording / training use | Same terms, §3 & §5 | ℹ️ Not a compliance issue for the extension, but your prompts sent through `agy` may be recorded and used by Google unless you change the data-use preference in settings. |
+| Third-party/open-source models (incl. Anthropic) | Same terms, §8 — binds you to [Anthropic's Commercial Terms](https://www.anthropic.com/legal/commercial-terms) when selecting Claude models | ⚠️ If you pick Claude Sonnet through `agy`, Anthropic's commercial terms apply to that usage; ensure the credential behind it is an **API key**, not a consumer-subscription token routed outside its intended surface. |
+| No abuse/interference with the Service | Same terms, §6 opening clause | ✅ The extension runs the unmodified binary with normal print mode; no spoofing, no credential extraction. |
+
+### Conclusion
+
+**Low risk for personal use, but not zero-risk.** Unlike token-extraction bridges, agy-pi keeps authentication inside Google's official binary — the pattern Google's §6 targets is reusing Antigravity OAuth in non-Google clients, which this extension does not do. However, Google's "third-party tools accessing the Service" language is broad, and scripted/headless `agy -p` driven by an external agent could still fall under it if Google chooses to enforce strictly. Safer paths for heavy automation: authenticate `agy` with an **API key** (Gemini Enterprise Agent Platform) rather than personal-account OAuth, and be aware prompts may be logged/trained on unless opted out.
+
+*Last reviewed August 25, 2026 against antigravity.google/terms; terms may change.*
+
 ## License
 
 MIT

--- a/extensions/agy-pi/README.md
+++ b/extensions/agy-pi/README.md
@@ -1,6 +1,6 @@
 # agy-pi
 
-Bridge [agy](https://github.com/earendil-works/agy) CLI Gemini models into Pi Coding Agent.
+Bridge [agy](https://github.com/google-antigravity/antigravity-cli) CLI Gemini models into Pi Coding Agent.
 
 ![agy-pi — Gemini 3.7 Flash via agy CLI in a Pi session](../../assets/agy-pi.png)
 

--- a/extensions/claude-code-pi/README.md
+++ b/extensions/claude-code-pi/README.md
@@ -122,3 +122,28 @@ The extension disables Claude Code's own tools with `--tools ""`. Pi tool schema
 - This is slower than native HTTP providers because a `claude -p` process starts for each model turn.
 - Tool calling is prompt-bridged with `<pi_tool_call>{...}</pi_tool_call>` markers, so it is less reliable than native provider tool calling but still keeps execution in Pi.
 - Image input requires the stream-json transport and is supported for base64 image blocks; availability checks use `claude --version`, so real model calls may still fail if local Claude Code auth or account access is not configured.
+
+## Anthropic terms of service analysis
+
+A review of this extension's architecture against Anthropic's Consumer Terms of Service (§3.7), Commercial Terms of Service, and the Claude Code legal/compliance documentation (including the January–June 2026 enforcement wave and clarifications):
+
+| Rule | How this extension relates |
+|---|---|
+| No third-party harness spoofing / OAuth token extraction | ✅ **Compliant** — spawns the genuine `claude` binary as a subprocess; never touches OAuth tokens, intercepts authentication, or impersonates the Claude Code harness |
+| Binary must not be modified; built-in auth must not be disabled | ✅ Runs the unmodified, published `claude` binary |
+| Subscription automation must go through official CLI surfaces | ⚠️ It *does* use the official CLI (`claude -p`), which Anthropic treats as first-party usage — but heavy headless/scripted `claude -p` on Pro/Max subscription auth is exactly the pattern Anthropic has flagged, and since June 2026 such usage draws from a dedicated Agent SDK credit pool rather than normal plan limits |
+| Third-party products may not intermediate Claude for end users | ⚠️ Fine as a personal tool run by the account owner; risky if distributed so that other users route their own subscriptions through it |
+
+### Conclusion
+
+**Safe for personal use with your own credentials.** The architecture deliberately does the compliant thing: a real `claude -p` subprocess per turn, no token extraction, no API fallback. This is the pattern Anthropic treats as first-party usage.
+
+**Residual risks:**
+
+1. **Subscription auth + heavy automated/headless use** matches the traffic pattern that led to account bans in early 2026, and now consumes the separate Agent SDK credit. Using an **Anthropic API key** inside Claude Code removes all ambiguity.
+2. **Distributing it to others** who route their Pro/Max subscriptions through it edges toward "third-party product intermediating Claude" — the line Anthropic actively enforces (see the OpenCode and OpenClaw enforcement actions).
+3. `--permission-mode dontAsk` means tool calls requested by the model execute through Pi without prompting — an operational safety consideration independent of the terms of service.
+
+**Verdict: safe for personal use with your own credentials; use an API key for heavy automation; do not ship it as a subscription-backed backend for other users.**
+
+*Last reviewed against Anthropic's legal documentation published August 2026; terms and enforcement practices may change.*

--- a/extensions/grok-pi/package.json
+++ b/extensions/grok-pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grok-pi",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Bridge Grok session models (Grok 4.6/4.5, Composer, Build) into Pi by spawning the official Grok CLI headless per turn",
   "type": "module",
   "main": "./src/index.ts",

--- a/extensions/opencode-pi/README.md
+++ b/extensions/opencode-pi/README.md
@@ -137,3 +137,22 @@ npm test
 - Image and reasoning support are advertised per model only when verbose discovery reports those capabilities. Models configured via `OPENCODE_PI_MODELS` start on conservative text-only, non-reasoning fallback metadata (no discovery call at startup) until `/opencode-pi update` runs discovery to enrich them; default (unconfigured) IDs fall back the same way if discovery fails.
 - Reasoning levels are exposed only for variants reported by OpenCode; models without variants do not claim selectable thinking levels.
 - If OpenCode ever attempts to use its own tools, the extension fails the turn instead of hiding it.
+
+## Terms of service analysis
+
+This extension uses the **subprocess-delegation pattern**: every model turn spawns the real `opencode` CLI binary (`opencode run`); it never reads OAuth tokens, session credentials, or auth files, and never calls any model backend over HTTP directly. The bundled default models are OpenCode's own **free models** that work without `opencode auth login` at all.
+
+Checked against OpenCode's actual published terms ([Terms of Use](https://opencode.ai/legal/terms-of-service), eff. Aug 15, 2026, Anomaly Innovations):
+
+| Provision | Source | How this extension relates |
+|---|---|---|
+| Open source CLI governed by its license, not these Terms | Terms of Use, preamble: "our open source software that is not provided to you on a hosted basis is subject to the open source license" | ✅ The `opencode` agent is MIT-licensed; running it as a subprocess of Pi is ordinary use of open-source software |
+| No crawling/scraping the hosted Services | Terms of Use, restrictions §11 | ✅ Not applicable — the extension doesn't scrape anything |
+| Third-Party Models carry their own terms | "What about Third Party Models?" section | ⚠️ If you configure authenticated providers inside OpenCode (Zen paid models, or BYO keys), those providers' own terms apply — API keys are unambiguous; routing consumer-subscription quotas through automated headless use is where providers draw the line |
+| Free-model data collection | [OpenCode Zen docs](https://open-code.ai/en/docs/zen) | ℹ️ Not a compliance issue for the extension, but note: during their free period, Big Pickle, DeepSeek V4 Flash Free, MiMo-V2.5 Free and North Mini Code Free **may retain your prompts to improve the models** — don't send confidential data through them |
+
+### Conclusion
+
+**Safe — lowest-risk of the CLI-bridge extensions in this repo.** Real MIT-licensed binary subprocess, no credential extraction, no direct API calls, no subscription tokens involved. Two awareness items rather than risks: free Zen models may train on your inputs, and any *authenticated* provider configured inside OpenCode falls under that provider's terms instead.
+
+*Last reviewed August 25, 2026 against opencode.ai/legal/terms-of-service (eff. Aug 15, 2026); terms may change.*


### PR DESCRIPTION
Closes #60

## Summary
- Add Terms of service analysis sections to agy-pi, claude-code-pi, and opencode-pi READMEs.
- Bump grok-pi to 1.4.0 on this branch (grok-pi already documents a ToS posture from the CLI-subprocess rewrite).

## Test plan
- [ ] Skim the three new README sections for accuracy against current provider terms.
- [ ] Confirm grok-pi `package.json` version is 1.4.0.