### PR TITLE
fix(grok-pi): use --prompt-file to avoid Windows ENAMETOOLONG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **grok-pi 1.4.1**: Windows turns no longer pass Pi's full prompt as `grok --single` argv. CreateProcess caps the command line at ~32KB, so even a one-word message hit `spawn ENAMETOOLONG` and grok-pi misreported it as a missing Grok CLI. Turns now write the prompt to a temp file and invoke `grok --prompt-file`. Also treat `~/.grok/bin/grok.exe` as an installed CLI, and prefer that path when `GROK_PI_BIN` is unset on Windows.
+
 ### Changed
 
 - **grok-pi 1.3.0**: Rewritten as a strict CLI-subprocess bridge — every model turn now spawns the official `grok --single … --tools "" --disable-web-search --permission-mode dontAsk --output-format json` binary instead of calling xAI's CLI proxy over HTTP with tokens extracted from `~/.grok/auth.json`. The extension no longer reads, refreshes, or spoofs any credentials or client headers (removes `bin/grok-api-key`, `bin/grok-client-version`, `bin/grok-user-agent`, `bin/grok-usage` and the direct billing API `/grok-pi usage` command), resolving the Acceptable Use Policy bot-access and bypass-clause exposure; real token usage/cost is parsed from the CLI's JSON output, thinking levels map to `--effort`, and tool calls remain prompt-bridged `<pi_tool_call>` markers executed by Pi.

--- a/extensions/grok-pi/README.md
+++ b/extensions/grok-pi/README.md
@@ -4,7 +4,7 @@ Use **Grok CLI session models** inside **Pi Coding Agent** — including **Grok 
 
 ![grok-pi screenshot](../../assets/grok-pi.png)
 
-This extension registers a Pi provider named `grok-cli` that runs your existing, logged-in **Grok CLI** in its own supported single-turn mode: every model turn spawns the real `grok --single …` binary. Authentication, token refresh, client headers, and telemetry stay entirely inside the official CLI — this extension never reads credentials or talks to xAI endpoints over HTTP itself. It is **not** the official xAI API-key provider (`xai` / `XAI_API_KEY`).
+This extension registers a Pi provider named `grok-cli` that runs your existing, logged-in **Grok CLI** in its own supported single-turn mode: every model turn writes the prompt to a temp file and spawns the real `grok --prompt-file …` binary. Authentication, token refresh, client headers, and telemetry stay entirely inside the official CLI — this extension never reads credentials or talks to xAI endpoints over HTTP itself. It is **not** the official xAI API-key provider (`xai` / `XAI_API_KEY`).
 
 ## What you get
 
@@ -19,7 +19,7 @@ Model metadata is read from the CLI's own `~/.grok/models_cache.json` when prese
 
 ### Image input — known limitation
 
-Models such as Grok 4.x and Grok Build advertise **image input**, but this bridge cannot transmit images: `grok --single` accepts a plain-text prompt only. Any image attached in a Pi conversation is replaced with an `[image omitted: <mime type>]` placeholder before reaching the model, and grok-pi prints a one-time warning per session so degraded turns are explicit rather than silent. Send the relevant content as text (or paste file contents) instead of screenshots when using this provider.
+Models such as Grok 4.x and Grok Build advertise **image input**, but this bridge cannot transmit images: the grok CLI headless prompt is plain text only. Any image attached in a Pi conversation is replaced with an `[image omitted: <mime type>]` placeholder before reaching the model, and grok-pi prints a one-time warning per session so degraded turns are explicit rather than silent. Send the relevant content as text (or paste file contents) instead of screenshots when using this provider.
 
 ### Environment variables
 
