### PR TITLE
refactor(timestamp-pi): show ages beyond a day in days (#102)

### DIFF
--- a/extensions/timestamp-pi/src/index.ts
+++ b/extensions/timestamp-pi/src/index.ts
@@ -40,13 +40,14 @@ export function formatClock(ts: number): string {
   return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
 }
 
-/** Format a relative age: "now", "5s ago", "2m ago", "3h ago". */
+/** Format a relative age: "now", "5s ago", "2m ago", "3h ago", "2d ago". */
 export function formatRelative(ts: number, now: number): string {
   const diff = Math.max(0, Math.floor((now - ts) / 1000));
   if (diff < 5) return "now";
   if (diff < 60) return `${diff}s ago`;
   if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
-  return `${Math.floor(diff / 3600)}h ago`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
+  return `${Math.floor(diff / 86400)}d ago`;
 }
 
 /** Format a countdown as m:ss, clamped at 0:00. */


### PR DESCRIPTION
Closes #102

## Summary
Extend timestamp-pi relative age formatting beyond hours so ages of a day or more show in days.

## Approach
Added day boundary in formatRelative: under 86400s keeps hour format, 86400s and above returns Nd ago. Updated doc comment. Shorter formats unchanged.

## Changes
| File | Change |
|------|--------|
| `extensions/timestamp-pi/src/index.ts` | formatRelative day boundary + comment |

## Test Results
`npm run build` passes (tsc). `npm test` passes 25/25. Manual check: 1h ago, 1d ago, 2d ago, 25h -> 1d ago.

## Acceptance Criteria
- [x] An age of a day or more is shown in days
- [x] Existing shorter formats are unchanged
