### PR TITLE
fix(agy-pi): parse tab-separated models and refresh fallback (#86)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **agy-pi**: Parse tab-separated `agy models` output as `id<TAB>name` so registered ids stay clean, effort variants collapse into one base family, and `agy --model` receives a real slug ([#86](https://github.com/luongnv89/pi-extensions/issues/86)).
+- **agy-pi**: Refresh the bundled fallback against the current CLI catalog: drop retired `gemini-3.5-flash` variants and add `gemini-3.8-flash` high/medium/low ([#91](https://github.com/luongnv89/pi-extensions/issues/91)).
+
 - **opencode-pi 1.3.0**: Correctness and hygiene guards the session reuse depends on (#70, #71, #72, #73). The stale `DEFAULT_FREE_MODELS` fallback (dead `deepseek-v4-flash-free` / `nemotron-3-super-free` IDs) is replaced with live IDs (`mimo-v2.5-free`, `nemotron-3.5-lightning-free`, `ling-3.0-flash-fin-free`, `big-pickle`, all verified resolvable); every turn's OpenCode session record is captured from the JSON event stream and deleted fire-and-forget (one-shot turns after each turn, session turns at teardown or on restart, never failing the turn); the abort listener is detached on every exit path including error and timeout; and every turn is bounded by an unconditional 3-minute internal timeout even when Pi supplies no `timeoutMs`.
 
 ### Fixed

--- a/extensions/agy-pi/src/index.ts
+++ b/extensions/agy-pi/src/index.ts
@@ -39,16 +39,16 @@ function bundledModel(id: string, name: string, contextWindow = 1_048_576): AgyM
   return { id, name, contextWindow, maxTokens: DEFAULT_MAX_TOKENS, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 } };
 }
 
-const BUNDLED_MODELS: AgyModelInfo[] = [
+export const BUNDLED_MODELS: AgyModelInfo[] = [
+  bundledModel("gemini-3.8-flash-high", "Gemini 3.8 Flash"),
+  bundledModel("gemini-3.8-flash-medium", "Gemini 3.8 Flash"),
+  bundledModel("gemini-3.8-flash-low", "Gemini 3.8 Flash"),
   bundledModel("gemini-3.7-flash-high", "Gemini 3.7 Flash"),
   bundledModel("gemini-3.7-flash-medium", "Gemini 3.7 Flash"),
   bundledModel("gemini-3.7-flash-low", "Gemini 3.7 Flash"),
   bundledModel("gemini-3.6-flash-high", "Gemini 3.6 Flash"),
   bundledModel("gemini-3.6-flash-medium", "Gemini 3.6 Flash"),
   bundledModel("gemini-3.6-flash-low", "Gemini 3.6 Flash"),
-  bundledModel("gemini-3.5-flash-high", "Gemini 3.5 Flash"),
-  bundledModel("gemini-3.5-flash-medium", "Gemini 3.5 Flash"),
-  bundledModel("gemini-3.5-flash-low", "Gemini 3.5 Flash"),
   bundledModel("gemini-3.1-pro-high", "Gemini 3.1 Pro"),
   bundledModel("gemini-3.1-pro-low", "Gemini 3.1 Pro"),
   bundledModel("claude-sonnet-4-6", "Claude Sonnet 4.6 (Thinking)", 200_000),
@@ -99,32 +99,65 @@ function modelDisplayName(model: string): string {
   return `Agy ${model}`;
 }
 
-function dedupe(values: string[]): string[] {
-  return [...new Set(values)];
-}
-
 function effortOf(id: string): string | undefined {
   return id.match(/-(high|medium|low)$/)?.[1];
 }
 
+function baseIdOf(id: string): string {
+  const effort = effortOf(id);
+  return effort ? id.slice(0, id.length - effort.length - 1) : id;
+}
+
+function stripEffortName(name: string): string {
+  return name.replace(/\s+\((High|Medium|Low)\)$/i, "").trim();
+}
+
+function bundledForBase(baseId: string): AgyModelInfo | undefined {
+  const match = BUNDLED_MODELS.find((m) => m.id === baseId || baseIdOf(m.id) === baseId);
+  return match ? { ...match } : undefined;
+}
+
+/**
+ * Parse `agy models` stdout. Each line is `id<TAB>name` (extra columns ignored).
+ * Id-only lines (no tab) are kept so a bare-id CLI still works.
+ */
+export function parseAgyModelsOutput(stdout: string): Array<{ id: string; name?: string }> {
+  const models: Array<{ id: string; name?: string }> = [];
+  for (const raw of stdout.split(/\r?\n/)) {
+    if (!raw.trim()) continue;
+    const [idField, nameField] = raw.split("\t");
+    const id = idField?.trim() ?? "";
+    if (!id) continue;
+    const name = nameField?.trim();
+    models.push(name ? { id, name } : { id });
+  }
+  return models;
+}
+
+export type AgyModelRef = string | { id: string; name?: string };
+
 /** Collapse -high/-medium/-low variant ids into one base model per family. */
-function toBaseModels(ids: string[]): AgyModelInfo[] {
-  const groups = new Map<string, { levels: Set<string>; bundled?: AgyModelInfo }>();
-  for (const id of dedupe(ids)) {
+export function toBaseModels(refs: AgyModelRef[]): AgyModelInfo[] {
+  const groups = new Map<string, { levels: Set<string>; bundled?: AgyModelInfo; name?: string }>();
+  const seen = new Set<string>();
+  for (const ref of refs) {
+    const id = typeof ref === "string" ? ref.trim() : ref.id.trim();
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    const name = typeof ref === "string" ? undefined : ref.name?.trim();
     const effort = effortOf(id);
     const baseId = effort ? id.slice(0, id.length - effort.length - 1) : id;
     let group = groups.get(baseId);
     if (!group) {
-      group = { levels: new Set() };
-      const bundled = BUNDLED_MODELS.find((m) => m.id === baseId);
-      if (bundled) group.bundled = { ...bundled };
+      group = { levels: new Set(), bundled: bundledForBase(baseId) };
       groups.set(baseId, group);
     }
     if (effort) group.levels.add(effort);
+    if (name && !group.name) group.name = stripEffortName(name);
   }
   return [...groups.entries()].map(([baseId, group]) => ({
     id: baseId,
-    name: group.bundled?.name ?? modelDisplayName(baseId),
+    name: group.name ?? group.bundled?.name ?? modelDisplayName(baseId),
     contextWindow: group.bundled?.contextWindow ?? DEFAULT_CONTEXT_WINDOW,
     maxTokens: group.bundled?.maxTokens ?? DEFAULT_MAX_TOKENS,
     cost: group.bundled?.cost ?? { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
@@ -256,12 +289,9 @@ export async function discoverModels(opts?: {
       return { models: [], time: now, error: lastDiscoveryError };
     }
 
-    const modelIds = stdout
-      .split("\n")
-      .map((line) => line.trim())
-      .filter(Boolean);
+    const parsed = parseAgyModelsOutput(stdout);
 
-    registeredModels = toBaseModels(configured?.length ? configured : modelIds);
+    registeredModels = toBaseModels(configured?.length ? configured : parsed);
 
     lastDiscoveryTime = now;
     lastDiscoveryError = undefined;

--- a/extensions/agy-pi/test/helpers.test.mjs
+++ b/extensions/agy-pi/test/helpers.test.mjs
@@ -8,9 +8,14 @@ import { fileURLToPath } from "node:url";
 const extRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 const {
 	agyBin,
+	agySlugForLevel,
+	BUNDLED_MODELS,
 	checkAgyStatus,
+	discoverModels,
+	parseAgyModelsOutput,
 	setupGuidance,
 	streamAgy,
+	toBaseModels,
 } = await import(`file://${join(extRoot, "src/index.ts")}`);
 
 // process.env values are coerced to strings, so `process.env.X = undefined`
@@ -111,6 +116,114 @@ test("checkAgyStatus reports unusable when --version exits nonzero", async () =>
 		assert.equal(status.summary, "agy CLI is unusable");
 		assert.equal(status.detail, "boom");
 	});
+});
+
+function withClearedModels(run) {
+	const previousModels = process.env.AGY_PI_MODELS;
+	delete process.env.AGY_PI_MODELS;
+	return Promise.resolve()
+		.then(run)
+		.finally(() => restoreEnv("AGY_PI_MODELS", previousModels));
+}
+
+const TAB_MODELS_SCRIPT = `
+if (process.argv[2] === "models") {
+  process.stdout.write([
+    "gemini-3.8-flash-high\\tGemini 3.8 Flash (High)",
+    "gemini-3.8-flash-medium\\tGemini 3.8 Flash (Medium)",
+    "gemini-3.8-flash-low\\tGemini 3.8 Flash (Low)",
+    "gemini-3.7-flash-high\\tGemini 3.7 Flash (High)",
+    "claude-sonnet-4-6\\tClaude Sonnet 4.6 (Thinking)",
+    "gpt-oss-120b-medium\\tGPT-OSS 120B (Medium)",
+    "",
+    "extra-id\\tExtra Name\\textra-column",
+  ].join("\\n") + "\\n");
+} else {
+  process.stdout.write("agy 1.1.25\\n");
+}
+`;
+
+test("parseAgyModelsOutput splits id and display name on the first tab", () => {
+	const parsed = parseAgyModelsOutput(
+		[
+			"gemini-3.8-flash-high\tGemini 3.8 Flash (High)",
+			"",
+			"  gemini-3.8-flash-low\tGemini 3.8 Flash (Low)\tignored-column  ",
+			"bare-id-only",
+			"\tmissing-id",
+		].join("\n"),
+	);
+	assert.deepEqual(parsed, [
+		{ id: "gemini-3.8-flash-high", name: "Gemini 3.8 Flash (High)" },
+		{ id: "gemini-3.8-flash-low", name: "Gemini 3.8 Flash (Low)" },
+		{ id: "bare-id-only" },
+	]);
+});
+
+test("toBaseModels collapses effort variants and uses the CLI display name", () => {
+	const models = toBaseModels([
+		{ id: "gemini-3.8-flash-high", name: "Gemini 3.8 Flash (High)" },
+		{ id: "gemini-3.8-flash-medium", name: "Gemini 3.8 Flash (Medium)" },
+		{ id: "gemini-3.8-flash-low", name: "Gemini 3.8 Flash (Low)" },
+		{ id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6 (Thinking)" },
+	]);
+	assert.equal(models.length, 2);
+	assert.equal(models[0].id, "gemini-3.8-flash");
+	assert.equal(models[0].name, "Gemini 3.8 Flash");
+	assert.deepEqual(new Set(models[0].effortLevels), new Set(["high", "medium", "low"]));
+	assert.equal(models[1].id, "claude-sonnet-4-6");
+	assert.equal(models[1].name, "Claude Sonnet 4.6 (Thinking)");
+	assert.equal(models[1].effortLevels, undefined);
+});
+
+test("bundled fallback names only models the CLI currently offers", () => {
+	const ids = BUNDLED_MODELS.map((model) => model.id);
+	assert.equal(
+		ids.some((id) => id.startsWith("gemini-3.5-flash")),
+		false,
+		"stale gemini-3.5-flash variants must not remain in the fallback",
+	);
+	assert.ok(
+		ids.includes("gemini-3.8-flash-high") &&
+			ids.includes("gemini-3.8-flash-medium") &&
+			ids.includes("gemini-3.8-flash-low"),
+		"current gemini-3.8-flash family must be in the fallback",
+	);
+	const families = toBaseModels(ids).map((model) => model.id);
+	assert.ok(families.includes("gemini-3.8-flash"));
+	assert.ok(families.includes("gemini-3.7-flash"));
+	assert.ok(families.includes("gemini-3.6-flash"));
+	assert.ok(families.includes("gemini-3.1-pro"));
+	assert.ok(families.includes("claude-sonnet-4-6"));
+	assert.ok(families.includes("claude-opus-4-6-thinking"));
+	assert.ok(families.includes("gpt-oss-120b"));
+	assert.equal(families.some((id) => id.includes("gemini-3.5")), false);
+	const flash = toBaseModels(ids).find((model) => model.id === "gemini-3.8-flash");
+	assert.equal(flash?.name, "Gemini 3.8 Flash");
+	assert.deepEqual(new Set(flash?.effortLevels), new Set(["high", "medium", "low"]));
+});
+
+test("discoverModels splits tab-separated agy models lines into clean ids", async () => {
+	await withClearedModels(() =>
+		withFakeAgy(TAB_MODELS_SCRIPT, async () => {
+			const { models, error } = await discoverModels({ forceDiscovery: true });
+			assert.equal(error, undefined);
+			assert.ok(models.length > 0);
+			for (const model of models) {
+				assert.equal(model.id.includes("\t"), false, `id still contains a tab: ${JSON.stringify(model.id)}`);
+				assert.doesNotMatch(model.id, /\s/, `id still contains whitespace: ${JSON.stringify(model.id)}`);
+				assert.doesNotMatch(model.id, /Gemini|Claude|GPT-OSS|Flash|Thinking/);
+			}
+			const flash = models.find((model) => model.id === "gemini-3.8-flash");
+			assert.ok(flash, `expected collapsed gemini-3.8-flash, got ${models.map((m) => m.id).join(",")}`);
+			assert.deepEqual(new Set(flash.effortLevels), new Set(["high", "medium", "low"]));
+			assert.equal(agySlugForLevel("gemini-3.8-flash", "high"), "gemini-3.8-flash-high");
+			assert.equal(agySlugForLevel("gemini-3.8-flash", "low"), "gemini-3.8-flash-low");
+			const extra = models.find((model) => model.id === "extra-id");
+			assert.ok(extra, "extra columns must not leak into the model id");
+			assert.equal(extra.id.includes("extra-column"), false);
+		}),
+	);
 });
 
 test("streamAgy emits actionable setup guidance instead of a bare empty response when the binary is missing", async () => {


### PR DESCRIPTION
Closes #86
Closes #91

## Summary

agy-pi treated each `agy models` line as a raw model id, so tab-separated `id<TAB>name` output registered garbage ids, blocked effort collapsing, and forwarded those strings to `agy --model`. Discovery now splits on the first tab and collapses effort variants into one family. The bundled fallback was also refreshed against the live CLI catalog: retired `gemini-3.5-flash` variants are gone and `gemini-3.8-flash` high/medium/low are present.

## Approach

Parse id and display name through collapse, then refresh the bundled list and align the collapse lookup.

## Decision Record

- **Root cause:** `discoverModels` split stdout on newline only, so registered ids became `gemini-3.8-flash-high<TAB>Gemini 3.8 Flash (High)`. `effortOf` anchors `-(high|medium|low)$` at end-of-string, collapsing never fired, and `agySlugForLevel` forwarded the garbage string. Separately, `BUNDLED_MODELS` still shipped retired `gemini-3.5-flash` variants and omitted the current `gemini-3.8-flash` family.
- **Options considered:** Option 1 — split on tab and keep the first field only / swap 3.5 for 3.8 in place; Option 2 — parse id and display name through collapse, then refresh the fallback and align bundled lookup; Option 3 — share a regex parser with cursor-pi / drop the bundled list.
- **Options rejected:** Option 1 — discards the CLI display name and does not prove the rest of the fallback still matches the CLI; Option 3 — cursor-pi uses `id - name` while agy is tab-separated, and dropping the fallback breaks the default-config path.
- **Selected option:** Option 2 — parse id and display name through collapse, then refresh the fallback and align bundled lookup
- **Residual risk:** Live `agy models` could add extra columns; the parser keeps only the first field as the id and the second as the name. The bundled list will still drift on the next CLI rename.
- **Effort profile:** light — fast path (pre-work Effort S); synthesis skipped, QA capped at 1 cycle
- **Reproduction:** `cd extensions/agy-pi && node --test --test-name-pattern='splits tab-separated' test/helpers.test.mjs` confirmed red for tab-bearing ids (`id still contains a tab: "gemini-3.8-flash-high\tGemini 3.8 Flash (High)"`) → regression tests in `extensions/agy-pi/test/helpers.test.mjs`

Analyzed at: `fix/86-1-1-parse-the-tab-separated-agy-models @ d09ecdb` (2026-09-03)

## Changes

| File | Change |
|------|--------|
| `extensions/agy-pi/src/index.ts` | Add `parseAgyModelsOutput`; feed `{id, name}` into `toBaseModels`; look up bundled metadata by base or variant id; replace `gemini-3.5-flash` with `gemini-3.8-flash` in `BUNDLED_MODELS`. |
| `extensions/agy-pi/test/helpers.test.mjs` | Cover tab parsing, extra columns, effort collapse, clean `--model` slugs, and the refreshed fallback catalog. |
| `CHANGELOG.md` | Record the parser and fallback-catalog fixes. |

## Test Results

- Unit tests: 10 passed (`cd extensions/agy-pi && npm test`)
- Integration tests: included in the same suite (`discoverModels` with fake-agy tab output)
- E2e tests: skipped — no e2e framework
- Live CLI check: `agy models` (agy 1.1.25) parsed to 7 families; bundled ids are a subset of the live catalog
- Build: passed (`cd extensions/agy-pi && npm run build`)
- QA cycles: 1

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| #86 — Model ids registered from discovery contain no tab character and no display name | pass | Verified red: `node --test --test-name-pattern='splits tab-separated' test/helpers.test.mjs` → fixed → `discoverModels splits tab-separated agy models lines into clean ids` |
| #86 — Effort variants collapse into one base model per family with their levels recorded | pass | Verified red with the same command → fixed → collapsed `gemini-3.8-flash` with `high`/`medium`/`low`; `toBaseModels collapses effort variants and uses the CLI display name` |
| #86 — The slug passed to `agy --model` is a real model id the CLI accepts | pass | Verified red with the same command → fixed → `agySlugForLevel("gemini-3.8-flash", "high")` is `gemini-3.8-flash-high`, which is in the live `agy models` catalog |
| #91 — The bundled fallback contains no model id the CLI no longer offers | pass | `bundled fallback names only models the CLI currently offers`; live `agy models` comparison found no bundled id absent from the CLI |
| #91 — Current model families are represented in the fallback | pass | Fallback includes `gemini-3.8-flash` high/medium/low plus current 3.7/3.6/3.1/claude/gpt-oss families |

<!-- gitissue:qa v1 head=eaa840ea4c93ed025d6c3958cc645df6ea2d7793 profile=light cycles=1 review=clean ui=none -->
