### PR TITLE
feat(opencode-pi): session reuse, cost/status discovery, P1 hygiene (epic #69)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **opencode-pi 1.2.0**: Prompt caching via OpenCode session reuse across turns (#69, #74, #75, #76). Each Pi session keeps one stable OpenCode project directory (removed at session teardown) and one continued OpenCode session: continuation turns pass `--session` and send only the transcript delta instead of the full transcript, so the provider serves cached prompt prefixes (measured on `mimo-v2.5-free`: 483 input tokens with zero cache read fresh vs 51 input with 1216 cached tokens continued). The session restarts fresh — full transcript, new OpenCode session — whenever the model, tool list, or system prompt changes, the transcript no longer extends the previously sent prefix, or any turn errors, times out, or aborts. Turns without a Pi session ID keep the previous isolated one-shot behavior.
+- **opencode-pi 1.2.0**: Real model cost and status from discovery metadata (#77, #78, #79). Free models are selected by zero input/output cost instead of the `-free` name pattern (same seven models on current metadata; future free models without the suffix are picked up automatically), inactive-status models are skipped, and a paid model registered via `OPENCODE_PI_MODELS` now reports its real cost instead of zero.
+
+### Fixed
+
+- **opencode-pi 1.2.0**: Correctness and hygiene guards the session reuse depends on (#70, #71, #72, #73). The stale `DEFAULT_FREE_MODELS` fallback (dead `deepseek-v4-flash-free` / `nemotron-3-super-free` IDs) is replaced with live IDs (`mimo-v2.5-free`, `nemotron-3.5-lightning-free`, `ling-3.0-flash-fin-free`, `big-pickle`, all verified resolvable); every turn's OpenCode session record is captured from the JSON event stream and deleted fire-and-forget (one-shot turns after each turn, session turns at teardown or on restart, never failing the turn); the abort listener is detached on every exit path including error and timeout; and every turn is bounded by an unconditional 3-minute internal timeout even when Pi supplies no `timeoutMs`.
+
 ### Fixed
 
 - **grok-pi 1.4.1**: Windows turns no longer pass Pi's full prompt as `grok --single` argv. CreateProcess caps the command line at ~32KB, so even a one-word message hit `spawn ENAMETOOLONG` and grok-pi misreported it as a missing Grok CLI. Turns now write the prompt to a temp file and invoke `grok --prompt-file`. Also treat `~/.grok/bin/grok.exe` as an installed CLI, and prefer that path when `GROK_PI_BIN` is unset on Windows.

--- a/extensions/opencode-pi/README.md
+++ b/extensions/opencode-pi/README.md
@@ -98,29 +98,31 @@ This queries `opencode models opencode --verbose`, parses each model's capabilit
 | Environment variable | Description                                                                                         |
 | -------------------- | --------------------------------------------------------------------------------------------------- |
 | `OPENCODE_PI_BIN`    | Override the OpenCode executable path. Defaults to `opencode`.                                      |
-| `OPENCODE_PI_MODELS` | Comma- or space-separated model list to register. Values without `/` are prefixed with `opencode/`. Registers immediately with conservative fallback metadata (skipping verbose discovery so startup never pays a discovery timeout); run `/opencode-pi update` to enrich these models with real capabilities from verbose discovery. |
+| `OPENCODE_PI_MODELS` | Comma- or space-separated model list to register. Values without `/` are prefixed with `opencode/`. Registers immediately with conservative fallback metadata (skipping verbose discovery so startup never pays a discovery timeout); run `/opencode-pi update` to enrich these models with real capabilities and cost from verbose discovery. |
 
 Example:
 
 ```bash
-OPENCODE_PI_MODELS="opencode/deepseek-v4-flash-free,opencode/mimo-v2.5-free" pi
+OPENCODE_PI_MODELS="opencode/mimo-v2.5-free,opencode/big-pickle" pi
 ```
 
 ## How it works
 
 For each Pi model call, the extension:
 
-1. Discovers model metadata from the ID/JSON pairs printed by `opencode models opencode --verbose`.
-2. Creates a temporary OpenCode project with a locked-down `pi-model` agent.
+1. Discovers model metadata from the ID/JSON pairs printed by `opencode models opencode --verbose`. Free models are selected by zero input/output cost in that metadata (not by name), models whose status is not `active` are skipped, and each registered model reports its real cost.
+2. Reuses one OpenCode project directory per Pi session (tracked by Pi's session ID) with a locked-down `pi-model` agent, instead of a fresh temporary directory per turn.
 3. Denies OpenCode's own tools (`bash`, `edit`, `read`, web tools, subagents, etc.).
-4. Sends Pi's current prompt/context to `opencode run --format json` over stdin.
+4. Sends Pi's current prompt/context to `opencode run --format json` over stdin — the full transcript on the first turn, only the new transcript delta with `--session` on continuation turns so the provider serves cached prompt prefixes.
 5. Writes user and tool-result images to temporary files and adds one `--file` argument per image when the selected model advertises image input.
 6. Enables `--thinking` for reasoning models, maps supported Pi reasoning levels to discovered OpenCode variants, and converts reasoning JSON events into Pi thinking blocks.
 7. Converts marker-only `<pi_tool_call>{...}</pi_tool_call>` responses into real Pi tool calls, so Pi executes tools rather than OpenCode.
 
+A continuation restarts as a fresh full-transcript session whenever the model, tool list, or system prompt changes, or the transcript no longer extends the previously sent prefix (for example after compaction). Any error, timeout, or abort also drops the session so the next turn starts fresh. Every turn is bounded by an unconditional internal timeout (3 minutes by default, or Pi's `timeoutMs` when supplied), and the abort listener is detached on every exit path.
+
 Tool markers are treated as control syntax only inside `<pi_tool_call>` blocks. The parser accepts markers surrounded by model prose, whole-response JSON-quoted markers, common unambiguous closing-tag variants, and a complete JSON payload whose closing tag was omitted. It also narrowly repairs unescaped quotes inside JSON string values—a compatibility case seen when reasoning models generate shell commands—then applies the normal payload validation and current-tool allowlist. Truncated or ambiguous markers and other malformed arguments are never executed: valid sibling tool calls still run, unrecoverable marker text is stripped from the displayed response instead of failing the turn, and a corrective diagnostic is reported only when no marker payload could be salvaged or an unavailable tool was requested. Tool-call IDs are retained in the serialized transcript so later results can be matched correctly.
 
-This keeps file access and edits under Pi's normal tool pipeline. Temporary image and agent files are removed after each turn.
+This keeps file access and edits under Pi's normal tool pipeline. Turns without a Pi session context run in an isolated temporary project whose directory and OpenCode session record are deleted when the turn finishes. Turns inside a Pi session share one project directory and OpenCode session until the session ends, when both are removed at teardown.
 
 ## Testing
 
@@ -132,9 +134,9 @@ npm test
 
 ## Notes and limitations
 
-- This is a CLI bridge, not a native provider API. It is slower than direct HTTP providers because it starts `opencode run` for each model turn.
+- This is a CLI bridge, not a native provider API. It is slower than direct HTTP providers because it starts `opencode run` for each model turn; session reuse across turns keeps the provider's cached prompt prefix warm to reduce latency on free models.
 - Tool calling is prompt-bridged. Marker payloads remain shape-validated and tool-allowlisted; the only leniency is prose extraction and narrow repair of unescaped quotes inside JSON strings. Native tool-call providers can still be more reliable.
-- Image and reasoning support are advertised per model only when verbose discovery reports those capabilities. Models configured via `OPENCODE_PI_MODELS` start on conservative text-only, non-reasoning fallback metadata (no discovery call at startup) until `/opencode-pi update` runs discovery to enrich them; default (unconfigured) IDs fall back the same way if discovery fails.
+- Image, reasoning, and cost support are advertised per model only when verbose discovery reports those capabilities and cost. Models configured via `OPENCODE_PI_MODELS` start on conservative text-only, non-reasoning, zero-cost fallback metadata (no discovery call at startup) until `/opencode-pi update` runs discovery to enrich them; default (unconfigured) IDs fall back to the bundled free-model list the same way if discovery fails.
 - Reasoning levels are exposed only for variants reported by OpenCode; models without variants do not claim selectable thinking levels.
 - If OpenCode ever attempts to use its own tools, the extension fails the turn instead of hiding it.
 

--- a/extensions/opencode-pi/package-lock.json
+++ b/extensions/opencode-pi/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-pi",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-pi",
-      "version": "1.1.4",
+      "version": "1.2.0",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.6.0"

--- a/extensions/opencode-pi/package.json
+++ b/extensions/opencode-pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-pi",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "description": "Bridge OpenCode CLI free models into Pi without OpenCode login",
   "type": "module",
   "main": "./src/index.ts",

--- a/extensions/opencode-pi/src/index.test.ts
+++ b/extensions/opencode-pi/src/index.test.ts
@@ -23,14 +23,21 @@ import type {
   Model,
 } from "@earendil-works/pi-ai";
 import opencodePiExtension, {
+  cleanupPiSessionState,
+  deleteOpenCodeSession,
   discoverModels,
   imageContentsForModel,
+  isActiveModel,
+  isFreeModel,
   isToolCallMarkerResponse,
+  parseModelCost,
   parseToolCallResponse,
   parseToolCalls,
   parseVerboseModels,
   reasoningCliArgs,
+  resolveTurnTimeoutMs,
   streamOpenCode,
+  trackedPiSessionCount,
 } from "./index.js";
 
 function fakeModel(): Model<Api> {
@@ -210,7 +217,8 @@ opencode/text-free
       image: true,
       contextWindow: 200000,
       maxTokens: 32000,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      cost: { input: 99, output: 99, cacheRead: 0, cacheWrite: 0 },
+      costFromMetadata: true,
       thinkingLevelMap: {
         off: "none",
         minimal: null,
@@ -1231,5 +1239,536 @@ process.stdout.write([
     assert.match(info?.message ?? "", /registered \d+ OpenCode CLI model\(s\)/);
   } finally {
     restoreEnv("OPENCODE_PI_MODELS", previousModels);
+  }
+});
+
+test("parseModelCost reads real input, output, and cache figures", () => {
+  assert.deepEqual(
+    parseModelCost({
+      cost: { input: 10, output: 50, cache: { read: 1, write: 12.5 } },
+    }),
+    { input: 10, output: 50, cacheRead: 1, cacheWrite: 12.5 },
+  );
+});
+
+test("parseModelCost defaults missing or malformed figures to zero", () => {
+  assert.deepEqual(parseModelCost({}), {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+  });
+  assert.deepEqual(
+    parseModelCost({
+      cost: { input: -5, output: "free", cache: { read: NaN, write: null } },
+    }),
+    { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  );
+});
+
+test("parseVerboseModels records status and cost provenance", () => {
+  const output = `opencode/paid-model
+{
+  "cost": { "input": 3, "output": 15, "cache": { "read": 0.3, "write": 3.75 } },
+  "status": "active",
+  "capabilities": {}
+}
+opencode/retired-free
+{
+  "cost": { "input": 0, "output": 0, "cache": { "read": 0, "write": 0 } },
+  "status": "deprecated",
+  "capabilities": {}
+}
+`;
+  assert.deepEqual(parseVerboseModels(output), [
+    {
+      id: "opencode/paid-model",
+      name: "OpenCode paid-model",
+      reasoning: false,
+      image: false,
+      contextWindow: 128000,
+      maxTokens: 16384,
+      cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+      costFromMetadata: true,
+      status: "active",
+    },
+    {
+      id: "opencode/retired-free",
+      name: "OpenCode retired-free",
+      reasoning: false,
+      image: false,
+      contextWindow: 128000,
+      maxTokens: 16384,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      costFromMetadata: true,
+      status: "deprecated",
+    },
+  ]);
+});
+
+test("isFreeModel selects by cost metadata, not the name pattern", () => {
+  const zero = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+  // A free model without a -free suffix is picked up via cost metadata.
+  assert.equal(
+    isFreeModel({ id: "opencode/big-pickle", cost: zero, costFromMetadata: true }),
+    true,
+  );
+  // A paid model keeps its real cost even with a -free-looking name.
+  assert.equal(
+    isFreeModel({
+      id: "opencode/sneaky-free",
+      cost: { input: 3, output: 15, cacheRead: 0, cacheWrite: 0 },
+      costFromMetadata: true,
+    }),
+    false,
+  );
+  // Without cost metadata the legacy name pattern still applies.
+  assert.equal(isFreeModel({ id: "opencode/old-free", cost: zero }), true);
+  assert.equal(isFreeModel({ id: "opencode/old-paid", cost: zero }), false);
+});
+
+test("isActiveModel excludes non-active statuses and tolerates a missing field", () => {
+  assert.equal(isActiveModel("active"), true);
+  assert.equal(isActiveModel("Active"), true);
+  assert.equal(isActiveModel("deprecated"), false);
+  assert.equal(isActiveModel("disabled"), false);
+  assert.equal(isActiveModel(undefined), true);
+  assert.equal(isActiveModel(null), true);
+});
+
+test("discoverModels selects zero-cost models and skips inactive ones", async () => {
+  const previousModels = process.env.OPENCODE_PI_MODELS;
+  const previousBin = process.env.OPENCODE_PI_BIN;
+  delete process.env.OPENCODE_PI_MODELS;
+  const dir = mkdtempSync(join(tmpdir(), "opencode-pi-fake-bin-"));
+  const binPath = join(dir, "opencode-fake.js");
+  writeFileSync(
+    binPath,
+    `#!/usr/bin/env node
+process.stdout.write([
+  "opencode/plain-free-name",
+  JSON.stringify({
+    status: "active",
+    cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+    capabilities: {},
+  }),
+  "opencode/retired-free",
+  JSON.stringify({
+    status: "deprecated",
+    cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+    capabilities: {},
+  }),
+  "opencode/sneaky-free",
+  JSON.stringify({
+    status: "active",
+    cost: { input: 3, output: 15, cache: { read: 0.3, write: 0 } },
+    capabilities: {},
+  }),
+].join("\\n"));
+`,
+    "utf8",
+  );
+  chmodSync(binPath, 0o755);
+  process.env.OPENCODE_PI_BIN = binPath;
+
+  try {
+    const { models, error } = await discoverModels();
+
+    assert.equal(error, undefined);
+    assert.deepEqual(
+      models.map((model) => model.id),
+      ["opencode/plain-free-name"],
+    );
+  } finally {
+    restoreEnv("OPENCODE_PI_BIN", previousBin);
+    restoreEnv("OPENCODE_PI_MODELS", previousModels);
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("discoverModels reports real cost for a configured paid model", async () => {
+  const previousModels = process.env.OPENCODE_PI_MODELS;
+  const previousBin = process.env.OPENCODE_PI_BIN;
+  process.env.OPENCODE_PI_MODELS = "opencode/paid-model";
+  const dir = mkdtempSync(join(tmpdir(), "opencode-pi-fake-bin-"));
+  const binPath = join(dir, "opencode-fake.js");
+  writeFileSync(
+    binPath,
+    `#!/usr/bin/env node
+process.stdout.write([
+  "opencode/paid-model",
+  JSON.stringify({
+    status: "active",
+    cost: { input: 3, output: 15, cache: { read: 0.3, write: 3.75 } },
+    capabilities: {},
+  }),
+].join("\\n"));
+`,
+    "utf8",
+  );
+  chmodSync(binPath, 0o755);
+  process.env.OPENCODE_PI_BIN = binPath;
+
+  try {
+    const { models, error } = await discoverModels({ forceDiscovery: true });
+
+    assert.equal(error, undefined);
+    assert.equal(models.length, 1);
+    assert.deepEqual(models[0]?.cost, {
+      input: 3,
+      output: 15,
+      cacheRead: 0.3,
+      cacheWrite: 3.75,
+    });
+  } finally {
+    restoreEnv("OPENCODE_PI_BIN", previousBin);
+    restoreEnv("OPENCODE_PI_MODELS", previousModels);
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("discoverModels falls back to live free model IDs when discovery fails", async () => {
+  const previousModels = process.env.OPENCODE_PI_MODELS;
+  const previousBin = process.env.OPENCODE_PI_BIN;
+  delete process.env.OPENCODE_PI_MODELS;
+  const dir = mkdtempSync(join(tmpdir(), "opencode-pi-fake-bin-"));
+  const binPath = join(dir, "opencode-fake.js");
+  writeFileSync(
+    binPath,
+    "#!/usr/bin/env node\nprocess.stderr.write('boom');\nprocess.exit(1);\n",
+    "utf8",
+  );
+  chmodSync(binPath, 0o755);
+  process.env.OPENCODE_PI_BIN = binPath;
+
+  try {
+    const { models, error } = await discoverModels();
+
+    assert.notEqual(error, undefined);
+    assert.deepEqual(
+      models.map((model) => model.id),
+      [
+        "opencode/mimo-v2.5-free",
+        "opencode/nemotron-3.5-lightning-free",
+        "opencode/ling-3.0-flash-fin-free",
+        "opencode/big-pickle",
+      ],
+    );
+  } finally {
+    restoreEnv("OPENCODE_PI_BIN", previousBin);
+    restoreEnv("OPENCODE_PI_MODELS", previousModels);
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("resolveTurnTimeoutMs honors Pi timeouts and bounds unbounded turns", () => {
+  assert.equal(resolveTurnTimeoutMs(30), 30);
+  assert.equal(resolveTurnTimeoutMs(600_000), 600_000);
+  assert.equal(resolveTurnTimeoutMs(undefined), 180_000);
+  assert.equal(resolveTurnTimeoutMs(0), 180_000);
+  assert.equal(resolveTurnTimeoutMs(-5), 180_000);
+  assert.equal(resolveTurnTimeoutMs(Number.NaN), 180_000);
+  assert.equal(resolveTurnTimeoutMs(Number.POSITIVE_INFINITY), 180_000);
+});
+
+test("streamOpenCode detaches the abort listener on the error path", async () => {
+  let added = 0;
+  let removed = 0;
+  const signal = {
+    aborted: false,
+    addEventListener() {
+      added += 1;
+    },
+    removeEventListener() {
+      removed += 1;
+    },
+  } as unknown as AbortSignal;
+
+  await withFakeOpenCode(
+    fakeEventScript([
+      { type: "text", part: { text: '<pi_tool_call>{"name":"nope"}</pi_tool_call>' } },
+    ]),
+    () =>
+      streamOpenCode(fakeModel(), fakeContext(["read"]), { signal }).result(),
+  );
+
+  assert.equal(added, 1);
+  assert.equal(removed, 1);
+});
+
+test("streamOpenCode detaches the abort listener on the timeout path", async () => {
+  let added = 0;
+  let removed = 0;
+  const signal = {
+    aborted: false,
+    addEventListener() {
+      added += 1;
+    },
+    removeEventListener() {
+      removed += 1;
+    },
+  } as unknown as AbortSignal;
+
+  const message = await withFakeOpenCode(
+    "setInterval(() => undefined, 1_000);",
+    () =>
+      streamOpenCode(fakeModel(), fakeContext(), {
+        signal,
+        timeoutMs: 30,
+      }).result(),
+  );
+
+  assert.equal(message.stopReason, "error");
+  assert.equal(added, 1);
+  assert.equal(removed, 1);
+});
+
+// A fake `opencode` binary that records every invocation (args + stdin) and
+// answers turns with a fixed session ID, so session-reuse tests can assert
+// continuation args, delta-only prompts, and directory stability. The
+// fire-and-forget `session delete` helper hits the same binary and must not
+// pollute the capture log.
+function sessionFakeScript(capturePath: string, sessionId: string): string {
+  return `const fs = require("node:fs");
+if (process.argv.includes("session")) process.exit(0);
+let body = "";
+process.stdin.on("data", (chunk) => { body += chunk; });
+process.stdin.on("end", () => {
+  fs.appendFileSync(${JSON.stringify(capturePath)}, JSON.stringify({ args: process.argv.slice(2), stdin: body }) + "\\n");
+  process.stdout.write(JSON.stringify({ type: "text", part: { text: "hello" }, sessionID: ${JSON.stringify(sessionId)} }) + "\\n");
+  process.stdout.write(JSON.stringify({ type: "step_finish", part: { reason: "stop", tokens: { total: 10, input: 5, output: 5, reasoning: 0, cache: { read: 0, write: 0 } } }, sessionID: ${JSON.stringify(sessionId)} }) + "\\n");
+});
+`;
+}
+
+function readInvocations(capturePath: string): { args: string[]; stdin: string }[] {
+  if (!existsSync(capturePath)) return [];
+  return readFileSync(capturePath, "utf8")
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+function userContext(texts: string[], toolNames: string[] = []): Context {
+  return {
+    messages: texts.map((text, index) => ({
+      role: "user" as const,
+      content: text,
+      timestamp: index + 1,
+    })),
+    tools: toolNames.map((name) => ({
+      name,
+      description: `${name} tool`,
+      parameters: {},
+    })) as Context["tools"],
+  };
+}
+
+function conversationContext(): Context {
+  return {
+    messages: [
+      { role: "user", content: "first question", timestamp: 1 },
+      {
+        role: "assistant",
+        content: [{ type: "text" as const, text: "hello" }],
+        timestamp: 2,
+      } as unknown as Context["messages"][number],
+      { role: "user", content: "second question", timestamp: 3 },
+    ],
+  };
+}
+
+test("streamOpenCode reuses the session and sends only the transcript delta", async () => {
+  const captureDir = mkdtempSync(join(tmpdir(), "opencode-pi-capture-"));
+  const capturePath = join(captureDir, "invocations.jsonl");
+  const piSessionId = `pi-reuse-${Date.now()}`;
+  try {
+    const first = await withFakeOpenCode(
+      sessionFakeScript(capturePath, "ses-reuse-1"),
+      () =>
+        streamOpenCode(fakeModel(), userContext(["first question"]), {
+          sessionId: piSessionId,
+        }).result(),
+    );
+    assert.equal(first.stopReason, "stop");
+
+    const second = await withFakeOpenCode(
+      sessionFakeScript(capturePath, "ses-reuse-1"),
+      () =>
+        streamOpenCode(fakeModel(), conversationContext(), {
+          sessionId: piSessionId,
+        }).result(),
+    );
+    assert.equal(second.stopReason, "stop");
+
+    const invocations = readInvocations(capturePath);
+    assert.equal(invocations.length, 2);
+    // First turn starts a fresh session with the full transcript.
+    assert.equal(invocations[0]?.args.includes("--session"), false);
+    assert.match(invocations[0]?.stdin ?? "", /first question/);
+    // Continuation passes --session, reuses the directory, and sends the delta.
+    const sessionIndex = invocations[1]?.args.indexOf("--session") ?? -1;
+    assert.notEqual(sessionIndex, -1);
+    assert.equal(invocations[1]?.args[sessionIndex + 1], "ses-reuse-1");
+    assert.match(invocations[1]?.stdin ?? "", /second question/);
+    assert.equal((invocations[1]?.stdin ?? "").includes("first question"), false);
+    const dirIndex = (args: string[]) => args.indexOf("--dir");
+    assert.equal(
+      invocations[1]?.args[dirIndex(invocations[1]?.args ?? []) + 1],
+      invocations[0]?.args[dirIndex(invocations[0]?.args ?? []) + 1],
+    );
+    assert.equal(trackedPiSessionCount() >= 1, true);
+  } finally {
+    await cleanupPiSessionState(piSessionId);
+    rmSync(captureDir, { recursive: true, force: true });
+  }
+});
+
+test("streamOpenCode starts fresh after an error drops the session", async () => {
+  const captureDir = mkdtempSync(join(tmpdir(), "opencode-pi-capture-"));
+  const capturePath = join(captureDir, "invocations.jsonl");
+  const piSessionId = `pi-drop-${Date.now()}`;
+  try {
+    const first = await withFakeOpenCode(
+      sessionFakeScript(capturePath, "ses-drop-1"),
+      () =>
+        streamOpenCode(fakeModel(), userContext(["first question"]), {
+          sessionId: piSessionId,
+        }).result(),
+    );
+    assert.equal(first.stopReason, "stop");
+
+    // A failed turn (invalid tool-call payload) drops the recorded session.
+    const failed = await withFakeOpenCode(
+      `const fs = require("node:fs");
+if (process.argv.includes("session")) process.exit(0);
+let body = "";
+process.stdin.on("data", (chunk) => { body += chunk; });
+process.stdin.on("end", () => {
+  fs.appendFileSync(${JSON.stringify(capturePath)}, JSON.stringify({ args: process.argv.slice(2), stdin: body }) + "\\n");
+  process.stdout.write(JSON.stringify({ type: "text", part: { text: '<pi_tool_call>{"name":"nope"}</pi_tool_call>', sessionID: "ses-drop-1" } }) + "\\n");
+});
+`,
+      () =>
+        streamOpenCode(fakeModel(), userContext(["boom"]), {
+          sessionId: piSessionId,
+        }).result(),
+    );
+    assert.equal(failed.stopReason, "error");
+
+    const recovered = await withFakeOpenCode(
+      sessionFakeScript(capturePath, "ses-drop-2"),
+      () =>
+        streamOpenCode(fakeModel(), userContext(["third question"]), {
+          sessionId: piSessionId,
+        }).result(),
+    );
+    assert.equal(recovered.stopReason, "stop");
+
+    const invocations = readInvocations(capturePath);
+    assert.equal(invocations.length, 3);
+    // The recovery turn starts a fresh full-transcript session.
+    assert.equal(invocations[2]?.args.includes("--session"), false);
+    assert.match(invocations[2]?.stdin ?? "", /Conversation transcript/);
+  } finally {
+    await cleanupPiSessionState(piSessionId);
+    rmSync(captureDir, { recursive: true, force: true });
+  }
+});
+
+test("streamOpenCode restarts the session when tools change", async () => {
+  const captureDir = mkdtempSync(join(tmpdir(), "opencode-pi-capture-"));
+  const capturePath = join(captureDir, "invocations.jsonl");
+  const piSessionId = `pi-tools-${Date.now()}`;
+  try {
+    const first = await withFakeOpenCode(
+      sessionFakeScript(capturePath, "ses-tools-1"),
+      () =>
+        streamOpenCode(fakeModel(), userContext(["q1"], ["read"]), {
+          sessionId: piSessionId,
+        }).result(),
+    );
+    assert.equal(first.stopReason, "stop");
+
+    const second = await withFakeOpenCode(
+      sessionFakeScript(capturePath, "ses-tools-2"),
+      () =>
+        streamOpenCode(fakeModel(), userContext(["q1", "q2"], ["read", "bash"]), {
+          sessionId: piSessionId,
+        }).result(),
+    );
+    assert.equal(second.stopReason, "stop");
+
+    const invocations = readInvocations(capturePath);
+    assert.equal(invocations.length, 2);
+    // A changed tool list restarts with the full transcript, not a delta.
+    assert.equal(invocations[1]?.args.includes("--session"), false);
+    assert.match(invocations[1]?.stdin ?? "", /Available Pi tools/);
+    assert.match(invocations[1]?.stdin ?? "", /q1/);
+  } finally {
+    await cleanupPiSessionState(piSessionId);
+    rmSync(captureDir, { recursive: true, force: true });
+  }
+});
+
+test("streamOpenCode runs isolated fresh sessions without a Pi session ID", async () => {
+  const captureDir = mkdtempSync(join(tmpdir(), "opencode-pi-capture-"));
+  const capturePath = join(captureDir, "invocations.jsonl");
+  try {
+    for (const question of ["q1", "q2"]) {
+      const message = await withFakeOpenCode(
+        sessionFakeScript(capturePath, "ses-once"),
+        () => streamOpenCode(fakeModel(), userContext([question])).result(),
+      );
+      assert.equal(message.stopReason, "stop");
+    }
+    const invocations = readInvocations(capturePath);
+    assert.equal(invocations.length, 2);
+    for (const invocation of invocations) {
+      assert.equal(invocation.args.includes("--session"), false);
+      assert.match(invocation.stdin, /Conversation transcript/);
+    }
+    assert.notEqual(
+      invocationDir(invocations[0]),
+      invocationDir(invocations[1]),
+    );
+    function invocationDir(invocation: { args: string[] }): string {
+      return invocation.args[invocation.args.indexOf("--dir") + 1] ?? "";
+    }
+  } finally {
+    rmSync(captureDir, { recursive: true, force: true });
+  }
+});
+
+test("deleteOpenCodeSession never throws without a session ID", () => {
+  assert.doesNotThrow(() => deleteOpenCodeSession(undefined));
+});
+
+test("cleanupPiSessionState removes the project directory at teardown", async () => {
+  const captureDir = mkdtempSync(join(tmpdir(), "opencode-pi-capture-"));
+  const capturePath = join(captureDir, "invocations.jsonl");
+  const piSessionId = `pi-teardown-${Date.now()}`;
+  let before = 0;
+  try {
+    await withFakeOpenCode(
+      sessionFakeScript(capturePath, "ses-teardown-1"),
+      () =>
+        streamOpenCode(fakeModel(), userContext(["hello"]), {
+          sessionId: piSessionId,
+        }).result(),
+    );
+    before = trackedPiSessionCount();
+    assert.equal(before >= 1, true);
+    const invocations = readInvocations(capturePath);
+    const dir = invocations[0]?.args[invocations[0]?.args.indexOf("--dir") + 1];
+    assert.equal(existsSync(dir), true);
+
+    await cleanupPiSessionState(piSessionId);
+
+    assert.equal(existsSync(dir), false);
+    assert.equal(trackedPiSessionCount(), before - 1);
+  } finally {
+    await cleanupPiSessionState(piSessionId);
+    rmSync(captureDir, { recursive: true, force: true });
   }
 });

--- a/extensions/opencode-pi/src/index.ts
+++ b/extensions/opencode-pi/src/index.ts
@@ -30,7 +30,16 @@ const DEFAULT_CONTEXT_WINDOW = 128_000;
 const DEFAULT_MAX_TOKENS = 16_384;
 const DISCOVERY_TIMEOUT_MS = 8_000;
 const STATUS_TIMEOUT_MS = 10_000;
+const SESSION_DELETE_TIMEOUT_MS = 10_000;
 const STDERR_LIMIT = 20_000;
+/**
+ * Upper bound for every model turn, applied even when Pi supplies no
+ * `timeoutMs`. A session ID reused from the wrong project directory hangs
+ * with empty stdout/stderr, so no turn may wait indefinitely (#73).
+ */
+const DEFAULT_TURN_TIMEOUT_MS = 180_000;
+/** Cap on tracked Pi sessions; the oldest entry is evicted with cleanup. */
+const MAX_TRACKED_PI_SESSIONS = 10;
 
 export type CliStatus = {
   ok: boolean;
@@ -39,12 +48,18 @@ export type CliStatus = {
 };
 
 const DEFAULT_FREE_MODELS = [
-  "opencode/deepseek-v4-flash-free",
   "opencode/mimo-v2.5-free",
-  "opencode/nemotron-3-super-free",
+  "opencode/nemotron-3.5-lightning-free",
+  "opencode/ling-3.0-flash-fin-free",
   "opencode/big-pickle",
 ];
-const ZERO_COST = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 } as const;
+export type ModelCost = {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+};
+const ZERO_COST: ModelCost = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
 const THINKING_LEVELS = [
   "off",
   "minimal",
@@ -61,7 +76,10 @@ export type OpenCodeModelInfo = {
   image: boolean;
   contextWindow: number;
   maxTokens: number;
-  cost: typeof ZERO_COST;
+  cost: ModelCost;
+  /** True when `cost` was read from discovery metadata rather than defaulted. */
+  costFromMetadata?: boolean;
+  status?: string;
   thinkingLevelMap?: ThinkingLevelMap;
 };
 
@@ -115,6 +133,61 @@ function maxTokensFor(model: string): number {
 
 function looksFree(model: string): boolean {
   return /(^opencode\/.*-free$)|(^opencode\/big-pickle$)/.test(model);
+}
+
+/** Read a non-negative finite cost figure; anything else means "unknown". */
+function costFigure(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0
+    ? value
+    : undefined;
+}
+
+/**
+ * Read the real per-model cost from verbose discovery metadata (#78).
+ * Missing or malformed figures fall back to zero so a model is never
+ * reported with an invented non-zero cost.
+ */
+export function parseModelCost(metadata: unknown): ModelCost {
+  const value = metadata as {
+    cost?: {
+      input?: unknown;
+      output?: unknown;
+      cache?: { read?: unknown; write?: unknown };
+    };
+  } | null;
+  const cost = value?.cost;
+  return {
+    input: costFigure(cost?.input) ?? 0,
+    output: costFigure(cost?.output) ?? 0,
+    cacheRead: costFigure(cost?.cache?.read) ?? 0,
+    cacheWrite: costFigure(cost?.cache?.write) ?? 0,
+  };
+}
+
+/**
+ * Free models are identified by zero input and output cost in the discovery
+ * metadata (#77). When a record carries no usable cost figures (older CLI
+ * output), fall back to the legacy `-free` name pattern so paid models are
+ * never misregistered as free.
+ */
+export function isFreeModel(model: {
+  id: string;
+  cost: ModelCost;
+  costFromMetadata?: boolean;
+}): boolean {
+  if (model.cost.input !== 0 || model.cost.output !== 0) return false;
+  if (model.costFromMetadata === true) return true;
+  return looksFree(model.id);
+}
+
+/**
+ * Discovery metadata carries a per-model status field (#79). Only `active`
+ * models are registered; a missing status is treated as active so older CLI
+ * output without the field keeps working.
+ */
+export function isActiveModel(status: unknown): boolean {
+  if (status === undefined || status === null) return true;
+  return String(status).trim().toLowerCase() === "active";
 }
 
 function dedupe(values: string[]): string[] {
@@ -219,11 +292,25 @@ export function parseVerboseModels(output: string): OpenCodeModelInfo[] {
 
     const value = metadata as {
       name?: unknown;
+      status?: unknown;
+      cost?: {
+        input?: unknown;
+        output?: unknown;
+        cache?: { read?: unknown; write?: unknown };
+      };
       limit?: { context?: unknown; output?: unknown };
       capabilities?: { reasoning?: unknown; input?: { image?: unknown } };
       variants?: unknown;
     };
     const reasoning = value.capabilities?.reasoning === true;
+    const cost = parseModelCost(value);
+    const costFromMetadata =
+      costFigure(value.cost?.input) !== undefined &&
+      costFigure(value.cost?.output) !== undefined;
+    const status =
+      typeof value.status === "string" && value.status.trim()
+        ? value.status.trim()
+        : undefined;
     records.set(id, {
       id,
       name:
@@ -237,7 +324,9 @@ export function parseVerboseModels(output: string): OpenCodeModelInfo[] {
         contextWindowFor(id),
       ),
       maxTokens: positiveNumber(value.limit?.output, maxTokensFor(id)),
-      cost: ZERO_COST,
+      cost,
+      ...(costFromMetadata ? { costFromMetadata: true as const } : {}),
+      ...(status !== undefined ? { status } : {}),
       ...(reasoning
         ? { thinkingLevelMap: thinkingLevelMap(value.variants) }
         : {}),
@@ -360,7 +449,9 @@ export async function discoverModels(opts?: {
     const byId = new Map(metadata.map((model) => [model.id, model]));
     const selected = configured?.length
       ? dedupe(configured).map((id) => byId.get(id) ?? fallbackModel(id))
-      : metadata.filter((model) => looksFree(model.id));
+      : metadata.filter(
+          (model) => isActiveModel(model.status) && isFreeModel(model),
+        );
     if (selected.length === 0) {
       throw new Error("opencode verbose model discovery returned no free models");
     }
@@ -1022,6 +1113,172 @@ function parseToolCallJson(raw: string): ParsedToolCall[] {
   return calls;
 }
 
+/**
+ * Effective per-turn timeout: honor Pi's `timeoutMs` when it is a positive
+ * finite number, otherwise fall back to the unconditional internal bound so
+ * no turn can hang indefinitely (#73).
+ */
+export function resolveTurnTimeoutMs(timeoutMs: unknown): number {
+  return typeof timeoutMs === "number" &&
+    Number.isFinite(timeoutMs) &&
+    timeoutMs > 0
+    ? timeoutMs
+    : DEFAULT_TURN_TIMEOUT_MS;
+}
+
+/**
+ * Best-effort deletion of an OpenCode session record (#71). Fire-and-forget:
+ * a failed delete is swallowed so it never fails the turn, and the spawned
+ * helper is bounded by its own timeout.
+ */
+export function deleteOpenCodeSession(sessionId: string | undefined): void {
+  if (!sessionId) return;
+  try {
+    const child = spawn(opencodeBin(), ["session", "delete", sessionId], {
+      stdio: "ignore",
+      env: { ...process.env, OPENCODE_DISABLE_UPDATE_CHECK: "1" },
+      timeout: SESSION_DELETE_TIMEOUT_MS,
+    });
+    child.on("error", () => undefined);
+    if (typeof child.unref === "function") child.unref();
+  } catch {
+    // Never fail the turn because session cleanup failed.
+  }
+}
+
+export type PiSessionState = {
+  /** Lazily created per-Pi-session OpenCode project directory (#74). */
+  dirPromise?: Promise<string>;
+  /** Recorded OpenCode session ID reused across turns (#75). */
+  opencodeSessionId?: string;
+  /** Model ID the recorded session was created with. */
+  modelId?: string;
+  /** Serialized tool list the recorded session was created with (#76). */
+  toolsKey?: string;
+  /** System prompt the recorded session was created with (#76). */
+  systemPrompt?: string;
+  /** Serialized transcript prefix already sent to the recorded session. */
+  sentParts?: string[];
+};
+
+const piSessions = new Map<string, PiSessionState>();
+
+/** Number of tracked Pi sessions (exposed for tests). */
+export function trackedPiSessionCount(): number {
+  return piSessions.size;
+}
+
+function getPiSessionState(piSessionId: string): PiSessionState {
+  const existing = piSessions.get(piSessionId);
+  if (existing) {
+    // Refresh recency so eviction drops the least-recently-used entry.
+    piSessions.delete(piSessionId);
+    piSessions.set(piSessionId, existing);
+    return existing;
+  }
+  const state: PiSessionState = {};
+  piSessions.set(piSessionId, state);
+  while (piSessions.size > MAX_TRACKED_PI_SESSIONS) {
+    const oldest = piSessions.keys().next();
+    if (oldest.done) break;
+    void cleanupPiSessionState(oldest.value as string);
+  }
+  return state;
+}
+
+function ensurePiSessionDir(state: PiSessionState): Promise<string> {
+  state.dirPromise ??= createTempAgentDir().catch((error) => {
+    if (state.dirPromise) state.dirPromise = undefined;
+    throw error;
+  });
+  return state.dirPromise;
+}
+
+/**
+ * Remove a Pi session's project directory and delete its OpenCode session
+ * record — the explicit cleanup path for session teardown (#74). With no
+ * argument, every tracked session is cleaned up.
+ */
+export async function cleanupPiSessionState(
+  piSessionId?: string,
+): Promise<void> {
+  const ids =
+    piSessionId === undefined ? [...piSessions.keys()] : [piSessionId];
+  await Promise.all(
+    ids.map(async (id) => {
+      const state = piSessions.get(id);
+      if (!state) return;
+      piSessions.delete(id);
+      deleteOpenCodeSession(state.opencodeSessionId);
+      state.opencodeSessionId = undefined;
+      if (state.dirPromise) {
+        const dirPromise = state.dirPromise;
+        state.dirPromise = undefined;
+        const dir = await dirPromise.catch(() => undefined);
+        if (dir) await rm(dir, { recursive: true, force: true }).catch(() => undefined);
+      }
+    }),
+  );
+}
+
+/** Forget a broken session so the next turn starts fresh (#75). */
+function dropOpencodeSession(state: PiSessionState): void {
+  deleteOpenCodeSession(state.opencodeSessionId);
+  state.opencodeSessionId = undefined;
+  state.modelId = undefined;
+  state.toolsKey = undefined;
+  state.systemPrompt = undefined;
+  state.sentParts = undefined;
+}
+
+function serializedTranscriptParts(messages: Message[]): string[] {
+  return messages.map(serializeMessage);
+}
+
+/**
+ * Decide whether the next turn may continue the recorded OpenCode session
+ * (#75, #76). Continuation requires the same model, the same serialized
+ * tool list and system prompt, and a transcript that extends — never
+ * rewrites — the previously sent prefix, with at least one new message.
+ */
+function continuationDelta(
+  state: PiSessionState,
+  modelId: string,
+  context: Context,
+  parts: string[],
+): string[] | undefined {
+  if (!state.opencodeSessionId) return undefined;
+  if (state.modelId !== modelId) return undefined;
+  if ((state.toolsKey ?? "") !== serializeTools(context.tools)) return undefined;
+  if ((state.systemPrompt ?? "") !== (context.systemPrompt ?? "")) return undefined;
+  const sent = state.sentParts ?? [];
+  if (sent.length >= parts.length) return undefined;
+  for (let index = 0; index < sent.length; index += 1) {
+    if (sent[index] !== parts[index]) return undefined;
+  }
+  return parts.slice(sent.length);
+}
+
+function buildContinuationPrompt(deltaParts: string[]): string {
+  return [
+    "# Continued Pi/OpenCode bridge turn",
+    "",
+    "This message continues your existing OpenCode session: the Pi system prompt,",
+    "tool list, and earlier transcript are already in context. Do not ask for them again.",
+    "If you need Pi to run a tool, your entire response must contain only one or more",
+    "tool-call blocks separated by whitespace:",
+    '<pi_tool_call>{"name":"tool_name","arguments":{}}</pi_tool_call>',
+    "Use only exact tool names from the earlier tool list. Never quote markers, explain",
+    "them, or wrap them in Markdown fences. If you can answer without a tool, answer normally.",
+    "",
+    "# New transcript since your last response",
+    "",
+    deltaParts.join("\n\n---\n\n"),
+    "",
+    "Now produce the next assistant message for Pi.",
+  ].join("\n");
+}
+
 async function createTempAgentDir(): Promise<string> {
   const dir = await mkdtemp(join(tmpdir(), "opencode-pi-"));
   const agentsDir = join(dir, ".opencode", "agents");
@@ -1080,24 +1337,56 @@ export function streamOpenCode(
     let accumulatedThinking = "";
     let stderr = "";
     let stdoutRemainder = "";
+    let capturedSessionId: string | undefined;
     let opencodeToolUse: string | undefined;
     let opencodeError: string | undefined;
     let finishReason: "stop" | "length" = "stop";
     let timedOut = false;
     let timer: ReturnType<typeof setTimeout> | undefined;
-    const prompt = buildPrompt(context);
+    // Per-Pi-session reuse key supplied by Pi core (stable for the life of
+    // the Pi session). Without it, every turn runs an isolated fresh
+    // session in its own temporary directory.
+    const piSessionId =
+      typeof options?.sessionId === "string" && options.sessionId
+        ? options.sessionId
+        : undefined;
+    const piState = piSessionId ? getPiSessionState(piSessionId) : undefined;
+    const transcriptParts = serializedTranscriptParts(context.messages);
 
     try {
       stream.push({ type: "start", partial: output });
       if (options?.signal?.aborted) throw new Error("Request was aborted");
 
-      tempDir = await createTempAgentDir();
+      // Continuation decision (#75, #76): reuse the recorded OpenCode
+      // session only when the model, tools, system prompt, and transcript
+      // prefix all still match. Any drift restarts fresh — and the stale
+      // session record is deleted so it cannot leak.
+      let delta = piState
+        ? continuationDelta(piState, model.id, context, transcriptParts)
+        : undefined;
+      if (piState && piState.opencodeSessionId && delta === undefined) {
+        dropOpencodeSession(piState);
+      }
+      const isContinuation = delta !== undefined;
+      const prompt = isContinuation
+        ? buildContinuationPrompt(delta)
+        : buildPrompt(context);
+      const sentMessages = isContinuation
+        ? context.messages.slice(transcriptParts.length - delta.length)
+        : context.messages;
+
+      const sessionDir = piState
+        ? await ensurePiSessionDir(piState)
+        : await createTempAgentDir().then((dir) => {
+            tempDir = dir;
+            return dir;
+          });
       if (options?.signal?.aborted) throw new Error("Request was aborted");
       const images = imageContentsForModel(
-        context.messages,
+        sentMessages,
         model.input.includes("image"),
       );
-      const imagePaths = await writeImageFiles(images, tempDir);
+      const imagePaths = await writeImageFiles(images, sessionDir);
       if (options?.signal?.aborted) throw new Error("Request was aborted");
       const args = [
         "run",
@@ -1109,8 +1398,11 @@ export function streamOpenCode(
         "--format",
         "json",
         "--dir",
-        tempDir,
+        sessionDir,
       ];
+      if (isContinuation && piState?.opencodeSessionId) {
+        args.push("--session", piState.opencodeSessionId);
+      }
       const requestedReasoning = options?.reasoning as
         | ModelThinkingLevel
         | undefined;
@@ -1126,16 +1418,13 @@ export function streamOpenCode(
 
       const abort = () => child.kill("SIGTERM");
       options?.signal?.addEventListener("abort", abort, { once: true });
-      if (
-        typeof options?.timeoutMs === "number" &&
-        Number.isFinite(options.timeoutMs) &&
-        options.timeoutMs > 0
-      ) {
-        timer = setTimeout(() => {
-          timedOut = true;
-          child.kill("SIGTERM");
-        }, options.timeoutMs);
-      }
+      // The timeout is unconditional: a turn is always bounded, even when
+      // Pi supplies no timeoutMs (#73).
+      const turnTimeoutMs = resolveTurnTimeoutMs(options?.timeoutMs);
+      timer = setTimeout(() => {
+        timedOut = true;
+        child.kill("SIGTERM");
+      }, turnTimeoutMs);
 
       child.stdin!.end(prompt);
       child.stdout!.setEncoding("utf8");
@@ -1149,6 +1438,16 @@ export function streamOpenCode(
         } catch {
           stderr = (stderr + `\n${line}`).slice(-STDERR_LIMIT);
           return;
+        }
+
+        // Every JSON event carries the OpenCode session ID (#71).
+        if (typeof event.sessionID === "string" && event.sessionID) {
+          capturedSessionId = event.sessionID;
+        } else if (
+          typeof event.part?.sessionID === "string" &&
+          event.part.sessionID
+        ) {
+          capturedSessionId = event.part.sessionID;
         }
 
         if (event.type === "text" && typeof event.part?.text === "string") {
@@ -1216,11 +1515,17 @@ export function streamOpenCode(
         stderr = (stderr + chunk).slice(-STDERR_LIMIT);
       });
 
-      const code = await new Promise<number | null>((resolve, reject) => {
-        child.on("error", reject);
-        child.on("close", resolve);
-      });
-      options?.signal?.removeEventListener("abort", abort);
+      // The abort listener is detached on every exit path — success,
+      // error, and timeout alike (#72).
+      let code: number | null;
+      try {
+        code = await new Promise<number | null>((resolve, reject) => {
+          child.on("error", reject);
+          child.on("close", resolve);
+        });
+      } finally {
+        options?.signal?.removeEventListener("abort", abort);
+      }
       if (timer) clearTimeout(timer);
       if (stdoutRemainder.trim()) handleLine(stdoutRemainder);
 
@@ -1228,7 +1533,7 @@ export function streamOpenCode(
         throw new Error("Request was aborted");
       }
       if (timedOut) {
-        throw new Error(`opencode timed out after ${options?.timeoutMs}ms`);
+        throw new Error(`opencode timed out after ${turnTimeoutMs}ms`);
       }
       if (code !== 0) {
         throw new Error(stderr.trim() || `opencode exited with code ${code}`);
@@ -1296,6 +1601,18 @@ export function streamOpenCode(
         prompt,
         accumulatedText + accumulatedThinking,
       );
+      // The turn succeeded: record the session for reuse, or delete the
+      // one-shot session record so it cannot accumulate (#71, #75).
+      if (piState) {
+        piState.opencodeSessionId =
+          capturedSessionId ?? piState.opencodeSessionId;
+        piState.modelId = model.id;
+        piState.toolsKey = serializeTools(context.tools);
+        piState.systemPrompt = context.systemPrompt ?? "";
+        piState.sentParts = transcriptParts;
+      } else {
+        deleteOpenCodeSession(capturedSessionId);
+      }
 
       if (accumulatedThinking) {
         const thinkingIndex = output.content.length;
@@ -1375,6 +1692,11 @@ export function streamOpenCode(
       stream.end();
     } catch (error) {
       if (timer) clearTimeout(timer);
+      // Any error, timeout, or abort drops the session ID so the next turn
+      // starts fresh with the full transcript; the failed session record is
+      // deleted best-effort and never fails the turn (#71, #75).
+      deleteOpenCodeSession(capturedSessionId);
+      if (piState) dropOpencodeSession(piState);
       output.stopReason = options?.signal?.aborted ? "aborted" : "error";
       output.errorMessage =
         error instanceof Error ? error.message : String(error);
@@ -1387,6 +1709,8 @@ export function streamOpenCode(
       stream.end();
     } finally {
       if (timer) clearTimeout(timer);
+      // Only one-shot turns own their directory. Per-Pi-session directories
+      // persist for reuse and are removed at session teardown (#74).
       if (tempDir) {
         await rm(tempDir, { recursive: true, force: true }).catch(
           () => undefined,
@@ -1474,6 +1798,12 @@ export default async function opencodePiExtension(pi: ExtensionAPI) {
     streamSimple: streamOpenCode,
   });
   registerApiHandler();
+
+  // Tear down per-Pi-session OpenCode state — project directories and
+  // session records — when the Pi session ends for any reason (#74).
+  pi.on("session_shutdown", () => {
+    void cleanupPiSessionState();
+  });
 
   pi.on("session_start", async (_event: any, ctx: any) => {
     const cliStatus = await checkCliStatus();


### PR DESCRIPTION
Implements all 10 tasks of epic #69 (opencode-pi v1.2.0).

**P1 — Correctness and hygiene (M1)**
- #70 — fallback list refreshed to live IDs (verified resolvable; dead IDs delisted upstream)
- #71 — sessionID captured from JSON events; fire-and-forget `opencode session delete` (one-shot turns: after each turn; session turns: at teardown/restart; never fails the turn)
- #72 — abort listener detached in try/finally on every exit path (tested on error + timeout paths)
- #73 — unconditional 3-min internal timeout when Pi supplies no timeoutMs

**P2 — Prompt caching via session reuse (M2)**
- #74 — one OpenCode project dir per Pi session (keyed by `options.sessionId`, LRU-capped, removed at `session_shutdown`)
- #75 — continuation passes `--session` + transcript delta only (live-measured cache read on continuation); any error/timeout/abort drops the session
- #76 — prefix check covers model + serialized tools + system prompt + transcript prefix; drift restarts fresh

**P3 — Model-list flexibility (M3)**
- #77 — free selection by zero cost metadata (same 7 models today; regex kept as fallback when cost metadata is absent)
- #78 — real cost (input/output/cache read/write) read from metadata; configured paid models report real cost
- #79 — non-active status excluded (missing status treated as active for older CLIs)

**Verification:** 66/66 tests pass (17 new); live CLI checks for continuation cache-read, fallback-ID resolution, and dead-ID absence.

Closes #70, closes #71, closes #72, closes #73, closes #74, closes #75, closes #76, closes #77, closes #78, closes #79