### PR TITLE
refactor(advisor-pi): cap conversation transcript per call (#96)

### DIFF
--- a/extensions/advisor-pi/README.md
+++ b/extensions/advisor-pi/README.md
@@ -18,6 +18,9 @@ advice to the executor.
 - Lets the executor decide when a consultation is useful.
 - Calls a configured advisor model through Pi's model registry and auth.
 - Tracks advisor uses per session branch and stops after the configured limit.
+- Caps the conversation transcript sent per call at a configurable character
+  limit (default 20000): longer transcripts keep the most recent context and
+  are marked as truncated, so per-call cost stays bounded as sessions grow.
 - Passes a prompt-cache preference (`none`, `short`, or `long`) where the
   selected provider supports it.
 - Defaults to `openai-codex/gpt-5.6-sol` with `high` thinking.
@@ -37,6 +40,7 @@ advice to the executor.
 /advisor-pi model <provider>/<model>
 /advisor-pi thinking <minimal|low|medium|high|xhigh|max>
 /advisor-pi max-uses <number>
+/advisor-pi max-transcript-chars <number>
 /advisor-pi cache <none|short|long>
 /advisor-pi reset
 ```
@@ -47,6 +51,7 @@ Examples:
 /advisor-pi model openai-codex/gpt-5.6-sol
 /advisor-pi thinking high
 /advisor-pi max-uses 5
+/advisor-pi max-transcript-chars 20000
 /advisor-pi cache long
 ```
 
@@ -56,6 +61,7 @@ Examples:
 pi --advisor-model openai-codex/gpt-5.6-sol \
    --advisor-thinking high \
    --advisor-max-uses 5 \
+   --advisor-max-transcript-chars 20000 \
    --advisor-cache short
 ```
 
@@ -98,7 +104,8 @@ Each advisor consultation is a separate model call. That means:
 - Advisor input and output are billed separately by the selected provider.
 - Streaming from the executor pauses while the advisor call runs.
 - Longer transcripts cost more because the advisor reads the conversation
-  context.
+  context. Each call sends at most `max-transcript-chars` characters
+  (default 20000), keeping the most recent context and marking truncation.
 - The `max-uses` setting is a safety budget; raise it only when deeper review is
   worth the extra cost.
 
@@ -121,6 +128,7 @@ specific model compatibility, and cache reads/writes may still be billed.
   reports.
 - The advisor has no tools and cannot inspect files beyond what appears in the
   transcript.
-- Very long conversations can make advisor calls slower and more expensive.
+- Very long conversations are truncated to the transcript cap before sending,
+  so older context may be omitted on advisor calls.
 - `max-uses` is tracked per Pi session branch from extension state and tool
   result details; manual session editing can affect reconstruction.

--- a/extensions/advisor-pi/src/index.ts
+++ b/extensions/advisor-pi/src/index.ts
@@ -17,6 +17,7 @@ const DEFAULT_MAX_USES = 5;
 const DEFAULT_CACHE_RETENTION: CacheRetention = "short";
 const DEFAULT_TIMEOUT_MS = 600_000;
 const DEFAULT_MAX_TOKENS = 4_000;
+export const DEFAULT_MAX_TRANSCRIPT_CHARS = 20_000;
 
 const advisorToolSchema = Type.Object({
 	question: Type.String({
@@ -49,6 +50,7 @@ type AdvisorConfig = {
 	cacheRetention: CacheRetention;
 	maxTokens: number;
 	timeoutMs: number;
+	maxTranscriptChars: number;
 };
 
 type AdvisorStateEntry = {
@@ -97,6 +99,10 @@ export default function advisorPiExtension(pi: ExtensionAPI) {
 	});
 	pi.registerFlag("advisor-cache", {
 		description: "Advisor prompt-cache preference: none, short, or long",
+		type: "string",
+	});
+	pi.registerFlag("advisor-max-transcript-chars", {
+		description: "Maximum conversation transcript characters sent per advisor call (keeps most recent)",
 		type: "string",
 	});
 	pi.registerFlag("advisor-enabled", {
@@ -151,7 +157,7 @@ export default function advisorPiExtension(pi: ExtensionAPI) {
 			if (!auth.ok) throw new Error(auth.error);
 
 			const startedAt = Date.now();
-			const conversationText = serializeCurrentConversation(ctx);
+			const conversationText = truncateTranscript(serializeCurrentConversation(ctx), config.maxTranscriptChars);
 			const userMessage: Message = {
 				role: "user",
 				content: [
@@ -223,7 +229,7 @@ export default function advisorPiExtension(pi: ExtensionAPI) {
 	});
 
 	pi.registerCommand("advisor-pi", {
-		description: "Configure advisor-pi: status, enable, disable, model, thinking, max-uses, cache, reset",
+		description: "Configure advisor-pi: status, enable, disable, model, thinking, max-uses, max-transcript-chars, cache, reset",
 		handler: async (args, ctx) => {
 			const result = handleCommand(args.trim(), ctx);
 			if (result.persist) persistState(pi, config, useCount);
@@ -312,6 +318,12 @@ export default function advisorPiExtension(pi: ExtensionAPI) {
 		if (typeof cacheFlag === "string") {
 			const cacheRetention = parseCacheRetention(cacheFlag);
 			if (cacheRetention) config.cacheRetention = cacheRetention;
+		}
+
+		const maxTranscriptCharsFlag = api.getFlag("advisor-max-transcript-chars");
+		if (typeof maxTranscriptCharsFlag === "string") {
+			const maxTranscriptChars = parsePositiveInt(maxTranscriptCharsFlag);
+			if (maxTranscriptChars !== undefined) config.maxTranscriptChars = maxTranscriptChars;
 		}
 	}
 
@@ -440,10 +452,28 @@ export default function advisorPiExtension(pi: ExtensionAPI) {
 					updateToolState: false,
 				};
 			}
+			case "max-transcript-chars": {
+				const maxTranscriptChars = parsePositiveInt(value);
+				if (maxTranscriptChars === undefined) {
+					return {
+						message: "Usage: /advisor-pi max-transcript-chars <positive-number>",
+						level: "error",
+						persist: false,
+						updateToolState: false,
+					};
+				}
+				config.maxTranscriptChars = maxTranscriptChars;
+				return {
+					message: `advisor-pi max transcript chars set to ${maxTranscriptChars}`,
+					level: "info",
+					persist: true,
+					updateToolState: false,
+				};
+			}
 			default:
 				return {
 					message:
-						"Usage: /advisor-pi [status|enable|disable|model <provider>/<model>|thinking <minimal|low|medium|high|xhigh|max>|max-uses <n>|cache <none|short|long>|reset]",
+						"Usage: /advisor-pi [status|enable|disable|model <provider>/<model>|thinking <minimal|low|medium|high|xhigh|max>|max-uses <n>|max-transcript-chars <n>|cache <none|short|long>|reset]",
 					level: "error",
 					persist: false,
 					updateToolState: false,
@@ -483,6 +513,7 @@ export default function advisorPiExtension(pi: ExtensionAPI) {
 			`model: ${config.provider}/${config.modelId} (${availability})`,
 			`thinking: ${config.thinkingLevel}`,
 			`uses: ${useCount}/${config.maxUses}`,
+			`transcript: max ${config.maxTranscriptChars} chars`,
 			`cache: ${config.cacheRetention}`,
 		].join(" • ");
 	}
@@ -511,6 +542,7 @@ export function defaultConfig(): AdvisorConfig {
 		cacheRetention: DEFAULT_CACHE_RETENTION,
 		maxTokens: DEFAULT_MAX_TOKENS,
 		timeoutMs: DEFAULT_TIMEOUT_MS,
+		maxTranscriptChars: DEFAULT_MAX_TRANSCRIPT_CHARS,
 	};
 }
 
@@ -530,6 +562,13 @@ function serializeCurrentConversation(ctx: ExtensionContext): string {
 	const sessionContext = buildSessionContext(entries, leafId);
 	const llmMessages = convertToLlm(sessionContext.messages);
 	return serializeConversation(llmMessages);
+}
+
+export function truncateTranscript(text: string, maxChars: number): string {
+	if (maxChars <= 0) return text;
+	if (text.length <= maxChars) return text;
+	const omitted = text.length - maxChars;
+	return `[... earlier conversation truncated: showing the most recent ${maxChars} of ${text.length} characters (${omitted} omitted)]\n\n${text.slice(text.length - maxChars)}`;
 }
 
 function buildAdvisorUserPrompt(params: AdvisorToolInput, conversationText: string): string {
@@ -622,6 +661,10 @@ export function normalizeConfig(
 		cacheRetention: parseCacheRetention(input.cacheRetention) ?? fallback.cacheRetention,
 		maxTokens: typeof input.maxTokens === "number" && input.maxTokens > 0 ? Math.floor(input.maxTokens) : fallback.maxTokens,
 		timeoutMs: typeof input.timeoutMs === "number" && input.timeoutMs > 0 ? Math.floor(input.timeoutMs) : fallback.timeoutMs,
+		maxTranscriptChars:
+			typeof input.maxTranscriptChars === "number" && input.maxTranscriptChars > 0
+				? Math.floor(input.maxTranscriptChars)
+				: fallback.maxTranscriptChars,
 	};
 
 	const legacyDefault = parseModelSpec(LEGACY_DEFAULT_ADVISOR_MODEL);

--- a/extensions/advisor-pi/test/advisor-transcript-cap.test.mjs
+++ b/extensions/advisor-pi/test/advisor-transcript-cap.test.mjs
@@ -1,0 +1,54 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { DEFAULT_MAX_TRANSCRIPT_CHARS, defaultConfig, normalizeConfig, truncateTranscript } from "../dist/index.js";
+
+const fallback = defaultConfig();
+
+describe("truncateTranscript", () => {
+	it("returns short transcripts unchanged", () => {
+		assert.equal(truncateTranscript("hello", 100), "hello");
+		assert.equal(truncateTranscript("hello", 5), "hello");
+	});
+
+	it("keeps the most recent characters and marks truncation", () => {
+		const text = "A".repeat(50) + "RECENT";
+		const out = truncateTranscript(text, 10);
+		assert.ok(out.includes("truncated"), "should say it truncated");
+		assert.equal(out.endsWith(text.slice(-10)), true);
+		assert.ok(!out.includes("A".repeat(50)), "should drop the head");
+	});
+
+	it("reports omitted character counts", () => {
+		const text = "x".repeat(120);
+		const out = truncateTranscript(text, 20);
+		assert.ok(out.includes("120"), "should mention original length");
+		assert.ok(out.includes("100"), "should mention omitted count");
+	});
+
+	it("treats non-positive limits as no cap", () => {
+		const text = "abc";
+		assert.equal(truncateTranscript(text, 0), text);
+		assert.equal(truncateTranscript(text, -5), text);
+	});
+});
+
+describe("maxTranscriptChars config", () => {
+	it("has a positive explicit default", () => {
+		assert.ok(Number.isInteger(DEFAULT_MAX_TRANSCRIPT_CHARS) && DEFAULT_MAX_TRANSCRIPT_CHARS > 0);
+		assert.equal(fallback.maxTranscriptChars, DEFAULT_MAX_TRANSCRIPT_CHARS);
+	});
+
+	it("preserves a valid stored value", () => {
+		const out = normalizeConfig({ maxTranscriptChars: 5000 }, fallback);
+		assert.equal(out.maxTranscriptChars, 5000);
+	});
+
+	it("falls back on invalid values", () => {
+		for (const bad of [0, -10, Number.NaN]) {
+			const out = normalizeConfig({ maxTranscriptChars: bad }, fallback);
+			assert.equal(out.maxTranscriptChars, fallback.maxTranscriptChars);
+		}
+		const out = normalizeConfig({}, fallback);
+		assert.equal(out.maxTranscriptChars, fallback.maxTranscriptChars);
+	});
+});


### PR DESCRIPTION
Closes #96

## Summary
Bounds the conversation transcript sent on each advisor call with an explicit, configurable character limit (default 20000). Longer transcripts keep the most recent context and are prefixed with a truncation notice, so per-call input cost no longer grows with session length.

## Decision Record
- Chose character-based tail truncation over message-count truncation: simpler, deterministic, works on the already-serialized text, and the marker reports exact kept/omitted counts.
- Chose default 20000 chars: large enough to retain useful recent context, small enough to bound cost; configurable via command and CLI flag.
- Named config `maxTranscriptChars` with command `max-transcript-chars` and flag `--advisor-max-transcript-chars` for symmetry with existing `max-uses`/`--advisor-max-uses`.

## Test Results
- `npm run build` in extensions/advisor-pi: clean (tsc).
- `node --test`: 17/17 pass (10 pre-existing + 7 new in test/advisor-transcript-cap.test.mjs covering truncation tail/marker/counts, default presence, stored-value preservation, invalid fallback).

## Acceptance Criteria Verification
- [x] The transcript sent per call is bounded by an explicit limit (DEFAULT_MAX_TRANSCRIPT_CHARS = 20000, applied in execute via truncateTranscript)
- [x] The limit is configurable (/advisor-pi max-transcript-chars <n>, --advisor-max-transcript-chars flag, persisted in branch state via normalizeConfig)
- [x] Truncation keeps the most recent context and says it truncated (tail slice + '[... earlier conversation truncated: ...]' marker)

<!-- gitissue:qa v1 head=28742d1385856c1adf326601bc537c416d3ed067 tests=17/17-passed -->