### PR TITLE
fix(cache-warm): make warming opt-in and preserve cadence

### DIFF
--- a/.tmp_issue_body.md
+++ b/.tmp_issue_body.md
@@ -1,0 +1,17 @@
+## Summary
+
+cache-warm extension starts with keep-alive enabled by default, which:
+- Sends paid turns without explicit user opt-in
+- Uses a 12/hour rate cap incompatible with the 4-minute warm cadence (needs 15/hour)
+- Eventually forces cache expiry when the limiter blocks sustained warming
+
+## Acceptance Criteria
+
+- [ ] Default `enabled` is `false` in `createWarmState()` and `resetSession()`
+- [ ] Rate cap is derived from cadence: 15/hour (from RATE_WINDOW_MS / CACHE_WARN_MS)
+- [ ] Documentation updated (README, DEVELOPMENT.md, CHANGELOG.md, DECISIONS.md)
+- [ ] Tests cover opt-in default, timer lifecycle, and sustained cadence
+
+## Why
+
+The previous 12/hour cap was incompatible with the default four-minute warm cadence. In a continuously enabled session it eventually blocked warming long enough for the five-minute cache to expire. Warming should require explicit opt-in to avoid unexpected costs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **cache-warm**: The default rolling-hour cap now permits the full four-minute short-cache refresh cadence (15/hour instead of 12/hour), rather than eventually blocking long enough to force a cache miss.
 - **grok-pi 1.4.1**: Windows turns no longer pass Pi's full prompt as `grok --single` argv. CreateProcess caps the command line at ~32KB, so even a one-word message hit `spawn ENAMETOOLONG` and grok-pi misreported it as a missing Grok CLI. Turns now write the prompt to a temp file and invoke `grok --prompt-file`. Also treat `~/.grok/bin/grok.exe` as an installed CLI, and prefer that path when `GROK_PI_BIN` is unset on Windows.
 
 ### Changed
 
 - **grok-pi 1.3.0**: Rewritten as a strict CLI-subprocess bridge — every model turn now spawns the official `grok --single … --tools "" --disable-web-search --permission-mode dontAsk --output-format json` binary instead of calling xAI's CLI proxy over HTTP with tokens extracted from `~/.grok/auth.json`. The extension no longer reads, refreshes, or spoofs any credentials or client headers (removes `bin/grok-api-key`, `bin/grok-client-version`, `bin/grok-user-agent`, `bin/grok-usage` and the direct billing API `/grok-pi usage` command), resolving the Acceptable Use Policy bot-access and bypass-clause exposure; real token usage/cost is parsed from the CLI's JSON output, thinking levels map to `--effort`, and tool calls remain prompt-bridged `<pi_tool_call>` markers executed by Pi.
-- **cache-warm**: Each keep-alive ping appends a unique `#w <iso>-<id>` suffix. An hourly send cap is **on by default** (12/hour; `/cache-warm rate on|off`, `CACHE_WARM_RATE_LIMIT`, `CACHE_WARM_MAX_PER_HOUR`).
+- **cache-warm**: Keep-alive is opt-in again and starts off in every session. Each ping appends a unique `#w <iso>-<id>` suffix. An hourly send cap is on when warming is enabled (15/hour by default; `/cache-warm rate on|off`, `CACHE_WARM_RATE_LIMIT`, `CACHE_WARM_MAX_PER_HOUR`).
 
 ### Added
 

