### PR TITLE
fix(grok-pi): normalize model catalog metadata (#97)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **opencode-pi 1.3.0**: Prompt caching via OpenCode session reuse across turns (#69, #74, #75, #76). Each Pi session keeps one stable OpenCode project directory (removed at session teardown) and one continued OpenCode session: continuation turns pass `--session` and send only the transcript delta instead of the full transcript, so the provider serves cached prompt prefixes (measured on `mimo-v2.5-free`: 483 input tokens with zero cache read fresh vs 51 input with 1216 cached tokens continued). The session restarts fresh — full transcript, new OpenCode session — whenever the model, tool list, or system prompt changes, the transcript no longer extends the previously sent prefix, or any turn errors, times out, or aborts. Turns without a Pi session ID keep the previous isolated one-shot behavior.
 - **opencode-pi 1.3.0**: Real model cost and status from discovery metadata (#77, #78, #79). Free models are selected by zero input/output cost instead of the `-free` name pattern (same seven models on current metadata; future free models without the suffix are picked up automatically), inactive-status models are skipped, and a paid model registered via `OPENCODE_PI_MODELS` now reports its real cost instead of zero.
 
+### Changed
+
+- **grok-pi**: Refreshed the bundled fallback catalog against an authenticated Grok CLI 1.0.14 listing. The CLI offered only `grok-4.6` and `grok-4.5`, so the retired Composer 2.5 and Grok Build defaults were removed (#99).
+
 ### Fixed
 
+- **grok-pi**: Model registration now reads real input/output/cache rates from CLI metadata instead of always reporting zero, and `GROK_PI_MODELS` selections retain matching cached context and reasoning metadata (#97, #98).
 - **opencode-pi 1.3.0**: Correctness and hygiene guards the session reuse depends on (#70, #71, #72, #73). The stale `DEFAULT_FREE_MODELS` fallback (dead `deepseek-v4-flash-free` / `nemotron-3-super-free` IDs) is replaced with live IDs (`mimo-v2.5-free`, `nemotron-3.5-lightning-free`, `ling-3.0-flash-fin-free`, `big-pickle`, all verified resolvable); every turn's OpenCode session record is captured from the JSON event stream and deleted fire-and-forget (one-shot turns after each turn, session turns at teardown or on restart, never failing the turn); the abort listener is detached on every exit path including error and timeout; and every turn is bounded by an unconditional 3-minute internal timeout even when Pi supplies no `timeoutMs`.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Find what you need, copy the install command, reload Pi (`/reload`).
 | Extension | What you get | Install |
 |---|---|---|
 | [claude-code-pi](extensions/claude-code-pi/README.md) | Claude models (`sonnet`, `opus`) via local `claude -p` | `pi install npm:claude-code-pi` |
-| [grok-pi](extensions/grok-pi/README.md) | Grok CLI models: Grok 4.6/4.5, Composer 2.5 | `pi install npm:grok-pi` |
+| [grok-pi](extensions/grok-pi/README.md) | Grok CLI models: Grok 4.6/4.5 | `pi install npm:grok-pi` |
 | [opencode-pi](extensions/opencode-pi/README.md) | Free OpenCode CLI models, no login required | `pi install npm:opencode-pi` |
 | [agy-pi](extensions/agy-pi/README.md) | agy CLI models (Gemini, Sonnet, GPT OSS), auto-discovered | `pi install npm:agy-pi` |
 | [cursor-pi](extensions/cursor-pi/README.md) | Cursor CLI models (`auto`, Composer, Codex…) via local `cursor-agent -p`, with install/auth verification | `pi install npm:cursor-pi` |
@@ -145,7 +145,7 @@ Reload Pi after any change: type `/reload` (or restart).
 |:---:|:---:|
 | **statusline-pi** — git, cost, CPU/MEM, context zone, tok/s | **statusline-pi** — wrapped footer on a narrow terminal |
 | ![statusline-pi](assets/statusline-pi-150toks-haiku-4.5.png) | ![statusline-pi two lines](assets/statusline-pi-2-lines.png) |
-| **grok-pi** — Composer 2.5 via `grok-cli` | **opencode-pi** — free OpenCode models in `/model` |
+| **grok-pi** — Grok CLI provider (historical Composer capture) | **opencode-pi** — free OpenCode models in `/model` |
 | ![grok-pi](assets/composer-2.5-170-tok-s.png) | ![opencode model list](assets/pi-opencode-cli-model-list.png) |
 | **opencode-pi** — DeepSeek flash in session | **claude-code-pi** — `claude-code-cli` provider |
 | ![opencode deepseek](assets/pi-opencode-deepseek-4-flash.jpeg) | ![claude code cli](assets/claude-code-pi.png) |
@@ -264,11 +264,11 @@ Full setup: [extensions/claude-code-pi/README.md](extensions/claude-code-pi/READ
 <details>
 <summary><strong>grok-pi</strong> — grok-cli provider</summary>
 
-Registers the **`grok-cli`** provider so Pi can use the same models as the Grok CLI (including **Grok 4.6** / **4.5** and **Composer 2.5**). Authenticate with `grok login`, then pick `grok-cli` in `/model`. Reasoning models honor Pi thinking levels (`Shift+Tab`, `/settings`, `--thinking`).
+Registers the **`grok-cli`** provider so Pi can use the same models as the Grok CLI (currently **Grok 4.6** / **4.5**). Authenticate with `grok login`, then pick `grok-cli` in `/model`. Reasoning models honor Pi thinking levels (`Shift+Tab`, `/settings`, `--thinking`). Cached metadata supplies context, reasoning, and model pricing when available, including for `GROK_PI_MODELS` selections.
 
 ![grok-pi — Grok CLI models in Pi](assets/grok-pi.png)
 
-![Composer 2.5 — ~170 tok/s in footer](assets/composer-2.5-170-tok-s.png)
+![Historical Composer 2.5 capture — ~170 tok/s in footer](assets/composer-2.5-170-tok-s.png)
 
 ```bash
 pi --provider grok-cli --model grok-4.6 --thinking high

--- a/extensions/grok-pi/README.md
+++ b/extensions/grok-pi/README.md
@@ -1,6 +1,6 @@
 # grok-pi
 
-Use **Grok CLI session models** inside **Pi Coding Agent** — including **Grok 4.6**, **Grok 4.5**, **Composer 2.5** (`grok-composer-2.5-fast`), and **Grok Build** (`grok-build`). Reasoning models expose Pi thinking levels (`Shift+Tab`, `/settings`, `--thinking`).
+Use **Grok CLI session models** inside **Pi Coding Agent** — currently **Grok 4.6** and **Grok 4.5**. Reasoning models expose Pi thinking levels (`Shift+Tab`, `/settings`, `--thinking`).
 
 ![grok-pi screenshot](../../assets/grok-pi.png)
 
@@ -12,14 +12,18 @@ This extension registers a Pi provider named `grok-cli` that runs your existing,
 |-------------|-------------|---------------------|-----------------|
 | `grok-cli` | `grok-4.6` | Grok 4.6 | `low`, `medium`, `high`, `xhigh` |
 | `grok-cli` | `grok-4.5` | Grok 4.5 | `low`, `medium`, `high` |
-| `grok-cli` | `grok-composer-2.5-fast` | Composer 2.5 | off (no reasoning menu) |
-| `grok-cli` | `grok-build` | Grok Build | off unless the CLI cache advertises efforts |
 
-Model metadata is read from the CLI's own `~/.grok/models_cache.json` when present (read-only); otherwise the extension ships safe defaults. Thinking levels come from each entry's `reasoning_efforts` (same menu as Grok `/effort`).
+Model metadata is read from the CLI's own `~/.grok/models_cache.json` when present (read-only); otherwise the extension ships safe defaults. Thinking levels come from each entry's `reasoning_efforts` (same menu as Grok `/effort`), and per-million-token rates come from `cost`/`pricing` metadata when the CLI supplies it. `GROK_PI_MODELS` selects IDs without discarding matching cached context, reasoning, or cost metadata.
+
+### Fallback catalog verification
+
+The fallback was checked on 2026-09-03 with authenticated Grok CLI 1.0.14. `grok models` confirmed the session was logged in with grok.com and listed only `grok-4.6` and `grok-4.5`; the retired `grok-composer-2.5-fast` and `grok-build` defaults were removed.
+
+Repeat this check after a Grok CLI upgrade by signing in with `grok login`, running `grok models`, and comparing every listed ID with `defaultModelCatalog()` in `src/models.ts` and its exact-list test in `test/models.test.mjs`.
 
 ### Image input — known limitation
 
-Models such as Grok 4.x and Grok Build advertise **image input**, but this bridge cannot transmit images: the grok CLI headless prompt is plain text only. Any image attached in a Pi conversation is replaced with an `[image omitted: <mime type>]` placeholder before reaching the model, and grok-pi prints a one-time warning per session so degraded turns are explicit rather than silent. Send the relevant content as text (or paste file contents) instead of screenshots when using this provider.
+Grok 4.x models advertise **image input**, but this bridge cannot transmit images: the grok CLI headless prompt is plain text only. Any image attached in a Pi conversation is replaced with an `[image omitted: <mime type>]` placeholder before reaching the model, and grok-pi prints a one-time warning per session so degraded turns are explicit rather than silent. Send the relevant content as text (or paste file contents) instead of screenshots when using this provider.
 
 ### Environment variables
 
@@ -179,14 +183,6 @@ pi --model grok-cli/grok-4.6:high
 
 The extension maps Grok's `reasoning_efforts` into Pi `thinkingLevelMap`. Levels the current model does not list are hidden, matching `/effort` in Grok CLI.
 
-### Switch to Grok Build
-
-```bash
-pi --provider grok-cli --model grok-build
-```
-
-Or select `grok-build` in `/model`.
-
 ### Quick smoke test
 
 ```bash
@@ -239,7 +235,7 @@ extensions/grok-pi/
 | **grok-pi (this extension)** | `grok-cli` | `grok login` session inside the official CLI |
 | **Built-in xAI** | `xai` | `XAI_API_KEY` or Pi `/login` for xAI |
 
-Use **grok-pi** when you want the same **Grok 4.6 / 4.5 / Composer / Build** session models your Grok CLI already uses, including `/effort` thinking levels. Use **xAI** when you have a console API key and want Pi's stock `grok-*` catalog from `api.x.ai`.
+Use **grok-pi** when you want the same **Grok 4.6 / 4.5** session models your Grok CLI already uses, including `/effort` thinking levels. Use **xAI** when you have a console API key and want Pi's stock `grok-*` catalog from `api.x.ai`.
 
 ## Terms of service posture
 

--- a/extensions/grok-pi/package.json
+++ b/extensions/grok-pi/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grok-pi",
   "version": "1.4.2",
-  "description": "Bridge Grok session models (Grok 4.6/4.5, Composer, Build) into Pi by spawning the official Grok CLI headless per turn",
+  "description": "Bridge Grok 4.6/4.5 session models into Pi by spawning the official Grok CLI headless per turn",
   "type": "module",
   "main": "./src/index.ts",
   "files": [

--- a/extensions/grok-pi/src/bridge.ts
+++ b/extensions/grok-pi/src/bridge.ts
@@ -60,15 +60,16 @@ function readJson<T>(path: string): T | null {
 
 /** Read-only model metadata from the CLI's own cache (or env override). */
 export function readCachedModels(): GrokModelInfo[] {
+	const cache = readJson<GrokModelsCache>(modelsCachePath());
 	const envModels = process.env.GROK_PI_MODELS?.trim();
 	if (envModels) {
-		return envModels
+		const selectedIds = envModels
 			.split(/[\s,]+/)
 			.map((id) => id.trim())
-			.filter(Boolean)
-			.map((model) => ({ model }));
+			.filter(Boolean);
+		return modelsFromCache(cache, selectedIds);
 	}
-	return modelsFromCache(readJson<GrokModelsCache>(modelsCachePath()));
+	return modelsFromCache(cache);
 }
 
 // ── Subprocess lifecycle ────────────────────────────────────────────────────

--- a/extensions/grok-pi/src/models.ts
+++ b/extensions/grok-pi/src/models.ts
@@ -19,6 +19,16 @@ export type GrokReasoningEffort = {
 	default?: boolean;
 };
 
+export type GrokModelCostMetadata = {
+	input?: unknown;
+	output?: unknown;
+	cacheRead?: unknown;
+	cacheWrite?: unknown;
+	cache_read?: unknown;
+	cache_write?: unknown;
+	cache?: { read?: unknown; write?: unknown };
+};
+
 export type GrokModelInfo = {
 	model: string;
 	name?: string;
@@ -28,6 +38,8 @@ export type GrokModelInfo = {
 	supports_reasoning_effort?: boolean;
 	reasoning_effort?: string;
 	reasoning_efforts?: GrokReasoningEffort[];
+	cost?: GrokModelCostMetadata;
+	pricing?: GrokModelCostMetadata;
 };
 
 export type GrokModelsCache = {
@@ -80,32 +92,27 @@ export function defaultModelCatalog(): GrokModelInfo[] {
 				{ id: "low", value: "low" },
 			],
 		},
-		{
-			model: "grok-composer-2.5-fast",
-			name: "Composer 2.5",
-			context_window: 200_000,
-			max_completion_tokens: 30_000,
-			api_backend: "responses",
-		},
-		{
-			model: "grok-build",
-			name: "Grok Build",
-			context_window: 512_000,
-			max_completion_tokens: 64_000,
-			api_backend: "responses",
-		},
 	];
 }
 
-export function modelsFromCache(cache: GrokModelsCache | null | undefined): GrokModelInfo[] {
-	if (!cache?.models) return defaultModelCatalog();
-	const out: GrokModelInfo[] = [];
-	for (const entry of Object.values(cache.models)) {
+export function modelsFromCache(
+	cache: GrokModelsCache | null | undefined,
+	selectedIds?: string[],
+): GrokModelInfo[] {
+	const discovered: GrokModelInfo[] = [];
+	for (const entry of Object.values(cache?.models ?? {})) {
 		const info = entry?.info;
 		if (!info?.model) continue;
-		out.push(info);
+		discovered.push(info);
 	}
-	return out.length > 0 ? out : defaultModelCatalog();
+	const available = discovered.length > 0 ? discovered : defaultModelCatalog();
+	if (!selectedIds) return available;
+
+	const byId = new Map(available.map((info) => [info.model, info]));
+	return selectedIds.map((model) => {
+		const info = byId.get(model);
+		return info ? { ...info } : { model };
+	});
 }
 
 export function modelSupportsReasoning(info: GrokModelInfo): boolean {
@@ -173,6 +180,46 @@ export function inputFor(info: GrokModelInfo): ("text" | "image")[] {
 	return ["text"];
 }
 
+export type GrokModelCost = {
+	input: number;
+	output: number;
+	cacheRead: number;
+	cacheWrite: number;
+};
+
+function costFigure(value: unknown): number | undefined {
+	return typeof value === "number" && Number.isFinite(value) && value >= 0
+		? value
+		: undefined;
+}
+
+function costBlock(metadata: GrokModelCostMetadata | undefined): Partial<GrokModelCost> {
+	return {
+		input: costFigure(metadata?.input),
+		output: costFigure(metadata?.output),
+		cacheRead:
+			costFigure(metadata?.cacheRead) ??
+			costFigure(metadata?.cache_read) ??
+			costFigure(metadata?.cache?.read),
+		cacheWrite:
+			costFigure(metadata?.cacheWrite) ??
+			costFigure(metadata?.cache_write) ??
+			costFigure(metadata?.cache?.write),
+	};
+}
+
+/** Read finite, non-negative per-million-token rates from CLI metadata. */
+export function modelCostFor(info: GrokModelInfo): GrokModelCost {
+	const cost = costBlock(info.cost);
+	const pricing = costBlock(info.pricing);
+	return {
+		input: cost.input ?? pricing.input ?? 0,
+		output: cost.output ?? pricing.output ?? 0,
+		cacheRead: cost.cacheRead ?? pricing.cacheRead ?? 0,
+		cacheWrite: cost.cacheWrite ?? pricing.cacheWrite ?? 0,
+	};
+}
+
 export function buildProviderModels(infos: GrokModelInfo[]) {
 	return infos.map((info) => {
 		const reasoning = modelSupportsReasoning(info);
@@ -185,7 +232,7 @@ export function buildProviderModels(infos: GrokModelInfo[]) {
 			input: inputFor(info),
 			contextWindow: info.context_window ?? 128_000,
 			maxTokens: maxTokensFor(info),
-			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			cost: modelCostFor(info),
 		};
 	});
 }

--- a/extensions/grok-pi/test/bridge-lifecycle.test.mjs
+++ b/extensions/grok-pi/test/bridge-lifecycle.test.mjs
@@ -25,9 +25,10 @@ childProcess.spawn = function patchedSpawn(command, args, options) {
 };
 syncBuiltinESMExports();
 
+let readCachedModels;
 let streamGrokCli;
 try {
-	({ streamGrokCli } = await import(pathToFileURL(join(extRoot, "src/bridge.ts")).href));
+	({ readCachedModels, streamGrokCli } = await import(pathToFileURL(join(extRoot, "src/bridge.ts")).href));
 } catch (error) {
 	childProcess.spawn = originalSpawn;
 	syncBuiltinESMExports();
@@ -88,6 +89,36 @@ function fakeModel() {
 		maxTokens: 16_384,
 	};
 }
+
+test("GROK_PI_MODELS keeps matching metadata from the CLI cache", () => {
+	const dir = mkdtempSync(join(tmpdir(), "grok-pi-models-"));
+	const previousHome = process.env.GROK_PI_HOME;
+	const previousModels = process.env.GROK_PI_MODELS;
+	writeFileSync(join(dir, "models_cache.json"), JSON.stringify({
+		models: {
+			"grok-4.6": {
+				info: {
+					model: "grok-4.6",
+					context_window: 500_000,
+					supports_reasoning_effort: true,
+					reasoning_efforts: [{ id: "high", value: "high" }],
+				},
+			},
+		},
+	}), "utf8");
+	process.env.GROK_PI_HOME = dir;
+	process.env.GROK_PI_MODELS = "grok-4.6";
+
+	try {
+		const [model] = readCachedModels();
+		assert.equal(model.context_window, 500_000);
+		assert.deepEqual(model.reasoning_efforts, [{ id: "high", value: "high" }]);
+	} finally {
+		restoreEnv("GROK_PI_HOME", previousHome);
+		restoreEnv("GROK_PI_MODELS", previousModels);
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
 
 function testContext(input) {
 	return {

--- a/extensions/grok-pi/test/models.test.mjs
+++ b/extensions/grok-pi/test/models.test.mjs
@@ -98,24 +98,104 @@ test("buildProviderModels exposes thinkingLevelMap for grok-4.6", () => {
 	assert.equal(model.maxTokens, 500_000);
 });
 
-test("modelsFromCache prefers cache entries and falls back to defaults", () => {
+test("buildProviderModels reads paid-model cost metadata", () => {
+	const [model] = buildProviderModels([{
+		model: "grok-paid",
+		cost: { input: 3, output: 15, cache: { read: 0.3, write: 3.75 } },
+	}]);
+
+	assert.deepEqual(model.cost, {
+		input: 3,
+		output: 15,
+		cacheRead: 0.3,
+		cacheWrite: 3.75,
+	});
+});
+
+test("buildProviderModels accepts flat cost and pricing metadata aliases", () => {
+	const [camelCase, snakeCase] = buildProviderModels([
+		{
+			model: "grok-flat-cost",
+			cost: { input: 4, output: 16, cacheRead: 0.4, cacheWrite: 4 },
+		},
+		{
+			model: "grok-flat-pricing",
+			pricing: { input: 5, output: 20, cache_read: 0.5, cache_write: 5 },
+		},
+	]);
+
+	assert.deepEqual(camelCase.cost, {
+		input: 4,
+		output: 16,
+		cacheRead: 0.4,
+		cacheWrite: 4,
+	});
+	assert.deepEqual(snakeCase.cost, {
+		input: 5,
+		output: 20,
+		cacheRead: 0.5,
+		cacheWrite: 5,
+	});
+});
+
+test("buildProviderModels defaults missing or malformed cost metadata to zero", () => {
+	const [missing, malformed] = buildProviderModels([
+		{ model: "grok-missing-cost" },
+		{
+			model: "grok-malformed-cost",
+			cost: { input: -1, output: "paid", cache: { read: Number.NaN, write: null } },
+		},
+	]);
+
+	const zero = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+	assert.deepEqual(missing.cost, zero);
+	assert.deepEqual(malformed.cost, zero);
+});
+
+test("modelsFromCache prefers cache entries and falls back to verified defaults", () => {
 	assert.deepEqual(
 		modelsFromCache(null).map((info) => info.model),
-		["grok-4.6", "grok-4.5", "grok-composer-2.5-fast", "grok-build"],
+		["grok-4.6", "grok-4.5"],
 	);
 
-	const cached = modelsFromCache({
+	const cache = {
 		models: {
 			"grok-4.6": {
 				info: {
 					model: "grok-4.6",
 					name: "Grok 4.6",
+					context_window: 500_000,
 					supports_reasoning_effort: true,
 					reasoning_efforts: [{ id: "high", value: "high" }],
 				},
 			},
 		},
-	});
+	};
+	const cached = modelsFromCache(cache);
 	assert.equal(cached.length, 1);
 	assert.deepEqual(supportedThinkingLevels(cached[0]), ["high"]);
+});
+
+test("modelsFromCache enriches environment-selected ids from cached metadata", () => {
+	const cache = {
+		models: {
+			"grok-4.6": {
+				info: {
+					model: "grok-4.6",
+					context_window: 500_000,
+					supports_reasoning_effort: true,
+					reasoning_efforts: [
+						{ id: "high", value: "high" },
+						{ id: "low", value: "low" },
+					],
+				},
+			},
+		},
+	};
+
+	const selected = modelsFromCache(cache, ["unknown-model", "grok-4.6"]);
+	assert.deepEqual(selected.map((info) => info.model), ["unknown-model", "grok-4.6"]);
+	assert.deepEqual(selected[0], { model: "unknown-model" });
+	assert.equal(selected[1].context_window, 500_000);
+	assert.deepEqual(supportedThinkingLevels(selected[1]), ["low", "high"]);
 });


### PR DESCRIPTION
Closes #97
Closes #98
Closes #99

## Summary

Normalize Grok CLI model metadata end to end: registered models now use validated pricing metadata, `GROK_PI_MODELS` keeps matching cached capabilities, and the fallback catalog matches an authenticated CLI listing.

## Approach

Use the existing `models.ts` normalization boundary for both cost mapping and environment-selected IDs, then refresh the static fallback only from the authenticated `grok models` result. Unknown override IDs retain the conservative bare-model fallback.

## Decision Record

- **Root cause:** `buildProviderModels` discarded model pricing by hardcoding four zero rates, while `readCachedModels` converted environment-selected IDs to bare objects and discarded cached context/reasoning metadata. Separately, the fallback still advertised two IDs absent from the authenticated CLI catalog.
- **Options considered:** Option 1 — isolated inline fixes; Option 2 — unified, testable metadata normalization plus verified catalog refresh; Option 3 — dynamic authenticated catalog discovery and broader provider refactor.
- **Options rejected:** Option 1 — duplicates normalization policy in the bridge and weakens direct regression coverage; Option 3 — adds startup subprocess and catalog-persistence complexity beyond these issues.
- **Selected option:** Option 2 — unified, testable metadata normalization plus verified catalog refresh.
- **Residual risk:** The authenticated Grok CLI 1.0.14 cache currently carries no `cost`/`pricing` fields, so those live entries remain unpriced until the CLI supplies rates; when supplied, rates are now preserved and registered. The CLI's per-turn `total_cost_usd` accounting remains unchanged.
- **Reproduction:** `node --test --test-name-pattern='cost metadata|environment-selected|verified defaults' test/models.test.mjs` confirmed red for hardcoded zero cost, metadata-dropping selection, and the stale fallback → regression tests in `test/models.test.mjs` and `test/bridge-lifecycle.test.mjs`.

Analyzed at: `fix/97-1-1-read-real-model-cost-instead-of @ 93d28f8` (2026-09-03)

## Changes

| File | Change |
|------|--------|
| `extensions/grok-pi/src/models.ts` | Parse validated cost/pricing rates, enrich selected IDs, and retain only authenticated fallback models. |
| `extensions/grok-pi/src/bridge.ts` | Resolve `GROK_PI_MODELS` through cached model metadata. |
| `extensions/grok-pi/test/models.test.mjs` | Cover paid rates, metadata validation/aliases, selected-ID enrichment, and exact fallback IDs. |
| `extensions/grok-pi/test/bridge-lifecycle.test.mjs` | Verify the environment override keeps matching CLI cache metadata. |
| `extensions/grok-pi/README.md` | Document pricing/override behavior and the repeatable authenticated catalog check. |
| `extensions/grok-pi/package.json` | Align package description with the current catalog. |
| `README.md` | Align catalog and extension overview with the current models. |
| `CHANGELOG.md` | Record fixes for #97/#98 and the authenticated catalog refresh for #99. |

## Test Results

- Unit/integration tests: 36 passed (`cd extensions/grok-pi && npm test`)
- Authenticated CLI check: passed (`grok models`, Grok CLI 1.0.14, logged in with grok.com; `grok-4.6` and `grok-4.5` only)
- Packaging: passed (`npm pack --dry-run --json`)
- Build: passed (`cd extensions/grok-pi && npm run build`)
- QA cycles: 1

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| #97 — Cost is read from model metadata rather than hardcoded to zero. | pass | Verified red: `node --test --test-name-pattern='cost metadata|environment-selected|verified defaults' test/models.test.mjs` → fixed → `buildProviderModels reads paid-model cost metadata`. |
| #97 — A paid model reports non-zero rates to Pi. | pass | Verified red with the same command → fixed → paid-model fixture asserts input 3, output 15, cache read 0.3, and cache write 3.75. |
| #98 — An overridden model keeps its real context window where metadata is available. | pass | Verified red with the same command → fixed → `modelsFromCache enriches environment-selected ids from cached metadata` and bridge lifecycle override test. |
| #98 — An overridden model keeps its reasoning-effort levels where metadata is available. | pass | Verified red with the same command → fixed → selected model retains `low`/`high` efforts and the bridge test retains cached `reasoning_efforts`. |
| #99 — The bundled catalog is compared against an authenticated model listing. | pass | `grok models` on authenticated Grok CLI 1.0.14 reported logged in with grok.com and listed only `grok-4.6`/`grok-4.5`. |
| #99 — Any model the CLI no longer offers is removed from the catalog. | pass | `defaultModelCatalog()` and its exact-list test remove `grok-composer-2.5-fast` and `grok-build`. |
| #99 — The check is recorded so it can be repeated. | pass | `extensions/grok-pi/README.md` documents the command, authenticated result, comparison targets, and rerun procedure. |

<!-- gitissue:qa v1 head=92bc65817d0b9416aff94c34e880b7915c16484a profile=full cycles=1 review=clean ui=none -->