@@ -117,6 +117,7 @@ On session start you should see an info notification that `grok-cli` was registe
 | `grok-pi: Grok CLI not found (~/.grok missing)` | Install Grok CLI (https://x.ai/grok), then `/reload` |
 | `grok-pi: Grok CLI is installed but ~/.grok/auth.json is missing` | Run `grok login`, then `/reload` |
 | `grok --single exited with code 1` | Run the same command directly to see the CLI's error; re-authenticate with `grok login` if needed |
+| `spawn ENAMETOOLONG` / “could not use the local Grok CLI” on Windows | Upgrade grok-pi to 1.4.1+. Turns must use `grok --prompt-file`; putting Pi's prompt on `grok --single` exceeds Windows' ~32KB command-line limit |
 | Models missing in Pi | `/reload`, then `pi --list-models grok-cli` |
 
 Inside Pi:
@@ -200,14 +201,14 @@ pi -p --no-session \
 
 The extension calls `pi.registerProvider("grok-cli", …)` with a custom API that spawns the **official Grok binary** for each turn:
 
-- **Transport:** local subprocess `grok --single "<turn>" --output-format json`
+- **Transport:** local subprocess `grok --prompt-file <temp> --output-format json` (avoids Windows `CreateProcess` argv length limits; `--single` is kept only for short smoke tests)
 - **Own Grok tools:** disabled via `--tools ""` + `--disable-web-search`, so Pi executes all real file/shell/network/MCP actions (tool calls travel as `<pi_tool_call>` blocks in the prompt text)
 - **Permissions:** `--permission-mode dontAsk` (no interactive prompts possible)
 - **Auth:** handled entirely inside the Grok CLI; no tokens are read, refreshed, or replayed by this extension
 - **Response parsing:** the JSON payload's `text`, `usage`, and `total_cost_usd` feed Pi's message and usage accounting
 - **Context:** prior messages, the system prompt, tool schemas, and past tool results are serialized into the single-turn prompt (same approach as `claude-code-pi`)
 
-Each spawned `grok --single` run is normal CLI usage from xAI's perspective — genuine binary, genuine headers, first-party telemetry. Note that the CLI persists a small session record under `~/.grok/sessions` per turn (its own default behavior); there is no supported flag to suppress this.
+Each spawned grok run is normal CLI usage from xAI's perspective — genuine binary, genuine headers, first-party telemetry. Note that the CLI persists a small session record under `~/.grok/sessions` per turn (its own default behavior); there is no supported flag to suppress this.
 
 ## Files in this extension
 

--- a/extensions/grok-pi/package.json
+++ b/extensions/grok-pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grok-pi",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Bridge Grok session models (Grok 4.6/4.5, Composer, Build) into Pi by spawning the official Grok CLI headless per turn",
   "type": "module",
   "main": "./src/index.ts",

--- a/extensions/grok-pi/src/bridge.ts
+++ b/extensions/grok-pi/src/bridge.ts
@@ -15,8 +15,8 @@ import {
 } from "@earendil-works/pi-ai";
 import { appendCapped, appendStdout, buildGrokArgs, buildPrompt, parseGrokCliOutput, smokeTestCommand, splitResponse } from "./cli.js";
 import { buildProviderModels, modelsFromCache, supportedThinkingLevels, type GrokModelInfo, type GrokModelsCache } from "./models.js";
-import { existsSync, readFileSync } from "node:fs";
-import { homedir } from "node:os";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 
 export const PROVIDER_ID = "grok-cli";
@@ -35,7 +35,13 @@ export function modelsCachePath(): string {
 }
 
 export function grokBin(): string {
-	return process.env.GROK_PI_BIN?.trim() || "grok";
+	const override = process.env.GROK_PI_BIN?.trim();
+	if (override) return override;
+	if (process.platform === "win32") {
+		const exe = join(grokHome(), "bin", "grok.exe");
+		if (existsSync(exe)) return exe;
+	}
+	return "grok";
 }
 
 function requestTimeoutMs(): number {
@@ -207,10 +213,10 @@ function setEstimatedUsage(model: Model<Api>, output: AssistantMessage, prompt: 
 }
 
 /**
- * Stream one grok model turn by spawning the official `grok --single`
- * headless mode. Auth, token refresh, headers, and telemetry stay entirely
- * inside the real binary — this extension never reads credentials or talks
- * HTTP to xAI itself.
+ * Stream one grok model turn by spawning the official grok CLI in headless
+ * mode (`--prompt-file`). Auth, token refresh, headers, and telemetry stay
+ * entirely inside the real binary — this extension never reads credentials
+ * or talks HTTP to xAI itself.
  */
 export function streamGrokCli(
 	model: Model<Api>,
@@ -243,15 +249,20 @@ export function streamGrokCli(
 			if (abort) options?.signal?.removeEventListener("abort", abort);
 		};
 		let stdoutError: Error | undefined;
+		let promptDir: string | undefined;
 
 		try {
 			stream.push({ type: "start", partial: output });
-			const args = buildGrokArgs(model.id, options?.reasoning as string | undefined, prompt);
+			promptDir = mkdtempSync(join(tmpdir(), "grok-pi-"));
+			const promptPath = join(promptDir, "prompt.txt");
+			writeFileSync(promptPath, prompt, "utf8");
+			const args = buildGrokArgs(model.id, options?.reasoning as string | undefined, undefined, promptPath);
 
 			const child = spawn(grokBin(), args, {
 				stdio: ["pipe", "pipe", "pipe"],
 				env: { ...process.env },
 				detached: true,
+				windowsHide: true,
 			});
 
 			abort = () => killTree(child);
@@ -287,8 +298,8 @@ export function streamGrokCli(
 
 			if (stdoutError) throw stdoutError;
 			if (options?.signal?.aborted) throw new Error("Request was aborted");
-			if (timedOut) throw new Error(`grok --single timed out after ${timeout}ms`);
-			if (code !== 0) throw new Error(stderr.trim() || `grok --single exited with code ${code}`);
+			if (timedOut) throw new Error(`grok timed out after ${timeout}ms`);
+			if (code !== 0) throw new Error(stderr.trim() || `grok exited with code ${code}`);
 
 			const parsed = parseGrokCliOutput(stdout);
 			const responseText = parsed.text ?? "";
@@ -362,10 +373,18 @@ export function streamGrokCli(
 			output.errorMessage = aborted
 				? "Request was aborted"
 				: timedOut
-					? `grok --single timed out after ${timeout}ms`
+					? `grok timed out after ${timeout}ms`
 					: setupGuidance(rawMessage);
 			stream.push({ type: "error", reason: output.stopReason, error: output });
 			stream.end();
+		} finally {
+			if (promptDir) {
+				try {
+					rmSync(promptDir, { recursive: true, force: true });
+				} catch {
+					// temp prompt file is best-effort
+				}
+			}
 		}
 	})();
 
@@ -411,7 +430,7 @@ export function cliStatusLines(status: CliStatus, cachedModels?: GrokModelInfo[]
 	const lines = [
 		`Provider: ${PROVIDER_ID}`,
 		`Grok binary: ${grokBin()}`,
-		"Transport: strictly local `grok --single` per model turn",
+		"Transport: strictly local `grok --prompt-file` per model turn",
 		"Fallbacks: none (no direct HTTP, no header spoofing, no credential access)",
 		'Own Grok tools: disabled via --tools "" + --disable-web-search',
 		"Thinking: --effort mapped from Pi thinking levels (minimal→low … xhigh)",

--- a/extensions/grok-pi/src/cli.ts
+++ b/extensions/grok-pi/src/cli.ts
@@ -28,11 +28,18 @@ export function effortArg(level: string | undefined): string | undefined {
  * Build argv for one headless grok model turn.
  *
  * Every request spawns the real, unmodified `grok` binary in its own supported
- * single-turn mode (`--single`). Grok's own tools are disabled with
- * `--tools ""` (+ `--disable-web-search` for belt and braces) so Pi executes
- * all real file/shell/network/MCP actions; auth stays entirely inside the CLI.
+ * single-turn mode. Prefer `--prompt-file` over `--single`: Windows
+ * CreateProcess rejects argv over ~32KB (`spawn ENAMETOOLONG`), and Pi's
+ * system prompt plus tool schemas already exceed that. Grok's own tools are
+ * disabled with `--tools ""` (+ `--disable-web-search`) so Pi executes all
+ * real file/shell/network/MCP actions; auth stays entirely inside the CLI.
  */
-export function buildGrokArgs(modelId: string, thinkingLevel?: string, prompt?: string): string[] {
+export function buildGrokArgs(
+	modelId: string,
+	thinkingLevel?: string,
+	prompt?: string,
+	promptFile?: string,
+): string[] {
 	const args = [
 		"--output-format", "json",
 		"--permission-mode", "dontAsk",
@@ -42,7 +49,8 @@ export function buildGrokArgs(modelId: string, thinkingLevel?: string, prompt?: 
 	];
 	const effort = effortArg(thinkingLevel);
 	if (effort) args.push("--effort", effort);
-	if (prompt !== undefined) args.push("--single", prompt);
+	if (promptFile) args.push("--prompt-file", promptFile);
+	else if (prompt !== undefined) args.push("--single", prompt);
 	return args;
 }
 
@@ -125,7 +133,7 @@ export function buildPrompt(context: Pick<Context, "systemPrompt" | "messages" |
 	sections.push(`# Pi/Grok CLI bridge instructions
 
 You are being used as the model backend for Pi Coding Agent through the local Grok CLI in single-turn mode.
-The extension invokes the grok binary with \`--single\` for each model turn.
+The extension invokes the grok binary with \`--prompt-file\` for each model turn.
 Grok's own tools are disabled with \`--tools ""\`; Pi, not Grok, executes real file, shell, network, and MCP actions.
 
 If you need Pi to run a tool, output only one or more tool-call blocks and no prose:

--- a/extensions/grok-pi/src/harness.ts
+++ b/extensions/grok-pi/src/harness.ts
@@ -11,10 +11,12 @@ export function grokAuthPathIn(grokHome: string): string {
 }
 
 export function grokHarnessStateIn(grokHome: string): GrokHarnessState {
+	const binDir = join(grokHome, "bin");
 	return {
 		installed:
 			existsSync(grokAuthPathIn(grokHome)) ||
-			existsSync(join(grokHome, "bin", "grok")),
+			existsSync(join(binDir, "grok")) ||
+			existsSync(join(binDir, "grok.exe")),
 		authPresent: existsSync(grokAuthPathIn(grokHome)),
 	};
 }

--- a/extensions/grok-pi/src/index.ts
+++ b/extensions/grok-pi/src/index.ts
@@ -78,7 +78,7 @@ export default function grokPiExtension(pi: ExtensionAPI) {
 
 			if (sub === "help") {
 				ctx.ui.notify("Usage: /grok-pi [status|models|test|help]", "info");
-				ctx.ui.notify("Every model turn spawns the official `grok` CLI (`grok --single`); no direct HTTP calls.", "info");
+				ctx.ui.notify("Every model turn spawns the official `grok` CLI (`grok --prompt-file`); no direct HTTP calls.", "info");
 				ctx.ui.notify("Auth and token refresh stay inside the Grok CLI — this extension never reads ~/.grok/auth.json.", "info");
 				ctx.ui.notify(`Model metadata (read-only): ${modelsCachePath()}`, "info");
 				ctx.ui.notify("Set GROK_PI_BIN to override the grok executable.", "info");

--- a/extensions/grok-pi/test/cli.test.mjs
+++ b/extensions/grok-pi/test/cli.test.mjs
@@ -31,7 +31,17 @@ test("buildGrokArgs disables Grok's own tools and pins the model", () => {
 	assert.equal(args[args.indexOf("--model") + 1], "grok-4.6");
 	assert.equal(args[args.indexOf("--effort") + 1], "high");
 	assert.equal(args[args.indexOf("--single") + 1], "hello");
+	assert.ok(!args.includes("--prompt-file"));
 	assert.ok(!args.includes("--no-session-persistence"), "flag does not exist in the grok CLI");
+});
+
+test("buildGrokArgs prefers --prompt-file over --single", () => {
+	const args = buildGrokArgs("grok-4.6", "medium", "hello", "C:\\tmp\\prompt.txt");
+
+	assert.equal(args[args.indexOf("--prompt-file") + 1], "C:\\tmp\\prompt.txt");
+	assert.ok(!args.includes("--single"));
+	assert.ok(!args.includes("hello"));
+	assert.equal(args[args.indexOf("--effort") + 1], "medium");
 });
 
 test("effortArg maps Pi thinking levels to grok efforts", () => {
@@ -225,6 +235,7 @@ test("buildPrompt embeds system prompt, tools, and transcript", () => {
 	});
 
 	assert.match(prompt, /Pi\/Grok CLI bridge instructions/);
+	assert.match(prompt, /--prompt-file/);
 	assert.match(prompt, /--tools ""/);
 	assert.match(prompt, /# Pi system prompt\n\nBe terse\./);
 	assert.match(prompt, /"name": "read"/);

--- a/extensions/grok-pi/test/harness-checks.test.mjs
+++ b/extensions/grok-pi/test/harness-checks.test.mjs
@@ -56,6 +56,19 @@ test("grokHarnessStateIn distinguishes a CLI install without login", () => {
 	}
 });
 
+test("grokHarnessStateIn treats Windows grok.exe as an install", () => {
+	const grokHome = tempGrokHome();
+	try {
+		mkdirSync(join(grokHome, "bin"), { recursive: true });
+		writeFileSync(join(grokHome, "bin", "grok.exe"), "MZ", "utf8");
+		const state = grokHarnessStateIn(grokHome);
+		assert.deepEqual(state, { installed: true, authPresent: false });
+		assert.equal(grokReadinessLabel(state), "no (run `grok login`)");
+	} finally {
+		rmSync(grokHome, { recursive: true, force: true });
+	}
+});
+
 test("install guidance names the Grok CLI and the install URL", () => {
 	const guidance = grokInstallGuidance();
 	assert.match(guidance, /Grok CLI not found/);


### PR DESCRIPTION
## Summary

On Windows, grok-pi stuffed Pi's full system prompt + tool schemas into `grok --single <prompt>`. `CreateProcess` caps argv at ~32KB, so even a one-word turn failed with `spawn ENAMETOOLONG`. grok-pi then wrapped that as `could not use the local Grok CLI` / install Grok / check PATH.

## Fix

- Write the prompt to a temp file and invoke `grok --prompt-file` for every model turn (`--single` remains for short smoke tests).
- Treat `~/.grok/bin/grok.exe` as an installed CLI (Windows installer does not create an extensionless `bin/grok`).
- Prefer that `grok.exe` path when `GROK_PI_BIN` is unset on Windows.

Verified `grok --prompt-file` with grok 1.0.13 on Windows; `npm test` in `extensions/grok-pi` is 26/26.

## Test plan

- [x] `npm test` in `extensions/grok-pi`
- [x] `grok --prompt-file` headless JSON turn on Windows
- [ ] `/reload` grok-pi in Pi on Windows and send a one-word message via `grok-cli/grok-4.6`