--- a/CODE_REVIEW.md
+++ b/CODE_REVIEW.md
@@ -1,0 +1,63 @@
+# Code Review Report
+
+**Date**: 2026-09-02
+**Scope**: Full audit of `extensions/cache-warm`
+**Mode**: Mode 1 — small extension, inline review
+**Files Reviewed**: 6 source/test files
+**Excluded**: generated `dist/`, `node_modules/`, and `package-lock.json`
+
+## Summary
+
+| Severity | Count |
+|----------|-------|
+| Critical | 0 |
+| Major | 2 |
+| Minor | 0 |
+| Info | 1 |
+
+## Critical Issues
+
+None.
+
+## Major Issues
+
+### [Correctness]: Default rate cap forces periodic cache expiry
+**File**: `extensions/cache-warm/src/warm.ts:27`
+**Category**: Conflicting invariants
+
+The short-cache scheduler warms when 60 seconds remain, producing a four-minute cadence. That requires up to 15 pings in a rolling hour, but the default cap is 12. In a continuously enabled session, the limiter eventually blocks warming long enough for the five-minute cache to expire. The existing rate-limit test checks burst limiting but not a sustained keep-alive cadence.
+
+**Suggested fix**: Derive the default cap from the rate window and the default refresh interval, and add a sustained-cadence regression test. A user-specified lower cap may still intentionally permit expiry.
+
+**Resolution**: Fixed. The derived default is 15/hour and the test suite covers sustained cadence.
+
+### [Safety]: Paid warming starts without explicit opt-in
+**File**: `extensions/cache-warm/src/warm.ts:124`
+**Category**: Unsafe default
+
+`createWarmState()` and `resetSession()` both enable paid background turns. This conflicts with the requested opt-in behavior and means installing or starting a session can generate paid traffic without `/cache-warm on`.
+
+**Suggested fix**: Default and reset `enabled` to `false`; verify startup creates no timer or warm request and explicit enablement still works.
+
+**Resolution**: Fixed. Startup and session-reset tests verify opt-in behavior and timer cleanup.
+
+## Minor Issues
+
+None.
+
+## Info
+
+### [Reliability]: Moving the warm point to 4m50s would reduce safety margin
+**File**: `extensions/cache-warm/src/cache.ts:8`
+**Category**: Scheduling trade-off
+
+The current threshold sends at roughly 4m00s for a five-minute TTL, leaving about 60 seconds for event-loop delay, machine wake-up, queueing, and provider latency. Sending at 4m50s leaves only ten seconds and cannot fix misses caused by the incompatible rate cap, idle auto-stop, prompt-prefix changes, or provider behavior.
+
+**Resolution**: Retained the one-minute safety margin and documented the rationale.
+
+## Recommendations
+
+1. Keep the current 60-second safety margin.
+2. Make warming off by default and require `/cache-warm on` per session.
+3. Raise/derive the default rolling-hour cap so it cannot defeat the default cadence.
+4. Document that cache hits are best-effort and that the 30-minute idle stop or an explicitly lower cap can permit later misses.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Find what you need, copy the install command, reload Pi (`/reload`).
 | Extension | What you get | Install |
 |---|---|---|
 | [advisor-pi](extensions/advisor-pi/README.md) | `advisor` tool: strategic guidance from a stronger model | `pi install npm:advisor-pi` |
-| [cache-warm](extensions/cache-warm/README.md) | Keep-alive pings that avoid prompt-cache misses (on by default, 30m idle auto-stop) | `pi install npm:cache-warm` |
+| [cache-warm](extensions/cache-warm/README.md) | Opt-in keep-alive pings that avoid prompt-cache misses | `pi install npm:cache-warm` |
 | [model-debugger](extensions/model-debugger/README.md) | Log all model requests/responses for provider debugging | `pi install npm:model-debugger` |
 
 ### Skill & themes
@@ -382,12 +382,13 @@ pi install npm:timestamp-pi   # or: pi -e ./extensions/timestamp-pi
 ![Cache-warm footer counting down, before and after a warm ping](assets/cache-warm.png)
 
 Keeps the prompt cache alive with hidden keep-alive turns.
