### PR TITLE
fix(agy-pi): derive turn outcome, unconditional timeout, abort cleanup, single chunk emission (#87 #88 #89 #90)

### DIFF
--- a/extensions/agy-pi/README.md
+++ b/extensions/agy-pi/README.md
@@ -44,6 +44,11 @@ Models are auto-discovered from `agy models` output. To force re-discovery:
 /agy-pi
 ```
 
+Every turn is bounded by a per-turn timeout: Pi's provided timeout is honored
+when positive, otherwise an internal 180s bound applies so a turn never hangs
+forever. A non-zero agy exit surfaces its stderr as an error; aborts and
+timeouts stop with the corresponding stop reason.
+
 > **Note:** agy's print mode requires `--model` to appear **before** `-p/--print`
 > and the prompt to be passed as an argument — otherwise the flag is silently
 > ignored and the CLI falls back to your default model (upstream issues

--- a/extensions/agy-pi/src/index.ts
+++ b/extensions/agy-pi/src/index.ts
@@ -22,6 +22,7 @@ const DEFAULT_CONTEXT_WINDOW = 1_048_576;
 const DEFAULT_MAX_TOKENS = 8_192;
 const STDERR_LIMIT = 20_000;
 const STATUS_TIMEOUT_MS = 10_000;
+export const DEFAULT_TURN_TIMEOUT_MS = 180_000;
 
 export type CliStatus = {
   ok: boolean;
@@ -324,6 +325,19 @@ function estimateTokens(text: string): number {
   return Math.max(1, Math.ceil(text.length / 4));
 }
 
+/**
+ * Effective per-turn timeout: honor Pi's `timeoutMs` when it is a positive
+ * finite number, otherwise fall back to the unconditional internal bound so
+ * no turn can hang indefinitely (#88).
+ */
+export function resolveTurnTimeoutMs(timeoutMs: unknown): number {
+  return typeof timeoutMs === "number" &&
+    Number.isFinite(timeoutMs) &&
+    timeoutMs > 0
+    ? timeoutMs
+    : DEFAULT_TURN_TIMEOUT_MS;
+}
+
 /** Build the prompt text from Pi messages for agy --print */
 function buildPrompt(context: Context): string {
   return context.messages
@@ -365,6 +379,12 @@ export function streamAgy(
 
     let stderr = "";
     let stdout = "";
+    let timedOut = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    // Single stable content index for the whole response (#90).
+    const contentIndex = 0;
+    let textStarted = false;
+    let textEnded = false;
 
     try {
       stream.push({ type: "start", partial: output });
@@ -390,45 +410,58 @@ export function streamAgy(
 
       const abort = () => child.kill("SIGTERM");
       options?.signal?.addEventListener("abort", abort, { once: true });
-
-      if (
-        typeof options?.timeoutMs === "number" &&
-        Number.isFinite(options.timeoutMs) &&
-        options.timeoutMs > 0
-      ) {
-        setTimeout(() => {
-          child.kill("SIGTERM");
-        }, options.timeoutMs);
-      }
+      // Every turn is bounded by an internal timeout even when Pi supplies
+      // no timeoutMs; the handle is kept so the timer can be cleared (#88).
+      const turnTimeoutMs = resolveTurnTimeoutMs(options?.timeoutMs);
+      timer = setTimeout(() => {
+        timedOut = true;
+        child.kill("SIGTERM");
+      }, turnTimeoutMs);
 
       child.stdin!.end(useArgvPrompt ? undefined : prompt);
       child.stdout!.setEncoding("utf8");
       child.stderr!.setEncoding("utf8");
 
-      child.stdout!.on("data", (chunk) => {
+      // Emit each chunk exactly once: one text_start before the first chunk,
+      // one delta per chunk holding only the new bytes, one text_end after
+      // close. The content array is never replaced, so contentIndex stays
+      // valid for the whole response (#90).
+      let textBlock: { type: "text"; text: string } | undefined;
+      child.stdout!.on("data", (chunk: string) => {
+        if (textEnded) return;
         stdout += chunk;
-        const text = stdout.trim();
-        if (text) {
-          const contentIndex = output.content.length;
-          output.content = [{ type: "text", text }];
+        if (!textStarted) {
+          textStarted = true;
+          textBlock = { type: "text", text: "" };
+          output.content = [textBlock];
           stream.push({ type: "text_start", contentIndex, partial: output });
-          stream.push({ type: "text_delta", contentIndex, delta: text, partial: output });
-          stream.push({ type: "text_end", contentIndex, content: text, partial: output });
         }
+        textBlock!.text = stdout;
+        stream.push({ type: "text_delta", contentIndex, delta: chunk, partial: output });
       });
 
       child.stderr!.on("data", (chunk) => {
-        stderr += chunk;
+        stderr = (stderr + chunk).slice(-STDERR_LIMIT);
       });
 
       let spawnError: Error | undefined;
-      await new Promise<void>((resolve) => {
-        child.on("close", () => resolve());
-        child.on("error", (error) => {
-          spawnError = error;
-          resolve();
+      let code: number | null = null;
+      try {
+        code = await new Promise<number | null>((resolve, reject) => {
+          child.on("error", reject);
+          child.on("close", resolve);
         });
-      });
+      } catch (error) {
+        spawnError = error instanceof Error ? error : new Error(String(error));
+      } finally {
+        // Cleanup runs on success, error, timeout and abort alike: the abort
+        // listener is detached and the timer is cleared on every exit path
+        // (#88, #89).
+        options?.signal?.removeEventListener("abort", abort);
+        if (timer) clearTimeout(timer);
+        timer = undefined;
+        textEnded = true;
+      }
 
       if (spawnError) {
         throw new Error(
@@ -436,26 +469,42 @@ export function streamAgy(
         );
       }
 
-      // Clean output
-      const content = stdout.trim();
-      const contentIndex = output.content.length;
-      output.content = [{ type: "text", text: content || "No response from agy." }];
-      output.stopReason = "stop";
+      // Derive the turn outcome from abort, timeout and the exit code (#87).
+      // Abort and timeout first: a killed child reports a null exit code.
+      if (options?.signal?.aborted) throw new Error("Request was aborted");
+      if (timedOut) throw new Error(`agy timed out after ${turnTimeoutMs}ms`);
+      if (code !== 0) {
+        throw new Error(stderr.trim() || `agy exited with code ${code}`);
+      }
 
-      stream.push({ type: "text_start", contentIndex, partial: output });
-      stream.push({ type: "text_delta", contentIndex, delta: content || "No response from agy.", partial: output });
-      stream.push({ type: "text_end", contentIndex, content: content || "No response from agy.", partial: output });
+      if (textStarted) {
+        stream.push({ type: "text_end", contentIndex, content: stdout, partial: output });
+      } else {
+        // A genuinely empty successful run stays distinguishable from any
+        // failure above (#87).
+        const placeholder = "No response from agy.";
+        output.content = [{ type: "text", text: placeholder }];
+        stream.push({ type: "text_start", contentIndex, partial: output });
+        stream.push({ type: "text_delta", contentIndex, delta: placeholder, partial: output });
+        stream.push({ type: "text_end", contentIndex, content: placeholder, partial: output });
+      }
+      output.stopReason = "stop";
 
       const lastUserMsg = context.messages[context.messages.length - 1];
       const promptText = lastUserMsg ? (typeof lastUserMsg.content === "string" ? lastUserMsg.content : lastUserMsg.content.map(c => c.type === "text" ? c.text : "").join("\n")) : "";
-      setEstimatedUsage(model, output, promptText, content);
+      setEstimatedUsage(model, output, promptText, stdout.trim());
 
       stream.push({ type: "done", reason: "stop", message: output });
     } catch (error) {
       const errMsg = error instanceof Error ? error.message : String(error);
-      output.content = [{ type: "text", text: `Error: ${errMsg}` }];
-      output.stopReason = "error";
-      stream.push({ type: "error", reason: "error", error: output });
+      output.stopReason = options?.signal?.aborted ? "aborted" : "error";
+      output.errorMessage = errMsg;
+      // Ensure output.content has text so downstream consumers see a real
+      // message instead of an empty turn (partial text stays as streamed).
+      if (output.content.length === 0) {
+        output.content.push({ type: "text", text: `Error: ${errMsg}` });
+      }
+      stream.push({ type: "error", reason: output.stopReason, error: output });
     }
   })();
 

--- a/extensions/agy-pi/test/helpers.test.mjs
+++ b/extensions/agy-pi/test/helpers.test.mjs
@@ -11,8 +11,10 @@ const {
 	agySlugForLevel,
 	BUNDLED_MODELS,
 	checkAgyStatus,
+	DEFAULT_TURN_TIMEOUT_MS,
 	discoverModels,
 	parseAgyModelsOutput,
+	resolveTurnTimeoutMs,
 	setupGuidance,
 	streamAgy,
 	toBaseModels,
@@ -226,18 +228,160 @@ test("discoverModels splits tab-separated agy models lines into clean ids", asyn
 	);
 });
 
-test("streamAgy emits actionable setup guidance instead of a bare empty response when the binary is missing", async () => {
+test("resolveTurnTimeoutMs honors a positive finite timeout and falls back to the internal default", () => {
+	assert.equal(DEFAULT_TURN_TIMEOUT_MS, 180_000);
+	assert.equal(resolveTurnTimeoutMs(5_000), 5_000);
+	assert.equal(resolveTurnTimeoutMs(0), DEFAULT_TURN_TIMEOUT_MS);
+	assert.equal(resolveTurnTimeoutMs(-1), DEFAULT_TURN_TIMEOUT_MS);
+	assert.equal(resolveTurnTimeoutMs(NaN), DEFAULT_TURN_TIMEOUT_MS);
+	assert.equal(resolveTurnTimeoutMs(Infinity), DEFAULT_TURN_TIMEOUT_MS);
+	assert.equal(resolveTurnTimeoutMs(undefined), DEFAULT_TURN_TIMEOUT_MS);
+	assert.equal(resolveTurnTimeoutMs("100"), DEFAULT_TURN_TIMEOUT_MS);
+});
+
+function fakeSignal() {
+	return {
+		aborted: false,
+		_adds: 0,
+		_removes: 0,
+		addEventListener() {
+			this._adds += 1;
+		},
+		removeEventListener() {
+			this._removes += 1;
+		},
+	};
+}
+
+function streamFromFakeAgy(script, options) {
+	return withFakeAgy(script, () =>
+		collectEvents(
+			streamAgy(fakeModel(), { messages: [{ role: "user", content: "hi", timestamp: 1 }] }, options),
+		),
+	);
+}
+
+test("streamAgy emits each chunk once on a stable content index (two-chunk response)", async () => {
+	const events = await streamFromFakeAgy(
+		`process.stdout.write("Hello "); setTimeout(() => { process.stdout.write("world"); }, 40);`,
+	);
+
+	assert.deepEqual(
+		events.map((event) => event.type),
+		["start", "text_start", "text_delta", "text_delta", "text_end", "done"],
+	);
+	for (const event of events) {
+		if (event.type.startsWith("text_")) {
+			assert.equal(event.contentIndex, 0, "content index must stay stable");
+		}
+	}
+	const deltas = events
+		.filter((event) => event.type === "text_delta")
+		.map((event) => event.delta);
+	assert.equal(deltas.join(""), "Hello world");
+	const done = events.at(-1);
+	assert.equal(done.type, "done");
+	assert.equal(done.message.stopReason, "stop");
+	const blocks = done.message.content.filter((block) => block.type === "text");
+	assert.equal(blocks.length, 1, "text must appear exactly once in the final message");
+	assert.equal(blocks[0].text, "Hello world");
+	const fullText = blocks[0].text;
+	assert.equal(
+		(fullText.match(/Hello world/g) ?? []).length,
+		1,
+		"the response text must not be re-emitted",
+	);
+});
+
+test("streamAgy surfaces a nonzero exit as an error carrying captured stderr", async () => {
+	const events = await streamFromFakeAgy(
+		`process.stderr.write("something broke\\n"); process.exit(1);`,
+	);
+
+	assert.deepEqual(
+		events.map((event) => event.type),
+		["start", "error"],
+	);
+	const error = events.at(-1);
+	if (error?.type !== "error") return;
+	assert.equal(error.reason, "error");
+	assert.equal(error.error.stopReason, "error");
+	assert.match(error.error.errorMessage ?? "", /something broke/);
+	const text = error.error.content.find((block) => block.type === "text")?.text ?? "";
+	assert.ok(text.includes("something broke"));
+	assert.ok(!text.includes("No response from agy."));
+});
+
+test("streamAgy reports a timeout as an error and clears the timer", async () => {
+	const signal = fakeSignal();
+	const events = await streamFromFakeAgy(
+		`setInterval(() => {}, 1000);`,
+		{ timeoutMs: 300, signal },
+	);
+
+	assert.equal(signal._adds, 1, "abort listener must be attached");
+	assert.equal(signal._removes, 1, "abort listener must be detached after the turn");
+	assert.deepEqual(events.map((event) => event.type), ["start", "error"]);
+	const error = events.at(-1);
+	if (error?.type !== "error") return;
+	assert.equal(error.error.stopReason, "error");
+	assert.match(error.error.errorMessage ?? "", /agy timed out after 300ms/);
+	const text = error.error.content.find((block) => block.type === "text")?.text ?? "";
+	assert.ok(text.includes("timed out after 300ms"));
+	assert.ok(!text.includes("No response from agy."));
+});
+
+test("streamAgy reports a mid-flight abort as the aborted stop reason", async () => {
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), 100);
+	let events;
+	try {
+		events = await streamFromFakeAgy(
+			`process.stdout.write("partial"); setInterval(() => {}, 1000);`,
+			{ signal: controller.signal },
+		);
+	} finally {
+		clearTimeout(timer);
+	}
+
+	const error = events.at(-1);
+	if (error?.type !== "error") return;
+	assert.equal(error.reason, "aborted");
+	assert.equal(error.error.stopReason, "aborted");
+	assert.equal(error.error.errorMessage, "Request was aborted");
+});
+
+test("streamAgy keeps a genuinely empty successful run distinct from failures", async () => {
+	const events = await streamFromFakeAgy(`process.exit(0);`);
+
+	assert.deepEqual(
+		events.map((event) => event.type),
+		["start", "text_start", "text_delta", "text_end", "done"],
+	);
+	const done = events.at(-1);
+	if (done?.type !== "done") return;
+	assert.equal(done.reason, "stop");
+	assert.equal(done.message.stopReason, "stop");
+	const text = done.message.content.find((block) => block.type === "text")?.text ?? "";
+	assert.equal(text, "No response from agy.");
+});
+
+test("streamAgy detaches the abort listener on a successful turn without a signal", async () => {
+	const signal = fakeSignal();
+	const events = await streamFromFakeAgy(`process.exit(0);`, { signal });
+	assert.equal(signal._adds, 1);
+	assert.equal(signal._removes, 1, "abort listener must be detached on success");
+	assert.deepEqual(events.map((event) => event.type), ["start", "text_start", "text_delta", "text_end", "done"]);
+});
+
+test("streamAgy emits actionable setup guidance and leaves no stranded timer when the binary is missing", async () => {
 	const previousBin = process.env.AGY_PI_BIN;
 	process.env.AGY_PI_BIN = missingBin();
 	try {
 		const events = await collectEvents(
 			streamAgy(fakeModel(), { messages: [{ role: "user", content: "hi", timestamp: 1 }] }),
 		);
-
-		assert.deepEqual(
-			events.map((event) => event.type),
-			["start", "error"],
-		);
+		assert.deepEqual(events.map((event) => event.type), ["start", "error"]);
 		const error = events.at(-1);
 		if (error?.type !== "error") return;
 		const text = error.error.content.find((block) => block.type === "text")?.text ?? "";


### PR DESCRIPTION
## Overview

Unified rewrite of `streamAgy`'s spawn/close lifecycle in `extensions/agy-pi`, resolving four batch-compatible P1 lifecycle bugs in one block.

## Changes

- **#87 — turn outcome derivation**: after close, the turn resolves from abort → timeout → exit code, in that order (a killed child reports a null exit code, so abort/timeout are checked first). A non-zero exit surfaces the captured stderr (`stderr.trim() || "agy exited with code N"`); a timeout reports `agy timed out after Nms`; an abort reports the `aborted` stop reason; only a genuinely empty successful run still says `No response from agy.` as a `stop`.
- **#88 — unconditional timeout**: every turn is bounded by `resolveTurnTimeoutMs()` — Pi's `timeoutMs` when positive, else `DEFAULT_TURN_TIMEOUT_MS` (180s). The `setTimeout` handle is kept and cleared on every exit path in the cleanup block.
- **#89 — abort listener cleanup**: the listener is detached via `removeEventListener` from a `finally` cleanup that also clears the timer, running on success, error, timeout and abort alike.
- **#90 — single chunk emission**: one `text_start` before the first stdout chunk, exactly one `text_delta` per chunk holding only the raw new bytes, one `text_end` after close — all on a stable `contentIndex` 0. The content array is never replaced, so the index never drifts and the response text appears exactly once.

## Decision Record

- Root cause: the close handler discarded the exit code, stderr accumulated but never read, abort checked only pre-spawn, fire-and-forget timer, and per-chunk re-emission of the whole text with a drifting content index.
- Options considered: inline close-handler checks (rejected — leaves #88/#89 cleanup broken), mirror the proven in-tree opencode/grok CLI-bridge lifecycle (selected), shared CLI-bridge runner (rejected — cross-package refactor, out of scope).
- Residual risk: the 180s internal default may feel long for a stuck CLI; callers pass an explicit `timeoutMs` to bound tighter. Deliberately untested directly: the 180s default path (would slow the suite); covered via `resolveTurnTimeoutMs` unit tests plus short-timeout integration tests.

## Test Results

- `npm run build` (tsc): clean
- `npm test` (node --test, no framework): **17/17 passing**
  - New: `resolveTurnTimeoutMs` unit matrix; two-chunk single-emission + stable index; nonzero-exit-with-stderr error; timeout error + listener detach; mid-flight abort → `stopReason: "aborted"`; empty-success placeholder; listener detach on a successful turn.

## Acceptance Criteria Verification

| Issue | AC | Verified |
|---|---|---|
| #87 | non-zero exit reports an error carrying captured stderr | test `surfaces a nonzero exit as an error carrying captured stderr` |
| #87 | timed-out turn reports a timeout | test `reports a timeout as an error and clears the timer` |
| #87 | aborted turn reports the aborted stop reason | test `reports a mid-flight abort as the aborted stop reason` |
| #87 | genuinely empty successful run stays distinguishable | test `keeps a genuinely empty successful run distinct from failures` |
| #88 | bounded even when Pi supplies no timeout | `resolveTurnTimeoutMs` default unit test |
| #88 | timer cleared on every exit path | `finally` cleanup + `leaves no stranded timer` test |
| #89 | listener detached on every exit path | detach assertions on timeout and success tests |
| #89 | cleanup runs from a block on success and failure | `finally` block, failure covered by missing-bin test |
| #90 | multi-chunk response emits text exactly once | two-chunk test: 2 deltas, text appears once |
| #90 | one start and one end bracket the deltas | event-type sequence assertion |
| #90 | content index stays valid | all `text_*` events carry `contentIndex === 0` |

Closes #87
Closes #88
Closes #89
Closes #90
