### PR TITLE
refactor(timestamp-pi): pause refresh interval while idle (#101)

### DIFF
--- a/extensions/timestamp-pi/src/index.ts
+++ b/extensions/timestamp-pi/src/index.ts
@@ -189,23 +189,30 @@ export default function timestampPiExtension(pi: ExtensionAPI) {
     },
   });
 
+  function ensureTimer(): void {
+    if (refreshTimer) return;
+    refreshTimer = setInterval(() => {
+      syncStatus();
+    }, 1_000);
+  }
+
+  function clearTimer(): void {
+    if (refreshTimer) clearInterval(refreshTimer);
+    refreshTimer = undefined;
+  }
+
   function mount(ctx: ExtensionContext): void {
     if (!ctx.hasUI) return;
 
     mountedCtx = ctx;
     // Don't add a status element yet — nothing to show until cache activity
     // starts. Other extensions keep their own footer elements untouched.
+    // syncStatus() starts the interval only when there is something to display.
     syncStatus();
-
-    if (refreshTimer) clearInterval(refreshTimer);
-    refreshTimer = setInterval(() => {
-      syncStatus();
-    }, 1_000);
   }
 
   function unmount(ctx?: ExtensionContext): void {
-    if (refreshTimer) clearInterval(refreshTimer);
-    refreshTimer = undefined;
+    clearTimer();
     if (ctx?.hasUI) {
       ctx.ui.setStatus(STATUS_KEY, undefined);
     }
@@ -222,8 +229,10 @@ export default function timestampPiExtension(pi: ExtensionAPI) {
       const tone =
         status.state === "expired" ? "error" : status.remainingMs <= CACHE_WARN_MS ? "warning" : "success";
       mountedCtx.ui.setStatus(STATUS_KEY, mountedCtx.ui.theme.fg(tone, `⏳ ${status.label}`));
+      ensureTimer();
     } else {
       mountedCtx.ui.setStatus(STATUS_KEY, undefined);
+      clearTimer();
     }
   }
 }


### PR DESCRIPTION
Closes #101

## Summary
Pause the timestamp-pi refresh interval while the cache status is idle, starting it only when there is something to display.

## Approach
Moved interval ownership into syncStatus with ensureTimer/clearTimer helpers. mount now only calls syncStatus, which starts the timer when state is active/expired and clears it when idle or disabled. unmount clears via clearTimer.

## Changes
| File | Change |
|------|--------|
| `extensions/timestamp-pi/src/index.ts` | Idle-aware refresh: ensureTimer/clearTimer, mount/syncStatus/unmount update |

## Test Results
`npm run build` passes (tsc). `npm test` passes 25/25.

## Acceptance Criteria
- [x] No interval runs while the cache status is idle
- [x] The countdown still updates every second once cache activity starts
- [x] The timer is still cleared on unmount
