### PR TITLE
feat(statusline-pi): notify at GPT 272k context (#61)

### DIFF
--- a/extensions/statusline-pi/README.md
+++ b/extensions/statusline-pi/README.md
@@ -39,6 +39,7 @@ Context zone icons change with usage:
 - Refreshes git change count and host CPU/memory usage every 5 seconds.
 - Shows **CPU** and **MEM** utilization for the local machine (`CPU 42% · MEM 68%`). CPU is derived from `os.cpus()` time deltas (omitted until the second sample). Memory is `(total - free) / total`. Colors follow the same thresholds as other indicators: default success, warning at ≥85%, error at ≥95%.
 - Shows average model response speed as output tokens per second (`tps`) across completed assistant responses.
+- Shows a warning when an OpenAI GPT model reaches 272,000 context tokens, the reported pricing breakpoint where the same token costs double. The warning is emitted once per threshold crossing.
 - Shows an **estimated accumulated session cost** in USD, summed from each assistant response's token usage (`input`, `output`, `cache-read`, `cache-write`) and the active model's per-million token rates from Pi's model catalog (aligned with [pi.dev/models](https://pi.dev/models)). This is an estimate only—actual billing may differ by provider, discounts, or OAuth subscriptions.
 - Updates the cost after each assistant response and when you switch models; omits the cost segment when the active model has no pricing, and displays `cost ?` when usage was reported without a computable price.
 - Includes the active assistant response in the average while it is streaming, then keeps the completed average visible while idle.

--- a/extensions/statusline-pi/src/index.ts
+++ b/extensions/statusline-pi/src/index.ts
@@ -49,6 +49,32 @@ const SPEED_RENDER_THROTTLE_MS = 250;
 const NARROW_BRANCH_WIDTH_RATIO = 0.55;
 const MIN_NARROW_BRANCH_WIDTH = 8;
 
+interface ModelIdentity {
+	provider?: string;
+	id?: string;
+}
+
+export const GPT_CONTEXT_PRICE_BREAKPOINT_TOKENS = 272_000;
+
+export function isGptModel(model: ModelIdentity | undefined): boolean {
+	const provider = model?.provider?.toLowerCase();
+	const modelId = model?.id?.replace(/^models\//, "").toLowerCase();
+
+	return (provider === "openai" || provider === "openai-codex") && modelId?.startsWith("gpt-") === true;
+}
+
+export function shouldNotifyGptContextBreakpoint(
+	model: ModelIdentity | undefined,
+	usedTokens: number,
+	notified: boolean,
+): boolean {
+	return !notified && isGptModel(model) && Number.isFinite(usedTokens) && usedTokens >= GPT_CONTEXT_PRICE_BREAKPOINT_TOKENS;
+}
+
+export function formatGptContextBreakpointNotice(): string {
+	return "GPT context reached 272,000 tokens — OpenAI pricing breakpoint: the same token costs double.";
+}
+
 export default function statuslinePiExtension(pi: ExtensionAPI) {
 	let enabled = true;
 	let gitInfo: GitInfo = { changedFiles: 0 };
@@ -65,10 +91,12 @@ export default function statuslinePiExtension(pi: ExtensionAPI) {
 	let sessionCost = createEmptySessionCostState();
 	let cpuSampler: CpuSampler = createCpuSampler();
 	let systemUsage: SystemUsageSnapshot = refreshSystemUsage(cpuSampler);
+	let notifiedGptContextBreakpoint = false;
 
 	pi.on("session_start", async (_event, ctx) => {
 		if (!ctx.hasUI) return;
 		mount(ctx);
+		maybeNotifyGptContextBreakpoint(ctx);
 	});
 
 	pi.on("session_shutdown", async () => {
@@ -79,20 +107,24 @@ export default function statuslinePiExtension(pi: ExtensionAPI) {
 		sessionCost = createEmptySessionCostState();
 		cpuSampler = createCpuSampler();
 		systemUsage = refreshSystemUsage(cpuSampler);
+		notifiedGptContextBreakpoint = false;
 	});
 
 	pi.on("model_select", async (_event, ctx) => {
 		resetResponseSpeed();
 		sessionCost = aggregateSessionCostFromContext(ctx);
+		notifiedGptContextBreakpoint = false;
+		maybeNotifyGptContextBreakpoint(ctx);
 		requestRender();
 	});
 	pi.on("thinking_level_select", async (_event, _ctx) => {
 		resetResponseSpeed();
 		requestRender();
 	});
-	pi.on("message_start", async (event, _ctx) => {
+	pi.on("message_start", async (event, ctx) => {
 		if (event.message.role !== "assistant") return;
 
+		maybeNotifyGptContextBreakpoint(ctx);
 		responseStartMs = Date.now();
 		liveOutputTokenEstimate = 0;
 		responseSpeed = getAverageResponseSpeed(completedResponseSpeed, {
@@ -102,8 +134,10 @@ export default function statuslinePiExtension(pi: ExtensionAPI) {
 		});
 		requestRender();
 	});
-	pi.on("message_update", async (event, _ctx) => {
-		if (event.message.role !== "assistant" || responseStartMs === undefined) return;
+	pi.on("message_update", async (event, ctx) => {
+		if (event.message.role !== "assistant") return;
+		maybeNotifyGptContextBreakpoint(ctx);
+		if (responseStartMs === undefined) return;
 
 		const streamEvent = event.assistantMessageEvent;
 		if (
@@ -123,6 +157,7 @@ export default function statuslinePiExtension(pi: ExtensionAPI) {
 		requestSpeedRender();
 	});
 	pi.on("message_end", async (event, ctx) => {
+		maybeNotifyGptContextBreakpoint(ctx);
 		if (event.message.role !== "assistant") {
 			requestRender();
 			return;
@@ -140,6 +175,7 @@ export default function statuslinePiExtension(pi: ExtensionAPI) {
 		requestRender();
 	});
 	pi.on("tool_result", async (_event, ctx) => {
+		maybeNotifyGptContextBreakpoint(ctx);
 		refreshGit(ctx.cwd, { forceGit: true });
 		requestRender();
 	});
@@ -243,7 +279,23 @@ export default function statuslinePiExtension(pi: ExtensionAPI) {
 		if (refreshTimer) clearInterval(refreshTimer);
 		refreshTimer = undefined;
 		renderRequested = undefined;
+		notifiedGptContextBreakpoint = false;
 		ctx.ui.setFooter(undefined);
+	}
+
+	function maybeNotifyGptContextBreakpoint(ctx: ExtensionContext): void {
+		if (!enabled || !ctx.hasUI) return;
+
+		const { usedTokens } = getUsage(ctx);
+		if (!isGptModel(ctx.model) || usedTokens < GPT_CONTEXT_PRICE_BREAKPOINT_TOKENS) {
+			notifiedGptContextBreakpoint = false;
+			return;
+		}
+
+		if (!shouldNotifyGptContextBreakpoint(ctx.model, usedTokens, notifiedGptContextBreakpoint)) return;
+
+		notifiedGptContextBreakpoint = true;
+		ctx.ui.notify(formatGptContextBreakpointNotice(), "warning");
 	}
 
 	function requestRender(): void {

--- a/extensions/statusline-pi/test/context-notification.test.mjs
+++ b/extensions/statusline-pi/test/context-notification.test.mjs
@@ -1,0 +1,122 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import statuslinePiExtension, {
+	GPT_CONTEXT_PRICE_BREAKPOINT_TOKENS,
+	formatGptContextBreakpointNotice,
+	isGptModel,
+	shouldNotifyGptContextBreakpoint,
+} from "../dist/index.js";
+
+function createHarness({ model = { provider: "openai", id: "gpt-5.5", contextWindow: 1_000_000 }, tokens = 0 } = {}) {
+	const handlers = new Map();
+	const notifications = [];
+	let usedTokens = tokens;
+	const resolvedModel = model === undefined
+		? undefined
+		: {
+			...model,
+			cost: model.cost ?? { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		};
+	const pi = {
+		on(event, handler) {
+			handlers.set(event, handler);
+		},
+		registerCommand() {},
+		getThinkingLevel() {
+			return "off";
+		},
+	};
+	const ctx = {
+		hasUI: true,
+		model: resolvedModel,
+		ui: {
+			notify(message, type) {
+				notifications.push({ message, type });
+			},
+		},
+		getContextUsage() {
+			return usedTokens === undefined ? undefined : { tokens: usedTokens };
+		},
+		sessionManager: {
+			getBranch() {
+				return [];
+			},
+		},
+	};
+
+	statuslinePiExtension(pi);
+
+	return {
+		ctx,
+		notifications,
+		messageEnd: handlers.get("message_end"),
+		setTokens(value) {
+			usedTokens = value;
+		},
+	};
+}
+
+function assistantMessage() {
+	return {
+		role: "assistant",
+		content: [],
+		usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	};
+}
+
+describe("GPT context pricing breakpoint", () => {
+	it("recognizes OpenAI GPT models and excludes other model families", () => {
+		assert.equal(isGptModel({ provider: "openai", id: "gpt-5.5" }), true);
+		assert.equal(isGptModel({ provider: "openai-codex", id: "models/gpt-5.6-sol" }), true);
+		assert.equal(isGptModel({ provider: "anthropic", id: "claude-sonnet-4" }), false);
+		assert.equal(isGptModel({ provider: "openai", id: "o3" }), false);
+		assert.equal(isGptModel(undefined), false);
+	});
+
+	it("notifies at the threshold but not below it or twice for the same crossing", () => {
+		const model = { provider: "openai", id: "gpt-5.5" };
+
+		assert.equal(shouldNotifyGptContextBreakpoint(model, GPT_CONTEXT_PRICE_BREAKPOINT_TOKENS - 1, false), false);
+		assert.equal(shouldNotifyGptContextBreakpoint(model, GPT_CONTEXT_PRICE_BREAKPOINT_TOKENS, false), true);
+		assert.equal(shouldNotifyGptContextBreakpoint(model, GPT_CONTEXT_PRICE_BREAKPOINT_TOKENS + 1, true), false);
+		assert.equal(shouldNotifyGptContextBreakpoint(undefined, GPT_CONTEXT_PRICE_BREAKPOINT_TOKENS, false), false);
+		assert.equal(shouldNotifyGptContextBreakpoint(model, Number.NaN, false), false);
+	});
+
+	it("describes the threshold and doubled-price impact", () => {
+		assert.match(formatGptContextBreakpointNotice(), /272,000/);
+		assert.match(formatGptContextBreakpointNotice(), /pricing breakpoint/);
+		assert.match(formatGptContextBreakpointNotice(), /costs double/);
+	});
+
+	it("notifies once for repeated events and allows a later threshold crossing", async () => {
+		const harness = createHarness({ tokens: GPT_CONTEXT_PRICE_BREAKPOINT_TOKENS - 1 });
+
+		await harness.messageEnd({ message: assistantMessage() }, harness.ctx);
+		harness.setTokens(GPT_CONTEXT_PRICE_BREAKPOINT_TOKENS);
+		await harness.messageEnd({ message: assistantMessage() }, harness.ctx);
+		harness.setTokens(GPT_CONTEXT_PRICE_BREAKPOINT_TOKENS + 1);
+		await harness.messageEnd({ message: assistantMessage() }, harness.ctx);
+
+		assert.equal(harness.notifications.length, 1);
+		assert.equal(harness.notifications[0].type, "warning");
+		assert.match(harness.notifications[0].message, /272,000/);
+		assert.match(harness.notifications[0].message, /costs double/);
+
+		harness.setTokens(0);
+		await harness.messageEnd({ message: assistantMessage() }, harness.ctx);
+		harness.setTokens(GPT_CONTEXT_PRICE_BREAKPOINT_TOKENS);
+		await harness.messageEnd({ message: assistantMessage() }, harness.ctx);
+		assert.equal(harness.notifications.length, 2);
+	});
+
+	it("does not notify for non-GPT or missing model/usage metadata", async () => {
+		const nonGpt = createHarness({ model: { provider: "anthropic", id: "claude-sonnet-4" }, tokens: GPT_CONTEXT_PRICE_BREAKPOINT_TOKENS });
+		await nonGpt.messageEnd({ message: assistantMessage() }, nonGpt.ctx);
+		assert.deepEqual(nonGpt.notifications, []);
+
+		const missingMetadata = createHarness({ model: undefined, tokens: undefined });
+		await missingMetadata.messageEnd({ message: assistantMessage() }, missingMetadata.ctx);
+		assert.deepEqual(missingMetadata.notifications, []);
+	});
+});


### PR DESCRIPTION
Closes #61

## Summary

Add a warning in statusline-pi when an OpenAI GPT model reaches 272,000 context tokens, the reported pricing breakpoint where the same token costs double.

## Approach

Option 1 — Direct minimal threshold notification: reuse statusline-pi's existing context-usage data and UI notification mechanism, with provider/model gating and one notification per threshold crossing.

## Decision Record

- **Root cause:** statusline-pi displayed remaining context and already supported one-shot UI notifications, but it had no threshold notification connecting GPT context usage to the reported OpenAI pricing breakpoint.
- **Options considered:** Option 1 — Direct minimal threshold notification; Option 2 — n/a; Option 3 — n/a
- **Options rejected:** n/a — trivial change, direct plan (light profile)
- **Selected option:** Option 1 — Direct minimal threshold notification
- **Residual risk:** Provider aliases outside the extension's supported OpenAI/OpenAI-Codex model metadata are not classified as GPT and will not trigger this warning.
- **Effort profile:** light — fast path (pre-work Effort S); synthesis skipped, QA capped at 1 cycle

Analyzed at: `feat/61-notify-when-gpt-context-reaches-272k @ dff6496` (2026-08-28)

## Changes

| File | Change |
|------|--------|
| `extensions/statusline-pi/src/index.ts` | Add GPT model detection, the 272,000-token threshold, one-shot warning state, and lifecycle checks. |
| `extensions/statusline-pi/test/context-notification.test.mjs` | Cover model scope, boundary behavior, repeated events, reset behavior, wording, and missing metadata. |
| `extensions/statusline-pi/README.md` | Document the new GPT context pricing warning. |

## Test Results

- Unit tests: 23 passed
- Integration tests: skipped — no integration framework
- E2e tests: skipped — no e2e framework
- Build: passed
- QA cycles: 1

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| For GPT models, a distinct notification appears when context usage reaches 272,000 tokens. | pass | `extensions/statusline-pi/src/index.ts`; `context-notification.test.mjs` boundary tests |
| The notification identifies 272,000 tokens as the OpenAI pricing breakpoint. | pass | `formatGptContextBreakpointNotice`; wording test |
| The notification explains the reported double-price impact for the same token at this breakpoint. | pass | Notice wording assertion in `context-notification.test.mjs` |
| Non-GPT model sessions do not display this GPT-specific notification. | pass | Provider/model exclusion tests in `context-notification.test.mjs` |

<!-- gitissue:qa v1 head=dff649605409ccdfc2d734a9b7e1c54c8fa8b7bd profile=light cycles=1 review=clean ui=code:clean@dff649605409ccdfc2d734a9b7e1c54c8fa8b7bd -->