### PR TITLE
test(grok-pi): cover prompt-file cleanup (#64)

### DIFF
--- a/extensions/grok-pi/test/bridge-lifecycle.test.mjs
+++ b/extensions/grok-pi/test/bridge-lifecycle.test.mjs
@@ -1,0 +1,214 @@
+import assert from "node:assert/strict";
+import {
+	chmodSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { register } from "node:module";
+import { dirname, join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+register("./resolve-ts-imports.mjs", import.meta.url);
+
+const extRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const { streamGrokCli } = await import(`file://${join(extRoot, "src/bridge.ts")}`);
+
+const FAKE_CLI = `
+import { dirname } from "node:path";
+import { readFileSync, writeFileSync } from "node:fs";
+
+const promptFlag = process.argv.indexOf("--prompt-file");
+const promptPath = process.argv[promptFlag + 1];
+const prompt = readFileSync(promptPath, "utf8");
+writeFileSync(
+	process.env.GROK_PI_TEST_CONTROL,
+	JSON.stringify({ promptPath, prompt }),
+	"utf8",
+);
+
+switch (process.env.GROK_PI_TEST_MODE) {
+	case "success":
+		process.stdout.write(JSON.stringify({ text: "fake success", usage: { input_tokens: 2, output_tokens: 2, total_tokens: 4 } }));
+		break;
+	case "failure":
+		process.stderr.write("fake CLI failure");
+		process.exitCode = 7;
+		break;
+	case "timeout":
+	case "abort":
+		setTimeout(() => process.exit(0), 5_000);
+		break;
+	default:
+		process.exitCode = 99;
+}
+`;
+
+function restoreEnv(key, value) {
+	if (value === undefined) delete process.env[key];
+	else process.env[key] = value;
+}
+
+function fakeModel() {
+	return {
+		id: "grok-test",
+		name: "Grok test",
+		api: "grok-cli-runner",
+		provider: "grok-cli",
+		baseUrl: "",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128_000,
+		maxTokens: 16_384,
+	};
+}
+
+function testContext(input) {
+	return {
+		systemPrompt: "Lifecycle test system prompt",
+		messages: [{ role: "user", content: input, timestamp: 1 }],
+		tools: [],
+	};
+}
+
+async function collectEvents(stream) {
+	const events = [];
+	for await (const event of stream) events.push(event);
+	return events;
+}
+
+function wait(ms) {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForControl(controlPath, timeoutMs = 2_000) {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		try {
+			return JSON.parse(readFileSync(controlPath, "utf8"));
+		} catch {
+			await wait(10);
+		}
+	}
+	throw new Error(`fake CLI did not read the prompt within ${timeoutMs}ms`);
+}
+
+async function collectWithWatchdog(eventsPromise, timeoutMs = 3_000) {
+	let timer;
+	try {
+		return await Promise.race([
+			eventsPromise,
+			new Promise((_, reject) => {
+				timer = setTimeout(() => reject(new Error(`stream did not finish within ${timeoutMs}ms`)), timeoutMs);
+			}),
+		]);
+	} finally {
+		clearTimeout(timer);
+	}
+}
+
+async function withFakeCli(mode, run) {
+	const dir = mkdtempSync(join(tmpdir(), "grok-pi-lifecycle-"));
+	const binPath = join(dir, "grok-fake.mjs");
+	const controlPath = join(dir, "control.json");
+	writeFileSync(binPath, `#!/usr/bin/env node\n${FAKE_CLI}`, "utf8");
+	chmodSync(binPath, 0o755);
+
+	const previousBin = process.env.GROK_PI_BIN;
+	const previousControl = process.env.GROK_PI_TEST_CONTROL;
+	const previousMode = process.env.GROK_PI_TEST_MODE;
+	const previousTimeout = process.env.GROK_PI_TIMEOUT_MS;
+	process.env.GROK_PI_BIN = binPath;
+	process.env.GROK_PI_TEST_CONTROL = controlPath;
+	process.env.GROK_PI_TEST_MODE = mode;
+	if (mode === "timeout") process.env.GROK_PI_TIMEOUT_MS = "250";
+	else delete process.env.GROK_PI_TIMEOUT_MS;
+
+	try {
+		return await run({ controlPath });
+	} finally {
+		restoreEnv("GROK_PI_BIN", previousBin);
+		restoreEnv("GROK_PI_TEST_CONTROL", previousControl);
+		restoreEnv("GROK_PI_TEST_MODE", previousMode);
+		restoreEnv("GROK_PI_TIMEOUT_MS", previousTimeout);
+		rmSync(dir, { recursive: true, force: true });
+	}
+}
+
+function assertPromptWasReadAndRemoved(control, expectedInput) {
+	assert.match(control.prompt, new RegExp(`USER:\\n${expectedInput}`));
+	assert.ok(control.promptPath.endsWith("/prompt.txt"));
+	assert.equal(readFileExists(control.promptPath), false, "prompt file should be removed");
+	assert.equal(readFileExists(dirname(control.promptPath)), false, "prompt directory should be removed");
+}
+
+function readFileExists(path) {
+	try {
+		readFileSync(path);
+		return true;
+	} catch (error) {
+		if (error?.code === "ENOENT") return false;
+		throw error;
+	}
+}
+
+test("successful model turns remove the prompt file and temporary directory", async () => {
+	const input = "success lifecycle input";
+	await withFakeCli("success", async ({ controlPath }) => {
+		const events = await collectWithWatchdog(collectEvents(streamGrokCli(fakeModel(), testContext(input))));
+		const control = await waitForControl(controlPath);
+
+		assert.deepEqual(events.map((event) => event.type), ["start", "text_start", "text_delta", "text_end", "done"]);
+		assert.equal(events.at(-1).reason, "stop");
+		assertPromptWasReadAndRemoved(control, input);
+	});
+});
+
+test("non-zero CLI exits remove the prompt file and temporary directory", async () => {
+	const input = "failure lifecycle input";
+	await withFakeCli("failure", async ({ controlPath }) => {
+		const events = await collectWithWatchdog(collectEvents(streamGrokCli(fakeModel(), testContext(input))));
+		const control = await waitForControl(controlPath);
+
+		assert.deepEqual(events.map((event) => event.type), ["start", "error"]);
+		const error = events.at(-1);
+		assert.equal(error.reason, "error");
+		assert.match(error.error.errorMessage, /fake CLI failure/);
+		assertPromptWasReadAndRemoved(control, input);
+	});
+});
+
+test("timeouts remove the prompt file and temporary directory", async () => {
+	const input = "timeout lifecycle input";
+	await withFakeCli("timeout", async ({ controlPath }) => {
+		const events = await collectWithWatchdog(collectEvents(streamGrokCli(fakeModel(), testContext(input))));
+		const control = await waitForControl(controlPath);
+
+		assert.deepEqual(events.map((event) => event.type), ["start", "error"]);
+		const error = events.at(-1);
+		assert.equal(error.reason, "error");
+		assert.equal(error.error.errorMessage, "grok timed out after 250ms");
+		assertPromptWasReadAndRemoved(control, input);
+	});
+});
+
+test("in-flight aborts remove the prompt file and temporary directory", async () => {
+	const input = "abort lifecycle input";
+	await withFakeCli("abort", async ({ controlPath }) => {
+		const controller = new AbortController();
+		const eventsPromise = collectEvents(streamGrokCli(fakeModel(), testContext(input), { signal: controller.signal }));
+		const control = await waitForControl(controlPath);
+		controller.abort();
+		const events = await collectWithWatchdog(eventsPromise);
+
+		assert.deepEqual(events.map((event) => event.type), ["start", "error"]);
+		const error = events.at(-1);
+		assert.equal(error.reason, "aborted");
+		assert.equal(error.error.errorMessage, "Request was aborted");
+		assertPromptWasReadAndRemoved(control, input);
+	});
+});

--- a/extensions/grok-pi/test/bridge-lifecycle.test.mjs
+++ b/extensions/grok-pi/test/bridge-lifecycle.test.mjs
@@ -8,7 +8,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { register } from "node:module";
-import { dirname, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
 
@@ -113,10 +113,15 @@ async function collectWithWatchdog(eventsPromise, timeoutMs = 3_000) {
 
 async function withFakeCli(mode, run) {
 	const dir = mkdtempSync(join(tmpdir(), "grok-pi-lifecycle-"));
-	const binPath = join(dir, "grok-fake.mjs");
+	const fakeCliPath = join(dir, "grok-fake.mjs");
+	const binPath = process.platform === "win32" ? join(dir, "grok-fake.cmd") : fakeCliPath;
 	const controlPath = join(dir, "control.json");
-	writeFileSync(binPath, `#!/usr/bin/env node\n${FAKE_CLI}`, "utf8");
-	chmodSync(binPath, 0o755);
+	writeFileSync(fakeCliPath, `#!/usr/bin/env node\n${FAKE_CLI}`, "utf8");
+	if (process.platform === "win32") {
+		writeFileSync(binPath, `@echo off\r\n"${process.execPath}" "%~dp0grok-fake.mjs" %*\r\n`, "utf8");
+	} else {
+		chmodSync(binPath, 0o755);
+	}
 
 	const previousBin = process.env.GROK_PI_BIN;
 	const previousControl = process.env.GROK_PI_TEST_CONTROL;
@@ -141,7 +146,7 @@ async function withFakeCli(mode, run) {
 
 function assertPromptWasReadAndRemoved(control, expectedInput) {
 	assert.match(control.prompt, new RegExp(`USER:\\n${expectedInput}`));
-	assert.ok(control.promptPath.endsWith("/prompt.txt"));
+	assert.equal(basename(control.promptPath), "prompt.txt");
 	assert.equal(readFileExists(control.promptPath), false, "prompt file should be removed");
 	assert.equal(readFileExists(dirname(control.promptPath)), false, "prompt directory should be removed");
 }

--- a/extensions/grok-pi/test/bridge-lifecycle.test.mjs
+++ b/extensions/grok-pi/test/bridge-lifecycle.test.mjs
@@ -1,21 +1,43 @@
 import assert from "node:assert/strict";
+import childProcess from "node:child_process";
 import {
-	chmodSync,
 	mkdtempSync,
 	readFileSync,
 	rmSync,
 	writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { register } from "node:module";
+import { register, syncBuiltinESMExports } from "node:module";
 import { basename, dirname, join } from "node:path";
 import { test } from "node:test";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 register("./resolve-ts-imports.mjs", import.meta.url);
 
 const extRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
-const { streamGrokCli } = await import(`file://${join(extRoot, "src/bridge.ts")}`);
+const originalSpawn = childProcess.spawn;
+childProcess.spawn = function patchedSpawn(command, args, options) {
+	const fakeCliPath = process.env.GROK_PI_TEST_FAKE_CLI;
+	if (command === process.execPath && fakeCliPath) {
+		return originalSpawn(process.execPath, [fakeCliPath, ...(args ?? [])], options);
+	}
+	return originalSpawn(command, args, options);
+};
+syncBuiltinESMExports();
+
+let streamGrokCli;
+try {
+	({ streamGrokCli } = await import(pathToFileURL(join(extRoot, "src/bridge.ts")).href));
+} catch (error) {
+	childProcess.spawn = originalSpawn;
+	syncBuiltinESMExports();
+	throw error;
+}
+
+test.after(() => {
+	childProcess.spawn = originalSpawn;
+	syncBuiltinESMExports();
+});
 
 const FAKE_CLI = `
 import { dirname } from "node:path";
@@ -114,20 +136,16 @@ async function collectWithWatchdog(eventsPromise, timeoutMs = 3_000) {
 async function withFakeCli(mode, run) {
 	const dir = mkdtempSync(join(tmpdir(), "grok-pi-lifecycle-"));
 	const fakeCliPath = join(dir, "grok-fake.mjs");
-	const binPath = process.platform === "win32" ? join(dir, "grok-fake.cmd") : fakeCliPath;
 	const controlPath = join(dir, "control.json");
 	writeFileSync(fakeCliPath, `#!/usr/bin/env node\n${FAKE_CLI}`, "utf8");
-	if (process.platform === "win32") {
-		writeFileSync(binPath, `@echo off\r\n"${process.execPath}" "%~dp0grok-fake.mjs" %*\r\n`, "utf8");
-	} else {
-		chmodSync(binPath, 0o755);
-	}
 
 	const previousBin = process.env.GROK_PI_BIN;
+	const previousFakeCli = process.env.GROK_PI_TEST_FAKE_CLI;
 	const previousControl = process.env.GROK_PI_TEST_CONTROL;
 	const previousMode = process.env.GROK_PI_TEST_MODE;
 	const previousTimeout = process.env.GROK_PI_TIMEOUT_MS;
-	process.env.GROK_PI_BIN = binPath;
+	process.env.GROK_PI_BIN = process.execPath;
+	process.env.GROK_PI_TEST_FAKE_CLI = fakeCliPath;
 	process.env.GROK_PI_TEST_CONTROL = controlPath;
 	process.env.GROK_PI_TEST_MODE = mode;
 	if (mode === "timeout") process.env.GROK_PI_TIMEOUT_MS = "250";
@@ -137,6 +155,7 @@ async function withFakeCli(mode, run) {
 		return await run({ controlPath });
 	} finally {
 		restoreEnv("GROK_PI_BIN", previousBin);
+		restoreEnv("GROK_PI_TEST_FAKE_CLI", previousFakeCli);
 		restoreEnv("GROK_PI_TEST_CONTROL", previousControl);
 		restoreEnv("GROK_PI_TEST_MODE", previousMode);
 		restoreEnv("GROK_PI_TIMEOUT_MS", previousTimeout);
@@ -161,59 +180,61 @@ function readFileExists(path) {
 	}
 }
 
-test("successful model turns remove the prompt file and temporary directory", async () => {
-	const input = "success lifecycle input";
-	await withFakeCli("success", async ({ controlPath }) => {
-		const events = await collectWithWatchdog(collectEvents(streamGrokCli(fakeModel(), testContext(input))));
-		const control = await waitForControl(controlPath);
+test("prompt-file cleanup lifecycle cases", async (t) => {
+	await t.test("successful model turns remove the prompt file and temporary directory", async () => {
+		const input = "success lifecycle input";
+		await withFakeCli("success", async ({ controlPath }) => {
+			const events = await collectWithWatchdog(collectEvents(streamGrokCli(fakeModel(), testContext(input))));
+			const control = await waitForControl(controlPath);
 
-		assert.deepEqual(events.map((event) => event.type), ["start", "text_start", "text_delta", "text_end", "done"]);
-		assert.equal(events.at(-1).reason, "stop");
-		assertPromptWasReadAndRemoved(control, input);
+			assert.deepEqual(events.map((event) => event.type), ["start", "text_start", "text_delta", "text_end", "done"]);
+			assert.equal(events.at(-1).reason, "stop");
+			assertPromptWasReadAndRemoved(control, input);
+		});
 	});
-});
 
-test("non-zero CLI exits remove the prompt file and temporary directory", async () => {
-	const input = "failure lifecycle input";
-	await withFakeCli("failure", async ({ controlPath }) => {
-		const events = await collectWithWatchdog(collectEvents(streamGrokCli(fakeModel(), testContext(input))));
-		const control = await waitForControl(controlPath);
+	await t.test("non-zero CLI exits remove the prompt file and temporary directory", async () => {
+		const input = "failure lifecycle input";
+		await withFakeCli("failure", async ({ controlPath }) => {
+			const events = await collectWithWatchdog(collectEvents(streamGrokCli(fakeModel(), testContext(input))));
+			const control = await waitForControl(controlPath);
 
-		assert.deepEqual(events.map((event) => event.type), ["start", "error"]);
-		const error = events.at(-1);
-		assert.equal(error.reason, "error");
-		assert.match(error.error.errorMessage, /fake CLI failure/);
-		assertPromptWasReadAndRemoved(control, input);
+			assert.deepEqual(events.map((event) => event.type), ["start", "error"]);
+			const error = events.at(-1);
+			assert.equal(error.reason, "error");
+			assert.match(error.error.errorMessage, /fake CLI failure/);
+			assertPromptWasReadAndRemoved(control, input);
+		});
 	});
-});
 
-test("timeouts remove the prompt file and temporary directory", async () => {
-	const input = "timeout lifecycle input";
-	await withFakeCli("timeout", async ({ controlPath }) => {
-		const events = await collectWithWatchdog(collectEvents(streamGrokCli(fakeModel(), testContext(input))));
-		const control = await waitForControl(controlPath);
+	await t.test("timeouts remove the prompt file and temporary directory", async () => {
+		const input = "timeout lifecycle input";
+		await withFakeCli("timeout", async ({ controlPath }) => {
+			const events = await collectWithWatchdog(collectEvents(streamGrokCli(fakeModel(), testContext(input))));
+			const control = await waitForControl(controlPath);
 
-		assert.deepEqual(events.map((event) => event.type), ["start", "error"]);
-		const error = events.at(-1);
-		assert.equal(error.reason, "error");
-		assert.equal(error.error.errorMessage, "grok timed out after 250ms");
-		assertPromptWasReadAndRemoved(control, input);
+			assert.deepEqual(events.map((event) => event.type), ["start", "error"]);
+			const error = events.at(-1);
+			assert.equal(error.reason, "error");
+			assert.equal(error.error.errorMessage, "grok timed out after 250ms");
+			assertPromptWasReadAndRemoved(control, input);
+		});
 	});
-});
 
-test("in-flight aborts remove the prompt file and temporary directory", async () => {
-	const input = "abort lifecycle input";
-	await withFakeCli("abort", async ({ controlPath }) => {
-		const controller = new AbortController();
-		const eventsPromise = collectEvents(streamGrokCli(fakeModel(), testContext(input), { signal: controller.signal }));
-		const control = await waitForControl(controlPath);
-		controller.abort();
-		const events = await collectWithWatchdog(eventsPromise);
+	await t.test("in-flight aborts remove the prompt file and temporary directory", async () => {
+		const input = "abort lifecycle input";
+		await withFakeCli("abort", async ({ controlPath }) => {
+			const controller = new AbortController();
+			const eventsPromise = collectEvents(streamGrokCli(fakeModel(), testContext(input), { signal: controller.signal }));
+			const control = await waitForControl(controlPath);
+			controller.abort();
+			const events = await collectWithWatchdog(eventsPromise);
 
-		assert.deepEqual(events.map((event) => event.type), ["start", "error"]);
-		const error = events.at(-1);
-		assert.equal(error.reason, "aborted");
-		assert.equal(error.error.errorMessage, "Request was aborted");
-		assertPromptWasReadAndRemoved(control, input);
+			assert.deepEqual(events.map((event) => event.type), ["start", "error"]);
+			const error = events.at(-1);
+			assert.equal(error.reason, "aborted");
+			assert.equal(error.error.errorMessage, "Request was aborted");
+			assertPromptWasReadAndRemoved(control, input);
+		});
 	});
 });

--- a/extensions/grok-pi/test/resolve-ts-imports.mjs
+++ b/extensions/grok-pi/test/resolve-ts-imports.mjs
@@ -1,0 +1,10 @@
+export async function resolve(specifier, context, nextResolve) {
+	if (specifier.startsWith(".") && specifier.endsWith(".js")) {
+		try {
+			return await nextResolve(`${specifier.slice(0, -3)}.ts`, context);
+		} catch {
+			// Keep Node's normal error for JavaScript imports without a TypeScript sibling.
+		}
+	}
+	return nextResolve(specifier, context);
+}


### PR DESCRIPTION
Closes #64

## Summary

Add deterministic lifecycle coverage for the temporary prompt-file cleanup used by the Grok CLI bridge. The tests exercise the complete stream lifecycle without changing production behavior.

## Approach

Option 1 — focused real-child lifecycle tests: use a test-local fake CLI process and consume the bridge stream fully before asserting prompt-file and temporary-directory cleanup.

## Decision Record

- **Root cause:** The prompt-file cleanup introduced by PR #63 runs in `streamGrokCli` lifecycle paths, but the existing suite did not exercise that lifecycle end to end.
- **Options considered:** Option 1 — focused real-child lifecycle tests; Option 2 — mock ChildProcess callbacks; Option 3 — refactor the bridge to inject cleanup.
- **Options rejected:** Option 2 — mocks would not verify real child-process, timeout, and abort ordering; Option 3 — an unnecessary production seam for test-only coverage.
- **Selected option:** Option 1 — focused real-child lifecycle tests.
- **Residual risk:** No production code changed. Tests passed locally on macOS; native Windows execution was not available, although the fixture uses a Windows-compatible real-process invocation. The light-profile QA ceiling was exceeded because the first two review cycles found and fixed blocking Windows portability issues.
- **Effort profile:** light — fast path (pre-work Effort S); synthesis skipped, QA capped at 1 cycle

Analyzed at: `refactor/64-add-lifecycle-tests-for-prompt-file @ 6eda5fb` (2026-09-01)

## Changes

| File | Change |
|------|--------|
| `extensions/grok-pi/test/bridge-lifecycle.test.mjs` | Add success, CLI-failure, timeout, and in-flight-abort cleanup tests using a real fake child process. |
| `extensions/grok-pi/test/resolve-ts-imports.mjs` | Resolve TypeScript sibling imports for the lifecycle test's dynamic bridge import. |

## Test Results

- Unit tests: 31 passed
- Integration tests: skipped (no integration framework)
- E2e tests: skipped (no e2e framework)
- Build: passed (`npm run build`)
- QA cycles: 3 (light ceiling 1; exceeded for blocking Windows portability fixes)

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| A successful model turn has coverage proving temporary prompt artifacts are cleaned up. | pass | `bridge-lifecycle.test.mjs`: successful model turns remove the prompt file and temporary directory |
| A CLI failure has coverage proving temporary prompt artifacts are cleaned up. | pass | `bridge-lifecycle.test.mjs`: non-zero CLI exits remove the prompt file and temporary directory |
| Timeout and abort outcomes each have coverage proving temporary prompt artifacts are cleaned up. | pass | `bridge-lifecycle.test.mjs`: timeout and in-flight abort cases assert cleanup |
| The lifecycle tests are deterministic and pass in the extension test suite. | pass | `npm test`: 31 passed; lifecycle tests repeated successfully |

<!-- gitissue:qa v1 head=a1112e31b0af3a660db3e8ae9957195a1acbaf23 profile=light cycles=3 review=clean tests=31@a1112e31b0af3a660db3e8ae9957195a1acbaf23 ui=none -->