-Default is **on**: new sessions start the keep-alive timer without `/cache-warm on`.
-Disable with `/cache-warm off`. Keep-alive auto-stops after 30 minutes idle
-(configurable: `/cache-warm duration 1h` or `CACHE_WARM_DURATION`). Pings use `pi.sendMessage()` (not `sendUserMessage` /
+Default is **off**: run `/cache-warm on` to opt in for the current session.
+Keep-alive auto-stops after 30 minutes idle (configurable: `/cache-warm duration 1h`
+or `CACHE_WARM_DURATION`). Pings use `pi.sendMessage()` (not `sendUserMessage` /
 `completeSimple`) and only fire when the session is idle, nothing is queued,
 cache activity has already been seen, and remaining TTL is under 60 seconds
-(`extensions/cache-warm/src/index.ts`). The 5-minute TTL is an Anthropic
+(`extensions/cache-warm/src/index.ts`). The default 15/hour cap supports this
+four-minute cadence without forcing an expiry. The 5-minute TTL is an Anthropic
 heuristic. Metrics report warm attempts, refreshes, likely avoided misses, and
 estimated net USD saved (gross cache discount minus warm-turn spend; `N/A` when
 rates are missing). See [extensions/cache-warm/README.md](extensions/cache-warm/README.md).

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -19,3 +19,8 @@ Append-only log of documentation ambiguities resolved with the user.
 - Q: Should cache-warm keep-alive start enabled, and should idle warming be unbounded?
 - A: Default on for new sessions (#55). Auto-stop after 30 minutes idle (from last user turn or enable) so a forgotten session does not bill overnight. `/cache-warm duration 1h` / `CACHE_WARM_DURATION` sets the window; `forever` disables auto-stop. `/cache-warm on` also clears a suppressed epoch while already enabled.
 - Source: issue #55 / PR #56 review; follow-up idle auto-stop
+
+## 2026-09-02
+- Q: Should cache-warm continue starting enabled, and should its default timing move from roughly 4m00s to 4m50s for a five-minute cache?
+- A (user): Make cache-warm off by default. Keep the existing one-minute safety margin rather than moving to 4m50s: review found that the 12/hour limiter, not the 4m00s send point, could force periodic misses. Derive the default cap from the cadence (15/hour) so it cannot block a normally scheduled refresh.
+- Source: cache-warm logic review

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -354,14 +354,15 @@ session entries, so history survives reloads and never reaches the LLM.
 ### cache-warm
 
 `cache-warm` is a separate keep-alive extension (not part of timestamp-pi).
-Default is on: `session_start` starts a 1s tick timer (`unref`'d so it cannot
+Default is off: `/cache-warm on` starts a 1s tick timer (`unref`'d so it cannot
 hold the process open) that may `pi.sendMessage()` a hidden ping when remaining
 TTL is under 60s, the session is idle, and cache activity has already been
-observed (`extensions/cache-warm/src/index.ts`). Idle keep-alive auto-stops after
-30 minutes (from last user turn or enable); `/cache-warm duration 1h` or
-`CACHE_WARM_DURATION` changes that window (`forever` disables auto-stop).
-`/cache-warm on` clears a suppressed epoch even when already enabled.
-`/cache-warm off` stops the timer.
+observed (`extensions/cache-warm/src/index.ts`). The default rolling-hour cap is
+derived from the four-minute short-cache cadence (15/hour), so the limiter does
+not itself force expiry. Idle keep-alive auto-stops after 30 minutes (from last
+user turn or enable); `/cache-warm duration 1h` or `CACHE_WARM_DURATION` changes
+that window (`forever` disables auto-stop). `/cache-warm on` clears a suppressed
+epoch even when already enabled. `/cache-warm off` stops the timer.
 Metrics (`attempts`, `refreshes`, `likelyAvoidedMisses`, estimated net USD)
 live in `src/warm.ts` / `src/metrics.ts`; cost math is copied from
 statusline-pi rather than imported. The 5-minute TTL is an Anthropic heuristic.

--- a/extensions/cache-warm/README.md
+++ b/extensions/cache-warm/README.md
@@ -1,8 +1,8 @@
 # cache-warm
 
-Keep-alive for Pi's prompt cache. When enabled, the extension sends a tiny hidden turn before the cache TTL expires so a later user message is more likely to hit cache instead of paying for a miss.
+Opt-in keep-alive for Pi's prompt cache. When enabled, the extension sends a tiny hidden turn before the cache TTL expires so a later user message is more likely to hit cache instead of paying for a miss.
 
-**Default is on.** New sessions start keep-alive without `/cache-warm on`. Disable it with `/cache-warm off`. Keep-alive auto-stops after **30 minutes idle** (from the last user turn or `/cache-warm on`). Set any duration with `/cache-warm duration 1h` (or `30m`, `2h`, `forever`).
+**Default is off.** Installing the extension or starting a session does not send warm turns. Enable it for the current session with `/cache-warm on`. Keep-alive auto-stops after **30 minutes idle** (from the last user turn or `/cache-warm on`). Set any duration with `/cache-warm duration 1h` (or `30m`, `2h`, `forever`).
 
 ![Cache-warm footer counting down, before and after a warm ping](../../assets/cache-warm.png)
 
@@ -10,12 +10,12 @@ This is a separate package from [timestamp-pi](../timestamp-pi/README.md). times
 
 ## What it does
 
-- **Keep-alive pings** — when the remaining prompt-cache TTL drops under 60 seconds, and the session is idle with no queued messages, `cache-warm` injects a `display: false` custom message (`Reply "." only. Do not use tools. #w <iso>-<id>`) via `sendMessage`. The suffix is unique per send so providers do not see an identical prompt loop. A **rate limit is on by default** (12 pings per rolling hour). Toggle with `/cache-warm rate on|off` or `CACHE_WARM_RATE_LIMIT=off`. Cap size is `CACHE_WARM_MAX_PER_HOUR` (`0` or `forever` = unlimited while the limiter is on). Observed full one-hour Anthropic writes use a one-hour TTL; short and mixed writes schedule conservatively at five minutes. After 30 minutes with no user turn (configurable), keep-alive turns itself off so a forgotten session does not bill overnight.
+- **Keep-alive pings** — when the remaining prompt-cache TTL drops under 60 seconds (about 4 minutes after short-cache activity), and the session is idle with no queued messages, `cache-warm` injects a `display: false` custom message (`Reply "." only. Do not use tools. #w <iso>-<id>`) via `sendMessage`. The suffix is unique per send so providers do not see an identical prompt loop. A **rate limit is on by default** (15 pings per rolling hour, derived from the default four-minute cadence). Toggle with `/cache-warm rate on|off` or `CACHE_WARM_RATE_LIMIT=off`. Cap size is `CACHE_WARM_MAX_PER_HOUR` (`0` or `forever` = unlimited while the limiter is on). Observed full one-hour Anthropic writes use a one-hour TTL; short and mixed writes schedule conservatively at five minutes. After 30 minutes with no user turn (configurable), keep-alive turns itself off so a forgotten session does not bill overnight.
 - **Tool isolation** — once the hidden turn is confirmed, every hidden tool call is forcibly blocked, including retries, continuations, and interrupted work. If Pi drains queued user or foreign custom work before `agent_settled`, the guard is released at that message boundary so the external turn can use tools normally. The extension never changes the global active-tool list.
 - **Easy toggle** — `/cache-warm on`, `/cache-warm off`, or `/cache-warm` to toggle
 - **Honest metrics** — attempts, successful refreshes, likely avoided misses, and estimated net USD saved
 
-The five-minute fallback is an Anthropic heuristic, not a universal provider guarantee. Cache reads without new write evidence retain the most recent observed retention for the model/session. An unconfirmed dispatch is never retried within the same cache-activity epoch because a late first dispatch could otherwise create duplicate billed turns. `/cache-warm on` clears that suppression even when keep-alive is already enabled.
+The five-minute fallback is an Anthropic heuristic, not a universal provider guarantee. The one-minute send margin is intentional: moving the ping to 4m50s would leave only ten seconds for event-loop, queueing, and provider latency and would make expiry more likely. Cache reads without new write evidence retain the most recent observed retention for the model/session. An unconfirmed dispatch is never retried within the same cache-activity epoch because a late first dispatch could otherwise create duplicate billed turns. `/cache-warm on` clears that suppression even when keep-alive is already enabled. Cache misses can still occur after the idle auto-stop, with an explicitly lower hourly cap, after cache-key-relevant context changes, or because of provider behavior.
 
 Pings enter the LLM context. The assistant reply cannot be guaranteed invisible.
 
@@ -29,7 +29,7 @@ Pings enter the LLM context. The assistant reply cannot be guaranteed invisible.
 | `/cache-warm duration` | Show the idle auto-stop limit |
 | `/cache-warm duration 30m` | Set the idle auto-stop (`1h`, `2h`, `90`, `forever`; bare numbers are minutes) |
 | `/cache-warm rate` | Show whether the hourly ping cap is on |
-| `/cache-warm rate on` | Enable the hourly ping cap (default) |
+| `/cache-warm rate on` | Enable the hourly ping cap (default: 15/hour) |
 | `/cache-warm rate off` | Disable the hourly ping cap |
 | `/cache-warm status` | Enabled state, idle limit, rate limit, cache countdown, and metrics |
 | `/cache-warm metrics` | Attempts, refreshes, likely avoided misses, estimated net USD saved |
@@ -73,7 +73,7 @@ pi -e ./extensions/cache-warm
 pi install -l ./extensions/cache-warm
 ```
 
-Keep-alive is **on** by default and auto-stops after 30 minutes idle; use `/cache-warm off` to disable, or `/cache-warm duration 2h` (or `CACHE_WARM_DURATION=2h`) for a longer window. The hourly ping cap is on by default (`/cache-warm rate off` or `CACHE_WARM_RATE_LIMIT=off` to disable; `CACHE_WARM_MAX_PER_HOUR` defaults to `12`).
+Keep-alive is **off** by default. Run `/cache-warm on` to enable it for the current session. It auto-stops after 30 minutes idle; use `/cache-warm duration 2h` (or `CACHE_WARM_DURATION=2h`) for a longer window. The hourly ping cap is on by default (`/cache-warm rate off` or `CACHE_WARM_RATE_LIMIT=off` to disable; `CACHE_WARM_MAX_PER_HOUR` defaults to `15`).
 
 ## Development
 

--- a/extensions/cache-warm/package.json
+++ b/extensions/cache-warm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cache-warm",
   "version": "0.1.1",
-  "description": "Prompt-cache keep-alive for Pi with avoided-miss and USD-saved metrics (enabled by default)",
+  "description": "Opt-in prompt-cache keep-alive for Pi with avoided-miss and USD-saved metrics",
   "type": "module",
   "main": "./src/index.ts",
   "files": [

--- a/extensions/cache-warm/src/warm.ts
+++ b/extensions/cache-warm/src/warm.ts
@@ -23,8 +23,13 @@ export const WARM_TIMEOUT_MS = 60_000;
 /** Default idle window after last user activity before keep-alive auto-stops. */
 export const DEFAULT_ACTIVE_MS = 30 * 60 * 1000;
 export const RATE_WINDOW_MS = 60 * 60 * 1000;
-/** Hard cap on warm sends per rolling hour (0 = unlimited). */
-export const DEFAULT_MAX_PINGS_PER_HOUR = 12;
+/**
+ * Default cap that still permits the short-cache refresh cadence (0 = unlimited).
+ * User overrides may intentionally choose a lower cap and allow cache expiry.
+ */
+export const DEFAULT_MAX_PINGS_PER_HOUR = Math.ceil(
+	RATE_WINDOW_MS / (CACHE_TTL_MS - CACHE_WARN_MS),
+);
 
 export type RetentionKind = "short" | "long" | "mixed" | "unknown";
 
@@ -121,7 +126,7 @@ export interface WarmPingGate {
 
 export function createWarmState(): WarmState {
 	return {
-		enabled: true,
+		enabled: false,
 		cacheLastActive: undefined,
 		cacheEpoch: 0,
 		suppressedEpoch: undefined,
@@ -397,7 +402,7 @@ export function setEnabled(state: WarmState, enabled: boolean, now?: number): bo
 }
 
 export function resetSession(state: WarmState): void {
-	state.enabled = true;
+	state.enabled = false;
 	state.cacheLastActive = undefined;
 	state.cacheEpoch = 0;
 	state.suppressedEpoch = undefined;

--- a/extensions/cache-warm/test/cache-warm.test.mjs
+++ b/extensions/cache-warm/test/cache-warm.test.mjs
@@ -3,9 +3,11 @@ import assert from "node:assert/strict";
 import cacheWarmExtension, {
 	CACHE_TTL_LONG_MS,
 	CACHE_TTL_MS,
+	CACHE_WARN_MS,
 	DEFAULT_ACTIVE_MS,
 	DEFAULT_MAX_PINGS_PER_HOUR,
 	PING_CONTENT,
+	RATE_WINDOW_MS,
 	WARM_TIMEOUT_MS,
 	buildPingContent,
 	applyAssistantUsage,
@@ -31,6 +33,7 @@ import cacheWarmExtension, {
 	setEnabled,
 	setRateLimitEnabled,
 	shouldSendWarmPing,
+	underRateLimit,
 } from "../dist/index.js";
 
 function model(overrides = {}) {
@@ -106,9 +109,13 @@ function gate(state, now, overrides = {}) {
 }
 
 describe("commands and dispatch state", () => {
-	it("keeps warming on by default and parses easy toggles", () => {
-		assert.equal(createWarmState().enabled, true);
+	it("keeps warming off by default and parses easy toggles", () => {
+		assert.equal(createWarmState().enabled, false);
 		assert.equal(createWarmState().activeMs, DEFAULT_ACTIVE_MS);
+		assert.equal(
+			createWarmState().maxPerHour,
+			Math.ceil(RATE_WINDOW_MS / (CACHE_TTL_MS - CACHE_WARN_MS)),
+		);
 		assert.equal(createWarmState().maxPerHour, DEFAULT_MAX_PINGS_PER_HOUR);
 		assert.equal(createWarmState().rateLimitEnabled, true);
 		assert.equal(parseCacheWarmArgs("").action, "toggle");
@@ -214,6 +221,7 @@ describe("commands and dispatch state", () => {
 		const state = createWarmState();
 		const selectedModel = model();
 		state.modelKey = "openai/test-model";
+		setEnabled(state, true);
 		const pingAt = 1_000 + CACHE_TTL_MS - 30_000;
 		seedCache(state, 1_000, selectedModel);
 		setActiveMs(state, 10 * 60_000);
@@ -228,16 +236,31 @@ describe("commands and dispatch state", () => {
 		assert.equal(shouldSendWarmPing(gate(state, pingAt)), true);
 	});
 
-	it("varies ping bodies and caps sends per rolling hour", () => {
+	it("varies ping bodies and caps sends without blocking the default cadence", () => {
 		const first = buildPingContent(1_700_000_000_000, "abc");
 		const second = buildPingContent(1_700_000_000_001, "def");
 		assert.match(first, new RegExp(`^${PING_CONTENT.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")} #w `));
 		assert.notEqual(first, second);
 
+		const interval = CACHE_TTL_MS - CACHE_WARN_MS;
+		const priorDefaultPings = Array.from(
+			{ length: DEFAULT_MAX_PINGS_PER_HOUR },
+			(_, index) => (index + 1) * interval,
+		);
+		assert.equal(
+			underRateLimit(
+				(DEFAULT_MAX_PINGS_PER_HOUR + 1) * interval,
+				priorDefaultPings,
+				DEFAULT_MAX_PINGS_PER_HOUR,
+			),
+			true,
+		);
+
 		const state = createWarmState();
 		const selectedModel = model();
 		state.modelKey = "openai/test-model";
 		state.maxPerHour = 2;
+		setEnabled(state, true);
 		seedCache(state, 1_000, selectedModel);
 		const pingAt = 1_000 + CACHE_TTL_MS - 30_000;
 		assert.equal(shouldSendWarmPing(gate(state, pingAt)), true);
@@ -670,7 +693,7 @@ describe("reset safety", () => {
 		resetSession(state);
 		assert.equal(state.warmRunActive, undefined);
 		assert.equal(state.dispatchPending, undefined);
-		assert.equal(state.enabled, true);
+		assert.equal(state.enabled, false);
 	});
 
 	it("quarantines pending work on model change and clears pending work on shutdown", () => {
@@ -692,52 +715,57 @@ describe("reset safety", () => {
 });
 
 describe("extension event wiring", { concurrency: false }, () => {
-	it("starts the keep-alive timer on session_start without an explicit enable", async () => {
+	it("starts disabled without creating a keep-alive timer", async () => {
 		const harness = createHarness();
 		await harness.start();
-		assert.match(await harness.status(), /cache-warm: on/);
-		assert.equal(harness.unrefCalls, 1);
+		assert.match(await harness.status(), /cache-warm: off/);
+		assert.equal(harness.unrefCalls, 0);
+		assert.equal(harness.hasActiveTimer, false);
 		await harness.seed(1_000);
-		harness.tickAt(1_000 + CACHE_TTL_MS - 30_000);
-		assert.equal(harness.sent.length, 1);
+		assert.equal(harness.sent.length, 0);
 		harness.restore();
 	});
 
-	it("lets /cache-warm off, on, and empty-args toggle keep-alive", async () => {
+	it("lets /cache-warm on, off, and empty-args toggle keep-alive", async () => {
 		const harness = createHarness();
 		await harness.start();
-		assert.match(await harness.status(), /cache-warm: on/);
-
-		await harness.command("off");
 		assert.match(await harness.status(), /cache-warm: off/);
 
 		await harness.command("");
 		assert.match(await harness.status(), /cache-warm: on/);
+		assert.equal(harness.hasActiveTimer, true);
 
 		await harness.command("");
 		assert.match(await harness.status(), /cache-warm: off/);
+		assert.equal(harness.hasActiveTimer, false);
 
 		await harness.seed(1_000);
-		harness.tickAt(1_000 + CACHE_TTL_MS - 30_000);
 		assert.equal(harness.sent.length, 0);
 
 		await harness.command("on");
 		assert.match(await harness.status(), /cache-warm: on/);
+		assert.equal(harness.hasActiveTimer, true);
 		harness.tickAt(1_000 + CACHE_TTL_MS - 29_000);
 		assert.equal(harness.sent.length, 1);
+
+		await harness.command("off");
+		assert.match(await harness.status(), /cache-warm: off/);
+		assert.equal(harness.hasActiveTimer, false);
+		assert.equal(harness.clearIntervalCalls, 2);
 		harness.restore();
 	});
 
-	it("restores keep-alive after session_shutdown in the same process", async () => {
+	it("resets explicit enablement after session_shutdown", async () => {
 		const harness = createHarness();
-		await harness.start();
-		await harness.command("off");
+		await harness.startAndEnable();
+		assert.equal(harness.hasActiveTimer, true);
 		await harness.emit("session_shutdown", { type: "session_shutdown", reason: "quit" });
+		assert.equal(harness.hasActiveTimer, false);
+		assert.equal(harness.clearIntervalCalls, 1);
 		await harness.start();
-		assert.match(await harness.status(), /cache-warm: on/);
+		assert.match(await harness.status(), /cache-warm: off/);
 		await harness.seed(1_000);
-		harness.tickAt(1_000 + CACHE_TTL_MS - 30_000);
-		assert.equal(harness.sent.length, 1);
+		assert.equal(harness.sent.length, 0);
 		harness.restore();
 	});
 
@@ -807,20 +835,21 @@ describe("extension event wiring", { concurrency: false }, () => {
 
 	it("auto-stops keep-alive after the configured idle duration", async () => {
 		const harness = createHarness();
-		await harness.start();
+		await harness.startAndEnable();
 		await harness.command("duration 1m");
 		assert.match(harness.notices.at(-1), /idle limit set to 1m/);
 		await harness.seed(1_000);
 		harness.tickAt(1_000 + 61_000);
 		assert.match(await harness.status(), /cache-warm: off/);
-		harness.tickAt(1_000 + CACHE_TTL_MS - 30_000);
+		assert.equal(harness.hasActiveTimer, false);
+		assert.equal(harness.clearIntervalCalls, 1);
 		assert.equal(harness.sent.length, 0);
 		harness.restore();
 	});
 
 	it("retries a failed send after /cache-warm on while already enabled", async () => {
 		const harness = createHarness({ sendThrows: true });
-		await harness.start();
+		await harness.startAndEnable();
 		await harness.seed(1_000);
 		const first = 1_000 + CACHE_TTL_MS - 30_000;
 		harness.tickAt(first);
@@ -865,21 +894,27 @@ function createHarness(options = {}) {
 	const handlers = new Map();
 	let commandHandler;
 	let timerCallback;
+	let activeTimer;
 	let now = 0;
 	let unrefCalls = 0;
+	let clearIntervalCalls = 0;
 	const originalSetInterval = globalThis.setInterval;
 	const originalClearInterval = globalThis.clearInterval;
 	const originalDateNow = Date.now;
 	globalThis.setInterval = (callback) => {
 		timerCallback = callback;
-		return {
+		activeTimer = {
 			fake: true,
 			unref() {
 				unrefCalls += 1;
 			},
 		};
+		return activeTimer;
 	};
-	globalThis.clearInterval = () => {};
+	globalThis.clearInterval = (timer) => {
+		clearIntervalCalls += 1;
+		if (timer === activeTimer) activeTimer = undefined;
+	};
 	Date.now = () => now;
 	const sent = [];
 	const notices = [];
@@ -938,6 +973,12 @@ function createHarness(options = {}) {
 		get unrefCalls() {
 			return unrefCalls;
 		},
+		get clearIntervalCalls() {
+			return clearIntervalCalls;
+		},
+		get hasActiveTimer() {
+			return activeTimer !== undefined;
+		},
 		async start() {
 			await emit("session_start", { type: "session_start", reason: "startup" });
 		},
@@ -962,6 +1003,7 @@ function createHarness(options = {}) {
 		},
 		tickAt(value) {
 			now = value;
+			assert.ok(activeTimer);
 			assert.ok(timerCallback);
 			timerCallback();
 		},


### PR DESCRIPTION
Closes #68

## Summary

- make cache warming off by default and require `/cache-warm on` per session
- keep the existing one-minute expiry safety margin instead of moving to 4m50s
- derive the default rolling-hour cap from the four-minute cadence (15/hour), preventing the limiter from forcing cache misses
- add sustained-cadence, startup, reset, and timer-cleanup coverage
- update package metadata, user/developer docs, changelog, and decision record

## Why

The previous 12/hour cap was incompatible with the default four-minute warm cadence. In a continuously enabled session it eventually blocked warming long enough for the five-minute cache to expire. Moving the warm point to 4m50s would leave only ten seconds for event-loop, queueing, and provider latency, making expiration more likely rather than fixing the limiter issue.

## Validation

- `cd extensions/cache-warm && npm test` — 40 tests passed
- `git diff --check`
- `python3 -m json.tool extensions/cache-warm/package.json`