### PR TITLE
fix(advisor-pi): validate default model at load with fallback and guard migration (#93)

### DIFF
--- a/extensions/advisor-pi/README.md
+++ b/extensions/advisor-pi/README.md
@@ -21,6 +21,10 @@ advice to the executor.
 - Passes a prompt-cache preference (`none`, `short`, or `long`) where the
   selected provider supports it.
 - Defaults to `openai-codex/gpt-5.6-sol` with `high` thinking.
+- Validates the configured model against the registry at load: when the
+  default (or a stored/flag-provided model) does not resolve, it falls back
+  to a working model with a warning notice instead of failing every call.
+  Stored legacy defaults are only migrated when the migration target resolves.
 - Shows a compact `advisor:<provider>/<model> <thinking> <remaining>` status in Pi's
   footer when UI is available.
 

--- a/extensions/advisor-pi/package.json
+++ b/extensions/advisor-pi/package.json
@@ -18,6 +18,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "test": "node --test",
     "prepublishOnly": "npm run build"
   },
   "pi": {

--- a/extensions/advisor-pi/src/index.ts
+++ b/extensions/advisor-pi/src/index.ts
@@ -10,8 +10,8 @@ import { Type, type Static } from "typebox";
 
 const STATE_ENTRY = "advisor-pi-state";
 const TOOL_NAME = "advisor";
-const DEFAULT_ADVISOR_MODEL = "openai-codex/gpt-5.6-sol";
-const LEGACY_DEFAULT_ADVISOR_MODEL = "openai-codex/gpt-5.5";
+export const DEFAULT_ADVISOR_MODEL = "openai-codex/gpt-5.6-sol";
+export const LEGACY_DEFAULT_ADVISOR_MODEL = "openai-codex/gpt-5.5";
 const DEFAULT_ADVISOR_THINKING_LEVEL: AdvisorThinkingLevel = "high";
 const DEFAULT_MAX_USES = 5;
 const DEFAULT_CACHE_RETENTION: CacheRetention = "short";
@@ -72,6 +72,11 @@ type AdvisorToolDetails = {
 		usage?: Usage;
 	};
 	state: AdvisorStateEntry;
+};
+
+export type ModelRegistryLike = {
+	find: (provider: string, modelId: string) => unknown;
+	getAvailable?: () => Array<{ provider?: unknown; id?: unknown }>;
 };
 
 export default function advisorPiExtension(pi: ExtensionAPI) {
@@ -250,26 +255,27 @@ export default function advisorPiExtension(pi: ExtensionAPI) {
 	function refreshStateFromBranch(ctx: ExtensionContext): void {
 		config = defaultConfig();
 		useCount = 0;
-		const restoredFromBranch = restoreStateFromSession(ctx);
-		if (!restoredFromBranch) applyStartupFlags(pi);
+		const restoredFromBranch = restoreStateFromSession(ctx, ctx.modelRegistry);
+		if (!restoredFromBranch) applyStartupFlags(pi, ctx.modelRegistry);
+		ensureAdvisorModelResolves(ctx);
 		syncActiveTool(pi);
 		updateStatus(ctx);
 	}
 
-	function restoreStateFromSession(ctx: ExtensionContext): boolean {
+	function restoreStateFromSession(ctx: ExtensionContext, registry?: ModelRegistryLike): boolean {
 		let restored = false;
 		const branch = ctx.sessionManager.getBranch();
 		for (const entry of branch) {
 			if (entry.type === "custom" && entry.customType === STATE_ENTRY) {
 				restored = true;
 				const data = entry.data as Partial<AdvisorStateEntry> | undefined;
-				if (data?.config) config = normalizeConfig(data.config, config);
+				if (data?.config) config = normalizeConfig(data.config, config, registry);
 				if (typeof data?.useCount === "number") useCount = Math.max(0, data.useCount);
 			}
 			if (entry.type === "message" && entry.message.role === "toolResult" && entry.message.toolName === TOOL_NAME) {
 				restored = true;
 				const details = entry.message.details as Partial<AdvisorToolDetails> | undefined;
-				if (details?.state?.config) config = normalizeConfig(details.state.config, config);
+				if (details?.state?.config) config = normalizeConfig(details.state.config, config, registry);
 				if (typeof details?.state?.useCount === "number") useCount = Math.max(useCount, details.state.useCount);
 				else if (details?.advisor?.useCount) useCount = Math.max(useCount, details.advisor.useCount);
 			}
@@ -277,14 +283,14 @@ export default function advisorPiExtension(pi: ExtensionAPI) {
 		return restored;
 	}
 
-	function applyStartupFlags(api: ExtensionAPI): void {
+	function applyStartupFlags(api: ExtensionAPI, registry?: ModelRegistryLike): void {
 		const enabledFlag = api.getFlag("advisor-enabled");
 		if (typeof enabledFlag === "boolean") config.enabled = enabledFlag;
 
 		const modelFlag = api.getFlag("advisor-model");
 		if (typeof modelFlag === "string" && modelFlag.trim()) {
 			const parsed = parseModelSpec(modelFlag.trim());
-			if (parsed) {
+			if (parsed && (!registry || modelResolves(registry, parsed.provider, parsed.modelId))) {
 				config.provider = parsed.provider;
 				config.modelId = parsed.modelId;
 			}
@@ -306,6 +312,23 @@ export default function advisorPiExtension(pi: ExtensionAPI) {
 		if (typeof cacheFlag === "string") {
 			const cacheRetention = parseCacheRetention(cacheFlag);
 			if (cacheRetention) config.cacheRetention = cacheRetention;
+		}
+	}
+
+	function ensureAdvisorModelResolves(ctx: ExtensionContext): void {
+		const registry = ctx.modelRegistry as ModelRegistryLike | undefined;
+		if (!registry || modelResolves(registry, config.provider, config.modelId)) return;
+		const previous = `${config.provider}/${config.modelId}`;
+		const candidates = [parseModelSpec(DEFAULT_ADVISOR_MODEL), parseModelSpec(LEGACY_DEFAULT_ADVISOR_MODEL)].filter(
+			(candidate): candidate is { provider: string; modelId: string } => candidate !== undefined,
+		);
+		const working = resolveAdvisorModel(registry, candidates);
+		if (!working) return;
+		config.provider = working.provider;
+		config.modelId = working.modelId;
+		persistState(pi, config, useCount);
+		if (ctx.hasUI) {
+			ctx.ui.notify(`Advisor model ${previous} not found. Falling back to ${working.provider}/${working.modelId}.`, "warning");
 		}
 	}
 
@@ -477,7 +500,7 @@ Your role is strategic guidance only. You do not have tools and you do not make 
 
 Return guidance in short sections with bullets when useful.`;
 
-function defaultConfig(): AdvisorConfig {
+export function defaultConfig(): AdvisorConfig {
 	const parsed = parseModelSpec(DEFAULT_ADVISOR_MODEL) ?? { provider: "openai-codex", modelId: "gpt-5.6-sol" };
 	return {
 		enabled: true,
@@ -585,7 +608,11 @@ function persistState(pi: ExtensionAPI, config: AdvisorConfig, useCount: number)
 	pi.appendEntry(STATE_ENTRY, makeStateEntry(config, useCount));
 }
 
-function normalizeConfig(input: Partial<AdvisorConfig>, fallback: AdvisorConfig): AdvisorConfig {
+export function normalizeConfig(
+	input: Partial<AdvisorConfig>,
+	fallback: AdvisorConfig,
+	registry?: ModelRegistryLike,
+): AdvisorConfig {
 	const normalized: AdvisorConfig = {
 		enabled: typeof input.enabled === "boolean" ? input.enabled : fallback.enabled,
 		provider: typeof input.provider === "string" && input.provider ? input.provider : fallback.provider,
@@ -604,11 +631,53 @@ function normalizeConfig(input: Partial<AdvisorConfig>, fallback: AdvisorConfig)
 		normalized.provider === legacyDefault.provider &&
 		normalized.modelId === legacyDefault.modelId
 	) {
-		normalized.provider = fallback.provider;
-		normalized.modelId = fallback.modelId;
+		// Only rewrite the stored legacy default when the migration target resolves.
+		// Otherwise a resolving stored model would be replaced by a non-resolving default.
+		if (!registry || modelResolves(registry, fallback.provider, fallback.modelId)) {
+			normalized.provider = fallback.provider;
+			normalized.modelId = fallback.modelId;
+		}
+	}
+
+	if (registry && typeof input.provider === "string" && input.provider && typeof input.modelId === "string" && input.modelId) {
+		// Never replace a resolving stored model with a non-resolving one.
+		if (modelResolves(registry, input.provider, input.modelId) && !modelResolves(registry, normalized.provider, normalized.modelId)) {
+			normalized.provider = input.provider;
+			normalized.modelId = input.modelId;
+		}
 	}
 
 	return normalized;
+}
+
+export function modelResolves(registry: ModelRegistryLike | undefined, provider: string, modelId: string): boolean {
+	if (!registry) return false;
+	try {
+		const found = registry.find(provider, modelId);
+		return found !== undefined && found !== null;
+	} catch {
+		return false;
+	}
+}
+
+export function resolveAdvisorModel(
+	registry: ModelRegistryLike | undefined,
+	candidates: Array<{ provider: string; modelId: string }>,
+): { provider: string; modelId: string } | undefined {
+	if (!registry) return undefined;
+	for (const candidate of candidates) {
+		if (modelResolves(registry, candidate.provider, candidate.modelId)) return candidate;
+	}
+	try {
+		const available = registry.getAvailable?.();
+		const first = Array.isArray(available) ? available[0] : undefined;
+		if (first && typeof first.provider === "string" && typeof first.id === "string" && first.provider && first.id) {
+			return { provider: first.provider, modelId: first.id };
+		}
+	} catch {
+		// Ignore registry listing failures; callers keep the current config.
+	}
+	return undefined;
 }
 
 function parseModelSpec(value: string): { provider: string; modelId: string } | undefined {

--- a/extensions/advisor-pi/test/advisor-model-fallback.test.mjs
+++ b/extensions/advisor-pi/test/advisor-model-fallback.test.mjs
@@ -1,0 +1,100 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  DEFAULT_ADVISOR_MODEL,
+  LEGACY_DEFAULT_ADVISOR_MODEL,
+  defaultConfig,
+  modelResolves,
+  normalizeConfig,
+  resolveAdvisorModel,
+} from "../dist/index.js";
+
+function fakeRegistry(models, available) {
+  const known = new Set(models);
+  return {
+    find: (provider, modelId) => (known.has(`${provider}/${modelId}`) ? { provider, id: modelId } : undefined),
+    getAvailable: () => (available ?? []).map((spec) => ({ provider: spec.split("/")[0], id: spec.split("/").slice(1).join("/") })),
+  };
+}
+
+function split(spec) {
+  const slash = spec.indexOf("/");
+  return { provider: spec.slice(0, slash), modelId: spec.slice(slash + 1) };
+}
+
+const fallback = defaultConfig();
+
+describe("modelResolves", () => {
+  it("returns true when the registry finds the model", () => {
+    const registry = fakeRegistry(["openai-codex/gpt-5.6-sol"]);
+    assert.equal(modelResolves(registry, "openai-codex", "gpt-5.6-sol"), true);
+  });
+
+  it("returns false when the model is missing", () => {
+    const registry = fakeRegistry([]);
+    assert.equal(modelResolves(registry, "openai-codex", "gpt-5.6-sol"), false);
+  });
+
+  it("returns false when the registry throws or is absent", () => {
+    assert.equal(modelResolves({ find: () => { throw new Error("boom"); } }, "a", "b"), false);
+    assert.equal(modelResolves(undefined, "a", "b"), false);
+  });
+});
+
+describe("resolveAdvisorModel", () => {
+  it("picks the first resolving candidate", () => {
+    const registry = fakeRegistry(["prov-b/m2"]);
+    const picked = resolveAdvisorModel(registry, [
+      { provider: "prov-a", modelId: "m1" },
+      { provider: "prov-b", modelId: "m2" },
+    ]);
+    assert.deepEqual(picked, { provider: "prov-b", modelId: "m2" });
+  });
+
+  it("falls back to the first available model when no candidate resolves", () => {
+    const registry = fakeRegistry(["other/m9"], ["other/m9"]);
+    const picked = resolveAdvisorModel(registry, [{ provider: "nope", modelId: "missing" }]);
+    assert.deepEqual(picked, { provider: "other", modelId: "m9" });
+  });
+
+  it("returns undefined when nothing resolves", () => {
+    const registry = fakeRegistry([]);
+    assert.equal(resolveAdvisorModel(registry, [{ provider: "nope", modelId: "missing" }]), undefined);
+    assert.equal(resolveAdvisorModel(undefined, [{ provider: "a", modelId: "b" }]), undefined);
+  });
+});
+
+describe("normalizeConfig legacy migration guard", () => {
+  const legacy = split(LEGACY_DEFAULT_ADVISOR_MODEL);
+
+  it("rewrites the legacy default onto a resolving target", () => {
+    const target = split(DEFAULT_ADVISOR_MODEL);
+    const registry = fakeRegistry([DEFAULT_ADVISOR_MODEL]);
+    const out = normalizeConfig({ provider: legacy.provider, modelId: legacy.modelId }, fallback, registry);
+    assert.equal(out.provider, target.provider);
+    assert.equal(out.modelId, target.modelId);
+  });
+
+  it("keeps the stored legacy model when the migration target does not resolve", () => {
+    const registry = fakeRegistry([LEGACY_DEFAULT_ADVISOR_MODEL]);
+    const out = normalizeConfig({ provider: legacy.provider, modelId: legacy.modelId }, fallback, registry);
+    assert.equal(out.provider, legacy.provider);
+    assert.equal(out.modelId, legacy.modelId);
+  });
+
+  it("never replaces a resolving stored model with a non-resolving one", () => {
+    const stored = { provider: "custom", modelId: "advisor-v1", maxUses: 3 };
+    const registry = fakeRegistry(["custom/advisor-v1"]);
+    const out = normalizeConfig(stored, fallback, registry);
+    assert.equal(out.provider, "custom");
+    assert.equal(out.modelId, "advisor-v1");
+    assert.equal(out.maxUses, 3);
+  });
+
+  it("preserves the previous migration behavior without a registry", () => {
+    const target = split(DEFAULT_ADVISOR_MODEL);
+    const out = normalizeConfig({ provider: legacy.provider, modelId: legacy.modelId }, fallback);
+    assert.equal(out.provider, target.provider);
+    assert.equal(out.modelId, target.modelId);
+  });
+});


### PR DESCRIPTION
Validates the advisor model at load and guards the legacy config migration.

## Decision Record
- Option chosen (balanced): add registry-backed helpers (`modelResolves`, `resolveAdvisorModel`) plus an optional-registry guard in `normalizeConfig`, wired into `refreshStateFromBranch` with a fallback notice.
- Rejected: silent fallback without notice (issue requires notice); unconditional legacy rewrite (issue #94 forbids it).

## Changes
- `extensions/advisor-pi/src/index.ts`: load-time validation with fallback + warning (`ensureAdvisorModelResolves`); `normalizeConfig` only rewrites legacy default when the target resolves and never replaces a resolving stored model with a non-resolving one; startup `--advisor-model` flag ignored when it does not resolve; exported helpers for tests.
- `extensions/advisor-pi/test/advisor-model-fallback.test.mjs`: 10 regression tests.
- `extensions/advisor-pi/README.md`, `package.json` (`test` script).

## Test Results
- `npm run build`: pass (tsc clean).
- `npm test`: 10 pass, 0 fail.

## Acceptance Criteria Verification
- #93: default model validated at load; fallback with notice; no model-not-found on default install as long as any registry model resolves.
- #94: migration checks target resolves; resolving stored model never replaced by non-resolving (covered by `keeps the stored legacy model...` and `never replaces a resolving stored model...` tests).

Closes #93
Closes #94